### PR TITLE
Baseline initial maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dbwiddis @owaiskazi19 @joshpalis @ohltyler @amitgalitz @jackiehanyang

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# intellij files
+.idea/
+*.iml
+*.ipr
+*.iws
+*.log
+build-idea/
+out/
+
+# eclipse files
+.classpath
+.project
+
+# gradle stuff
+.gradle/
+build/
+bin/
+
+# vscode stuff
+.vscode/
+
+# osx stuff
+.DS_Store

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,14 @@
+## Overview
+
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
+| Maintainer        | GitHub ID                                               | Affiliation |
+| ----------------- | ------------------------------------------------------- | ----------- |
+| Amit Galitzky     | [amitgalitz](https://github.com/amitgalitz)             | Amazon      |
+| Jackie Han        | [jackiehanyang](https://github.com/jackiehanyang)       | Amazon      |
+| Owais Kazi        | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
+| Tyler Ohlsen      | [ohltyler](https://github.com/ohltyler)                 | Amazon      |
+| Josh Palis        | [joshpalis](https://github.com/joshpalis)               | Amazon      |
+| Dan Widdis        | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |


### PR DESCRIPTION
### Description

Add CODEOWNERS and MAINTAINERS files for initial project maintainer list.

### Issues Resolved
Part of #2 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
