### PR TITLE
Initial attempt to fix local publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,40 @@ buildscript {
     }
 }
 
+allprojects {
+    // Default to the apache license
+    project.ext.licenseName = 'The Apache Software License, Version 2.0'
+    project.ext.licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    publishing {
+        repositories {
+            maven {
+                name = 'staging'
+                url = "${rootProject.buildDir}/local-staging-repo"
+            }
+        }
+        publications {
+            // add license information to generated poms
+            all {
+                pom {
+                    name = 'opensearch-flow-framework'
+                    description = 'OpenSearch plugin that enables builders to innovate AI apps on OpenSearch'
+                }
+                pom.withXml { XmlProvider xml ->
+                    Node node = xml.asNode()
+                    node.appendNode('inceptionYear', '2021')
+
+                    Node license = node.appendNode('licenses').appendNode('license')
+                    license.appendNode('name', project.licenseName)
+                    license.appendNode('url', project.licenseUrl)
+
+                    Node developer = node.appendNode('developers').appendNode('developer')
+                    developer.appendNode('name', 'OpenSearch')
+                    developer.appendNode('url', 'https://github.com/opensearch-project/flow-framework')
+                }
+            }
+        }
+    }
+}
 
 publishing {
     publications {
@@ -86,18 +120,6 @@ publishing {
                 name = pluginName
                 description = pluginDescription
                 groupId = "org.opensearch.plugin"
-                licenses {
-                    license {
-                        name = "The Apache License, Version 2.0"
-                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        name = "OpenSearch Flow Framework Plugin"
-                        url = "https://github.com/opensearch-project/flow-framework"
-                    }
-                }
             }
         }
     }
@@ -122,6 +144,10 @@ allprojects {
 java {
     targetCompatibility = JavaVersion.VERSION_11
     sourceCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.matching {it.path in [":publishNebulaPublicationToMavenLocal"]}.all { task ->
+    task.dependsOn 'generatePomFileForPluginZipPublication'
 }
 
 repositories {


### PR DESCRIPTION
### Description
Fix `./gradlew publishToMavenLocal`

Still failing with the below:
```
* What went wrong:
Execution failed for task ':publishNebulaPublicationToMavenLocal'.
> Failed to publish publication 'nebula' to repository 'mavenLocal'
   > Invalid publication 'nebula': supplied groupId (org.opensearch) does not match value from POM file (org.opensearch.plugin). Cannot edit groupId directly in the POM file.
```

### Issues Resolved
Fixes https://github.com/opensearch-project/flow-framework/issues/186

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
