### PR TITLE
Changing resources created format

### DIFF
--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -152,5 +152,6 @@ public class CommonValue {
     public static final String RESOURCE_ID_FIELD = "resource_id";
     /** The field name for the ResourceCreated's resource name */
     public static final String WORKFLOW_STEP_NAME = "workflow_step_name";
-
+    /** The field name for the ResourceCreated's resource name */
+    public static final String WORKFLOW_STEP_ID = "workflow_step_id";
 }

--- a/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
+++ b/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.common;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Enum encapsulating the different step names and the resources they create
+ */
+public enum WorkflowResources {
+
+    CREATE_CONNECTOR("create_connector", "connector_id"),
+    REGISTER_REMOTE_MODEL("register_remote_model", "model_id"),
+    REGISTER_LOCAL_MODEL("register_local_model", "task_id"),
+    MODEL_GROUP("register_model_group", "group_model_id"),
+    CREATE_INGEST_PIPELINE("create_ingest_pipeline", "pipeline_id"),
+    CREATE_INDEX("create_index", "index");
+
+    private final String workflowStep;
+    private final String resourceCreated;
+    private static final Logger logger = LogManager.getLogger(WorkflowResources.class);
+
+    WorkflowResources(String workflowStep, String resourceCreated) {
+        this.workflowStep = workflowStep;
+        this.resourceCreated = resourceCreated;
+    }
+
+    public String getWorkflowStep() {
+        return workflowStep;
+    }
+
+    public String getResourceCreated() {
+        return resourceCreated;
+    }
+
+    /**
+     * gets the resources created type based on the workflowStep
+     * @param workflowStep workflow step name
+     * @return the resource that will be created
+     * @throws IOException if workflow step doesn't exist in enum
+     */
+    public static String getResourceByWorkflowStep(String workflowStep) throws IOException {
+        if (workflowStep != null && !workflowStep.isEmpty()) {
+            for (WorkflowResources mapping : values()) {
+                if (mapping.getWorkflowStep().equals(workflowStep)) {
+                    return mapping.getResourceCreated();
+                }
+            }
+        }
+        logger.error("Unable to find resource type for step: " + workflowStep);
+        throw new IOException("Unable to find resource type for step: " + workflowStep);
+    }
+
+    public static Set<String> getAllKeys() {
+        return Stream.of(values()).map(WorkflowResources::getResourceCreated).collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -399,6 +399,7 @@ public class FlowFrameworkIndicesHandler {
                 updatedContent.putAll(updatedFields);
                 updateRequest.doc(updatedContent);
                 updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                updateRequest.retryOnConflict(3);
                 // TODO: decide what condition can be considered as an update conflict and add retry strategy
                 client.update(updateRequest, ActionListener.runBefore(listener, () -> context.restore()));
             } catch (Exception e) {
@@ -468,6 +469,7 @@ public class FlowFrameworkIndicesHandler {
                 // TODO: Also add ability to change other fields at the same time when adding detailed provision progress
                 updateRequest.script(script);
                 updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                updateRequest.retryOnConflict(5);
                 // TODO: decide what condition can be considered as an update conflict and add retry strategy
                 client.update(updateRequest, ActionListener.runBefore(listener, () -> context.restore()));
             } catch (Exception e) {

--- a/src/main/java/org/opensearch/flowframework/model/ResourceCreated.java
+++ b/src/main/java/org/opensearch/flowframework/model/ResourceCreated.java
@@ -8,17 +8,21 @@
  */
 package org.opensearch.flowframework.model;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.flowframework.common.WorkflowResources;
 
 import java.io.IOException;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.flowframework.common.CommonValue.RESOURCE_ID_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STEP_ID;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STEP_NAME;
 
 /**
@@ -27,16 +31,21 @@ import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STEP_NAME
 // TODO: create an enum to add the resource name itself for each step example (create_connector_step -> connector)
 public class ResourceCreated implements ToXContentObject, Writeable {
 
+    private static final Logger logger = LogManager.getLogger(ResourceCreated.class);
+
     private final String workflowStepName;
+    private final String workflowStepId;
     private final String resourceId;
 
     /**
-     * Create this resources created object with given resource name and ID.
+     * Create this resources created object with given workflow step name, ID and resource ID.
      * @param workflowStepName The workflow step name associating to the step where it was created
+     * @param workflowStepId The workflow step ID associating to the step where it was created
      * @param resourceId The resources ID for relating to the created resource
      */
-    public ResourceCreated(String workflowStepName, String resourceId) {
+    public ResourceCreated(String workflowStepName, String workflowStepId, String resourceId) {
         this.workflowStepName = workflowStepName;
+        this.workflowStepId = workflowStepId;
         this.resourceId = resourceId;
     }
 
@@ -47,6 +56,7 @@ public class ResourceCreated implements ToXContentObject, Writeable {
      */
     public ResourceCreated(StreamInput input) throws IOException {
         this.workflowStepName = input.readString();
+        this.workflowStepId = input.readString();
         this.resourceId = input.readString();
     }
 
@@ -54,13 +64,15 @@ public class ResourceCreated implements ToXContentObject, Writeable {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         XContentBuilder xContentBuilder = builder.startObject()
             .field(WORKFLOW_STEP_NAME, workflowStepName)
-            .field(RESOURCE_ID_FIELD, resourceId);
+            .field(WORKFLOW_STEP_ID, workflowStepId)
+            .field(WorkflowResources.getResourceByWorkflowStep(workflowStepName), resourceId);
         return xContentBuilder.endObject();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(workflowStepName);
+        out.writeString(workflowStepId);
         out.writeString(resourceId);
     }
 
@@ -83,6 +95,15 @@ public class ResourceCreated implements ToXContentObject, Writeable {
     }
 
     /**
+     * Gets the workflow step id associated to the created resource
+     *
+     * @return the workflowStepId.
+     */
+    public String workflowStepId() {
+        return workflowStepId;
+    }
+
+    /**
      * Parse raw JSON content into a ResourceCreated instance.
      *
      * @param parser JSON based content parser
@@ -91,6 +112,7 @@ public class ResourceCreated implements ToXContentObject, Writeable {
      */
     public static ResourceCreated parse(XContentParser parser) throws IOException {
         String workflowStepName = null;
+        String workflowStepId = null;
         String resourceId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -102,22 +124,49 @@ public class ResourceCreated implements ToXContentObject, Writeable {
                 case WORKFLOW_STEP_NAME:
                     workflowStepName = parser.text();
                     break;
-                case RESOURCE_ID_FIELD:
-                    resourceId = parser.text();
+                case WORKFLOW_STEP_ID:
+                    workflowStepId = parser.text();
                     break;
                 default:
-                    throw new IOException("Unable to parse field [" + fieldName + "] in a resources_created object.");
+                    if (!isValidFieldName(fieldName)) {
+                        throw new IOException("Unable to parse field [" + fieldName + "] in a resources_created object.");
+                    } else {
+                        if (fieldName.equals(WorkflowResources.getResourceByWorkflowStep(workflowStepName))) {
+                            resourceId = parser.text();
+                        }
+                        break;
+                    }
             }
         }
-        if (workflowStepName == null || resourceId == null) {
-            throw new IOException("A ResourceCreated object requires both a workflowStepName and resourceId.");
+        if (workflowStepName == null || workflowStepId == null || resourceId == null) {
+            logger.error(
+                "Resource created object failed parsing: workflowStepName: {}, workflowStepId: {}, resourceId: {}",
+                workflowStepName,
+                workflowStepId,
+                resourceId
+            );
+            throw new IOException("A ResourceCreated object requires workflowStepName, workflowStepId and resourceId");
         }
-        return new ResourceCreated(workflowStepName, resourceId);
+
+        return new ResourceCreated(workflowStepName, workflowStepId, resourceId);
+    }
+
+    private static boolean isValidFieldName(String fieldName) {
+        return (WORKFLOW_STEP_NAME.equals(fieldName)
+            || RESOURCE_ID_FIELD.equals(fieldName)
+            || WORKFLOW_STEP_ID.equals(fieldName)
+            || WorkflowResources.getAllKeys().contains(fieldName));
     }
 
     @Override
     public String toString() {
-        return "resources_Created [resource_name=" + workflowStepName + ", id=" + resourceId + "]";
+        return "resources_Created [workflow_step_name= "
+            + workflowStepName
+            + ", workflow_step_id= "
+            + workflowStepName
+            + ", id= "
+            + resourceId
+            + "]";
     }
 
 }

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -208,7 +208,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                 ),
                 ActionListener.wrap(updateResponse -> {
                     logger.info("updated workflow {} state to {}", workflowId, State.COMPLETED);
-                }, exception -> { logger.error("Failed to update workflow state : {}", exception.getMessage()); })
+                }, exception -> { logger.error("Failed to update workflow state : {}", exception.getMessage(), exception); })
             );
         } catch (Exception ex) {
             logger.error("Provisioning failed for workflow {} : {}", workflowId, ex);
@@ -226,7 +226,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                 ),
                 ActionListener.wrap(updateResponse -> {
                     logger.info("updated workflow {} state to {}", workflowId, State.COMPLETED);
-                }, exceptionState -> { logger.error("Failed to update workflow state : {}", exceptionState.getMessage()); })
+                }, exceptionState -> { logger.error("Failed to update workflow state : {}", exceptionState.getMessage(), exceptionState); })
             );
         }
     }

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -11,21 +11,16 @@ package org.opensearch.flowframework.workflow;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.ToXContentObject;
-import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
-import org.opensearch.flowframework.model.ResourceCreated;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.ConnectorAction.ActionType;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
-import org.opensearch.script.Script;
-import org.opensearch.script.ScriptType;
 
 import java.io.IOException;
 import java.security.AccessController;
@@ -48,7 +43,6 @@ import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PROTOCOL_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
 
 /**
  * Step to create a connector for a remote model
@@ -60,7 +54,7 @@ public class CreateConnectorStep implements WorkflowStep {
     private MachineLearningNodeClient mlClient;
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
-    static final String NAME = "create_connector";
+    static final String NAME = WorkflowResources.CREATE_CONNECTOR.getWorkflowStep();
 
     /**
      * Instantiate this class
@@ -81,44 +75,28 @@ public class CreateConnectorStep implements WorkflowStep {
 
             @Override
             public void onResponse(MLCreateConnectorResponse mlCreateConnectorResponse) {
-                createConnectorFuture.complete(
-                    new WorkflowData(
-                        Map.ofEntries(Map.entry("connector_id", mlCreateConnectorResponse.getConnectorId())),
-                        data.get(0).getWorkflowId()
-                    )
-                );
+
                 try {
+                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    createConnectorFuture.complete(
+                        new WorkflowData(
+                            Map.ofEntries(Map.entry(resourceName, mlCreateConnectorResponse.getConnectorId())),
+                            data.get(0).getWorkflowId()
+                        )
+                    );
                     logger.info("Created connector successfully");
-                    String workflowId = data.get(0).getWorkflowId();
-                    String workflowStepName = getName();
-                    ResourceCreated newResource = new ResourceCreated(workflowStepName, mlCreateConnectorResponse.getConnectorId());
-                    XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
-                    newResource.toXContent(builder, ToXContentObject.EMPTY_PARAMS);
-
-                    // The script to append a new object to the resources_created array
-                    Script script = new Script(
-                        ScriptType.INLINE,
-                        "painless",
-                        "ctx._source.resources_created.add(params.newResource)",
-                        Collections.singletonMap("newResource", newResource)
+                    flowFrameworkIndicesHandler.updateResourceInStateIndex(
+                        data.get(0),
+                        getName(),
+                        mlCreateConnectorResponse.getConnectorId(),
+                        createConnectorFuture
                     );
 
-                    flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDocWithScript(
-                        WORKFLOW_STATE_INDEX,
-                        workflowId,
-                        script,
-                        ActionListener.wrap(updateResponse -> {
-                            logger.info("updated resources created of {}", workflowId);
-                        }, exception -> {
-                            createConnectorFuture.completeExceptionally(
-                                new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception))
-                            );
-                            logger.error("Failed to update workflow state with newly created resource: {}", exception);
-                        })
-                    );
-                } catch (IOException e) {
-                    logger.error("Failed to parse new created resource", e);
+                } catch (Exception e) {
+                    logger.error("Failed to parse and update new created resource", e);
+                    createConnectorFuture.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
                 }
+
             }
 
             @Override

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateIndexStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateIndexStep.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.client.Client;
@@ -17,6 +18,8 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.common.WorkflowResources;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 
 import java.util.HashMap;
@@ -25,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.opensearch.flowframework.common.CommonValue.INDEX_NAME;
 import static org.opensearch.flowframework.common.CommonValue.TYPE;
 
 /**
@@ -34,40 +36,56 @@ import static org.opensearch.flowframework.common.CommonValue.TYPE;
 public class CreateIndexStep implements WorkflowStep {
 
     private static final Logger logger = LogManager.getLogger(CreateIndexStep.class);
-    private ClusterService clusterService;
-    private Client client;
+    private final ClusterService clusterService;
+    private final Client client;
+    private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
     /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
-    static final String NAME = "create_index";
+    static final String NAME = WorkflowResources.CREATE_INDEX.getWorkflowStep();
     static Map<String, AtomicBoolean> indexMappingUpdated = new HashMap<>();
-    private static final Map<String, Object> indexSettings = Map.of("index.auto_expand_replicas", "0-1");
 
     /**
      * Instantiate this class
      *
      * @param clusterService The OpenSearch cluster service
      * @param client Client to create an index
+     * @param flowFrameworkIndicesHandler FlowFrameworkIndicesHandler class to update system indices
      */
-    public CreateIndexStep(ClusterService clusterService, Client client) {
+    public CreateIndexStep(ClusterService clusterService, Client client, FlowFrameworkIndicesHandler flowFrameworkIndicesHandler) {
         this.clusterService = clusterService;
         this.client = client;
+        this.flowFrameworkIndicesHandler = flowFrameworkIndicesHandler;
     }
 
     @Override
     public CompletableFuture<WorkflowData> execute(List<WorkflowData> data) {
-        CompletableFuture<WorkflowData> future = new CompletableFuture<>();
+        CompletableFuture<WorkflowData> createIndexFuture = new CompletableFuture<>();
         ActionListener<CreateIndexResponse> actionListener = new ActionListener<>() {
 
             @Override
             public void onResponse(CreateIndexResponse createIndexResponse) {
-                logger.info("created index: {}", createIndexResponse.index());
-                future.complete(new WorkflowData(Map.of(INDEX_NAME, createIndexResponse.index()), data.get(0).getWorkflowId()));
+                try {
+                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    logger.info("created index: {}", createIndexResponse.index());
+                    createIndexFuture.complete(
+                        new WorkflowData(Map.of(resourceName, createIndexResponse.index()), data.get(0).getWorkflowId())
+                    );
+                    flowFrameworkIndicesHandler.updateResourceInStateIndex(
+                        data.get(0),
+                        getName(),
+                        createIndexResponse.index(),
+                        createIndexFuture
+                    );
+                } catch (Exception e) {
+                    logger.error("Failed to parse and update new created resource", e);
+                    createIndexFuture.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
+                }
             }
 
             @Override
             public void onFailure(Exception e) {
                 logger.error("Failed to create an index", e);
-                future.completeExceptionally(e);
+                createIndexFuture.completeExceptionally(e);
             }
         };
 
@@ -75,13 +93,18 @@ public class CreateIndexStep implements WorkflowStep {
         String type = null;
         Settings settings = null;
 
-        for (WorkflowData workflowData : data) {
-            Map<String, Object> content = workflowData.getContent();
-            index = (String) content.get(INDEX_NAME);
-            type = (String) content.get(TYPE);
-            if (index != null && type != null && settings != null) {
-                break;
+        try {
+            for (WorkflowData workflowData : data) {
+                Map<String, Object> content = workflowData.getContent();
+                index = (String) content.get(WorkflowResources.getResourceByWorkflowStep(getName()));
+                type = (String) content.get(TYPE);
+                if (index != null && type != null && settings != null) {
+                    break;
+                }
             }
+        } catch (Exception e) {
+            logger.error("Failed to find the correct resource for the workflow step", e);
+            createIndexFuture.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
         }
 
         // TODO:
@@ -97,7 +120,7 @@ public class CreateIndexStep implements WorkflowStep {
             logger.error("Failed to find the right mapping for the index", e);
         }
 
-        return future;
+        return createIndexFuture;
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStep.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.ingest.PutPipelineRequest;
 import org.opensearch.client.Client;
 import org.opensearch.client.ClusterAdminClient;
@@ -18,6 +19,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.flowframework.common.WorkflowResources;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 
 import java.io.IOException;
 import java.util.List;
@@ -32,7 +36,6 @@ import static org.opensearch.flowframework.common.CommonValue.ID;
 import static org.opensearch.flowframework.common.CommonValue.INPUT_FIELD_NAME;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.OUTPUT_FIELD_NAME;
-import static org.opensearch.flowframework.common.CommonValue.PIPELINE_ID;
 import static org.opensearch.flowframework.common.CommonValue.PROCESSORS;
 import static org.opensearch.flowframework.common.CommonValue.TYPE;
 
@@ -44,18 +47,21 @@ public class CreateIngestPipelineStep implements WorkflowStep {
     private static final Logger logger = LogManager.getLogger(CreateIngestPipelineStep.class);
 
     /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
-    static final String NAME = "create_ingest_pipeline";
+    static final String NAME = WorkflowResources.CREATE_INGEST_PIPELINE.getWorkflowStep();
 
     // Client to store a pipeline in the cluster state
     private final ClusterAdminClient clusterAdminClient;
 
+    private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
+
     /**
      * Instantiates a new CreateIngestPipelineStep
-     *
      * @param client The client to create a pipeline and store workflow data into the global context index
+     * @param flowFrameworkIndicesHandler FlowFrameworkIndicesHandler class to update system indices
      */
-    public CreateIngestPipelineStep(Client client) {
+    public CreateIngestPipelineStep(Client client, FlowFrameworkIndicesHandler flowFrameworkIndicesHandler) {
         this.clusterAdminClient = client.admin().cluster();
+        this.flowFrameworkIndicesHandler = flowFrameworkIndicesHandler;
     }
 
     @Override
@@ -124,12 +130,26 @@ public class CreateIngestPipelineStep implements WorkflowStep {
             clusterAdminClient.putPipeline(putPipelineRequest, ActionListener.wrap(response -> {
                 logger.info("Created ingest pipeline : " + putPipelineRequest.getId());
 
-                // PutPipelineRequest returns only an AcknowledgeResponse, returning pipelineId instead
-                createIngestPipelineFuture.complete(
-                    new WorkflowData(Map.of(PIPELINE_ID, putPipelineRequest.getId()), data.get(0).getWorkflowId())
-                );
+                try {
+                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    // PutPipelineRequest returns only an AcknowledgeResponse, returning pipelineId instead
+                    // TODO: revisit this concept of pipeline_id to be consistent with what makes most sense to end user here
+                    createIngestPipelineFuture.complete(
+                        new WorkflowData(Map.of(resourceName, putPipelineRequest.getId()), data.get(0).getWorkflowId())
+                    );
+                    flowFrameworkIndicesHandler.updateResourceInStateIndex(
+                        data.get(0),
+                        getName(),
+                        putPipelineRequest.getId(),
+                        createIngestPipelineFuture
+                    );
 
-                // TODO : Use node client to index response data to global context (pending global context index implementation)
+                } catch (Exception e) {
+                    logger.error("Failed to parse and update new created resource", e);
+                    createIngestPipelineFuture.completeExceptionally(
+                        new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e))
+                    );
+                }
 
             }, exception -> {
                 logger.error("Failed to create ingest pipeline : " + exception.getMessage());

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -13,7 +13,9 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
@@ -31,7 +33,6 @@ import static org.opensearch.flowframework.common.CommonValue.CONNECTOR_ID;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_ID;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 
@@ -43,15 +44,18 @@ public class RegisterRemoteModelStep implements WorkflowStep {
     private static final Logger logger = LogManager.getLogger(RegisterRemoteModelStep.class);
 
     private MachineLearningNodeClient mlClient;
+    private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
-    static final String NAME = "register_remote_model";
+    static final String NAME = WorkflowResources.REGISTER_REMOTE_MODEL.getWorkflowStep();
 
     /**
      * Instantiate this class
      * @param mlClient client to instantiate MLClient
+     * @param flowFrameworkIndicesHandler FlowFrameworkIndicesHandler class to update system indices
      */
-    public RegisterRemoteModelStep(MachineLearningNodeClient mlClient) {
+    public RegisterRemoteModelStep(MachineLearningNodeClient mlClient, FlowFrameworkIndicesHandler flowFrameworkIndicesHandler) {
         this.mlClient = mlClient;
+        this.flowFrameworkIndicesHandler = flowFrameworkIndicesHandler;
     }
 
     @Override
@@ -62,16 +66,29 @@ public class RegisterRemoteModelStep implements WorkflowStep {
         ActionListener<MLRegisterModelResponse> actionListener = new ActionListener<>() {
             @Override
             public void onResponse(MLRegisterModelResponse mlRegisterModelResponse) {
-                logger.info("Remote Model registration successful");
-                registerRemoteModelFuture.complete(
-                    new WorkflowData(
-                        Map.ofEntries(
-                            Map.entry(MODEL_ID, mlRegisterModelResponse.getModelId()),
-                            Map.entry(REGISTER_MODEL_STATUS, mlRegisterModelResponse.getStatus())
-                        ),
-                        data.get(0).getWorkflowId()
-                    )
-                );
+                try {
+                    logger.info("Remote Model registration successful");
+                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    registerRemoteModelFuture.complete(
+                        new WorkflowData(
+                            Map.ofEntries(
+                                Map.entry(resourceName, mlRegisterModelResponse.getModelId()),
+                                Map.entry(REGISTER_MODEL_STATUS, mlRegisterModelResponse.getStatus())
+                            ),
+                            data.get(0).getWorkflowId()
+                        )
+                    );
+                    flowFrameworkIndicesHandler.updateResourceInStateIndex(
+                        data.get(0),
+                        getName(),
+                        mlRegisterModelResponse.getModelId(),
+                        registerRemoteModelFuture
+                    );
+
+                } catch (Exception e) {
+                    logger.error("Failed to parse and update new created resource", e);
+                    registerRemoteModelFuture.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
+                }
             }
 
             @Override

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowData.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowData.java
@@ -29,8 +29,11 @@ public class WorkflowData {
     @Nullable
     private String workflowId;
 
+    @Nullable
+    private String nodeId;
+
     private WorkflowData() {
-        this(Collections.emptyMap(), Collections.emptyMap(), "");
+        this(Collections.emptyMap(), Collections.emptyMap(), "", "");
     }
 
     /**
@@ -39,7 +42,7 @@ public class WorkflowData {
      * @param workflowId The workflow ID associated with this step
      */
     public WorkflowData(Map<String, Object> content, @Nullable String workflowId) {
-        this(content, Collections.emptyMap(), workflowId);
+        this(content, Collections.emptyMap(), workflowId, "");
     }
 
     /**
@@ -49,9 +52,21 @@ public class WorkflowData {
      * @param workflowId The workflow ID associated with this step
      */
     public WorkflowData(Map<String, Object> content, Map<String, String> params, @Nullable String workflowId) {
+        this(Map.copyOf(content), Map.copyOf(params), workflowId, null);
+    }
+
+    /**
+     * Instantiate this object with content and params.
+     * @param content The content map
+     * @param params The params map
+     * @param workflowId The workflow ID associated with this step
+     * @param nodeId the node ID associated with this step
+     */
+    public WorkflowData(Map<String, Object> content, Map<String, String> params, @Nullable String workflowId, @Nullable String nodeId) {
         this.content = Map.copyOf(content);
         this.params = Map.copyOf(params);
         this.workflowId = workflowId;
+        this.nodeId = nodeId;
     }
 
     /**
@@ -78,5 +93,14 @@ public class WorkflowData {
     @Nullable
     public String getWorkflowId() {
         return this.workflowId;
+    };
+
+    /**
+     * Returns the nodeId associated with this workflowData.
+     * @return the nodeId of this data.
+     */
+    @Nullable
+    public String getNodeId() {
+        return this.nodeId;
     };
 }

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -70,7 +70,7 @@ public class WorkflowProcessSorter {
         Map<String, ProcessNode> idToNodeMap = new HashMap<>();
         for (WorkflowNode node : sortedNodes) {
             WorkflowStep step = workflowStepFactory.createStep(node.type());
-            WorkflowData data = new WorkflowData(node.userInputs(), workflow.userParams(), workflowId);
+            WorkflowData data = new WorkflowData(node.userInputs(), workflow.userParams(), workflowId, node.id());
             List<ProcessNode> predecessorNodes = workflow.edges()
                 .stream()
                 .filter(e -> e.destination().equals(node.id()))

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -55,10 +55,10 @@ public class WorkflowStepFactory {
         FlowFrameworkIndicesHandler flowFrameworkIndicesHandler
     ) {
         stepMap.put(NoOpStep.NAME, new NoOpStep());
-        stepMap.put(CreateIndexStep.NAME, new CreateIndexStep(clusterService, client));
-        stepMap.put(CreateIngestPipelineStep.NAME, new CreateIngestPipelineStep(client));
-        stepMap.put(RegisterLocalModelStep.NAME, new RegisterLocalModelStep(mlClient));
-        stepMap.put(RegisterRemoteModelStep.NAME, new RegisterRemoteModelStep(mlClient));
+        stepMap.put(CreateIndexStep.NAME, new CreateIndexStep(clusterService, client, flowFrameworkIndicesHandler));
+        stepMap.put(CreateIngestPipelineStep.NAME, new CreateIngestPipelineStep(client, flowFrameworkIndicesHandler));
+        stepMap.put(RegisterLocalModelStep.NAME, new RegisterLocalModelStep(mlClient, flowFrameworkIndicesHandler));
+        stepMap.put(RegisterRemoteModelStep.NAME, new RegisterRemoteModelStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(DeployModelStep.NAME, new DeployModelStep(mlClient));
         stepMap.put(CreateConnectorStep.NAME, new CreateConnectorStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(ModelGroupStep.NAME, new ModelGroupStep(mlClient));

--- a/src/main/resources/mappings/workflow-state.json
+++ b/src/main/resources/mappings/workflow-state.json
@@ -31,15 +31,7 @@
       "type": "object"
     },
     "resources_created": {
-      "type": "nested",
-      "properties": {
-        "workflow_step_name": {
-          "type": "keyword"
-        },
-        "resource_id": {
-          "type": "keyword"
-        }
-      }
+      "type": "object"
     },
     "ui_metadata": {
       "type": "object",

--- a/src/test/java/org/opensearch/flowframework/model/ResourceCreatedTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/ResourceCreatedTests.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.flowframework.model;
 
+import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -20,17 +21,21 @@ public class ResourceCreatedTests extends OpenSearchTestCase {
     }
 
     public void testParseFeature() throws IOException {
-        ResourceCreated ResourceCreated = new ResourceCreated("A", "B");
-        assertEquals(ResourceCreated.workflowStepName(), "A");
-        assertEquals(ResourceCreated.resourceId(), "B");
+        String workflowStepName = WorkflowResources.CREATE_CONNECTOR.getWorkflowStep();
+        ResourceCreated ResourceCreated = new ResourceCreated(workflowStepName, "workflow_step_1", "L85p1IsBbfF");
+        assertEquals(ResourceCreated.workflowStepName(), workflowStepName);
+        assertEquals(ResourceCreated.workflowStepId(), "workflow_step_1");
+        assertEquals(ResourceCreated.resourceId(), "L85p1IsBbfF");
 
-        String expectedJson = "{\"workflow_step_name\":\"A\",\"resource_id\":\"B\"}";
+        String expectedJson =
+            "{\"workflow_step_name\":\"create_connector\",\"workflow_step_id\":\"workflow_step_1\",\"connector_id\":\"L85p1IsBbfF\"}";
         String json = TemplateTestJsonUtil.parseToJson(ResourceCreated);
         assertEquals(expectedJson, json);
 
         ResourceCreated ResourceCreatedTwo = ResourceCreated.parse(TemplateTestJsonUtil.jsonToParser(json));
-        assertEquals("A", ResourceCreatedTwo.workflowStepName());
-        assertEquals("B", ResourceCreatedTwo.resourceId());
+        assertEquals(workflowStepName, ResourceCreatedTwo.workflowStepName());
+        assertEquals("workflow_step_1", ResourceCreatedTwo.workflowStepId());
+        assertEquals("L85p1IsBbfF", ResourceCreatedTwo.resourceId());
     }
 
     public void testExceptions() throws IOException {
@@ -40,7 +45,7 @@ public class ResourceCreatedTests extends OpenSearchTestCase {
 
         String missingJson = "{\"resource_id\":\"B\"}";
         e = assertThrows(IOException.class, () -> ResourceCreated.parse(TemplateTestJsonUtil.jsonToParser(missingJson)));
-        assertEquals("A ResourceCreated object requires both a workflowStepName and resourceId.", e.getMessage());
+        assertEquals("Unable to find resource type for step: null", e.getMessage());
     }
 
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
@@ -21,6 +21,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -64,10 +65,12 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
     private ThreadPool threadPool;
     @Mock
     IndexMetadata indexMetadata;
+    private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
         MockitoAnnotations.openMocks(this);
         inputData = new WorkflowData(Map.ofEntries(Map.entry("index_name", "demo"), Map.entry("type", "knn")), "test-id");
         clusterService = mock(ClusterService.class);
@@ -84,7 +87,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
         when(clusterService.state()).thenReturn(ClusterState.builder(new ClusterName("test cluster")).build());
         when(metadata.indices()).thenReturn(Map.of(GLOBAL_CONTEXT_INDEX, indexMetadata));
 
-        createIndexStep = new CreateIndexStep(clusterService, client);
+        createIndexStep = new CreateIndexStep(clusterService, client, flowFrameworkIndicesHandler);
         CreateIndexStep.indexMappingUpdated = indexMappingUpdated;
     }
 
@@ -98,7 +101,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
 
         assertTrue(future.isDone() && !future.isCompletedExceptionally());
 
-        Map<String, Object> outputData = Map.of("index_name", "demo");
+        Map<String, Object> outputData = Map.of("index", "demo");
         assertEquals(outputData, future.get().getContent());
 
     }

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
@@ -14,6 +14,7 @@ import org.opensearch.client.AdminClient;
 import org.opensearch.client.Client;
 import org.opensearch.client.ClusterAdminClient;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.List;
@@ -37,11 +38,12 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
     private Client client;
     private AdminClient adminClient;
     private ClusterAdminClient clusterAdminClient;
+    private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
+        this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
         inputData = new WorkflowData(
             Map.ofEntries(
                 Map.entry("id", "pipelineId"),
@@ -67,7 +69,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
 
     public void testCreateIngestPipelineStep() throws InterruptedException, ExecutionException {
 
-        CreateIngestPipelineStep createIngestPipelineStep = new CreateIngestPipelineStep(client);
+        CreateIngestPipelineStep createIngestPipelineStep = new CreateIngestPipelineStep(client, flowFrameworkIndicesHandler);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ActionListener<AcknowledgedResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
@@ -85,7 +87,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
 
     public void testCreateIngestPipelineStepFailure() throws InterruptedException {
 
-        CreateIngestPipelineStep createIngestPipelineStep = new CreateIngestPipelineStep(client);
+        CreateIngestPipelineStep createIngestPipelineStep = new CreateIngestPipelineStep(client, flowFrameworkIndicesHandler);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ActionListener<AcknowledgedResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
@@ -105,7 +107,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
     }
 
     public void testMissingData() throws InterruptedException {
-        CreateIngestPipelineStep createIngestPipelineStep = new CreateIngestPipelineStep(client);
+        CreateIngestPipelineStep createIngestPipelineStep = new CreateIngestPipelineStep(client, flowFrameworkIndicesHandler);
 
         // Data with missing input and output fields
         WorkflowData incorrectData = new WorkflowData(

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
@@ -12,6 +12,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.model.MLModelConfig;
@@ -32,6 +33,7 @@ import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STA
 import static org.opensearch.flowframework.common.CommonValue.TASK_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
@@ -43,12 +45,15 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
     @Mock
     MachineLearningNodeClient machineLearningNodeClient;
 
+    private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
 
         MockitoAnnotations.openMocks(this);
-        this.registerLocalModelStep = new RegisterLocalModelStep(machineLearningNodeClient);
+        this.registerLocalModelStep = new RegisterLocalModelStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
         MLModelConfig config = TextEmbeddingModelConfig.builder()
             .modelType("testModelType")

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -12,6 +12,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
@@ -30,6 +31,7 @@ import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -38,6 +40,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
 
     private RegisterRemoteModelStep registerRemoteModelStep;
     private WorkflowData workflowData;
+    private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
     @Mock
     MachineLearningNodeClient mlNodeClient;
@@ -45,9 +48,10 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
 
         MockitoAnnotations.openMocks(this);
-        this.registerRemoteModelStep = new RegisterRemoteModelStep(mlNodeClient);
+        this.registerRemoteModelStep = new RegisterRemoteModelStep(mlNodeClient, flowFrameworkIndicesHandler);
         this.workflowData = new WorkflowData(
             Map.ofEntries(
                 Map.entry("function_name", "remote"),


### PR DESCRIPTION
### Description

Added updates to resources_created section for register model, create index, create ingest pipeline and create connector steps.

Changed the format of creating a resource to: 
```
 {
                "_index": ".plugins-workflow-state",
                "_id": "RvEFF4wBKbeLfRazqAdh",
                "_score": 1.0,
                "_source": {
                    "workflow_id": "RvEFF4wBKbeLfRazqAdh",
                    "state": "PROVISIONING",
                    "provisioning_progress": "IN_PROGRESS",
                    "provision_start_time": 1701193321252,
                    "resources_created": [
                        {
                            "workflow_step_name": "create_connector",
                            "workflow_step_id": "workflow_step_1-amit-test",
                            "connector_id": "TfEGF4wBKbeLfRazCwcp"
                        },
                        {
                            "workflow_step_name": "register_remote_model",
                            "workflow_step_id": "workflow_step_2",
                            "model_id": "T_EGF4wBKbeLfRazCwdx"
                        }
                    ],
                    "provision_end_time": 1701193305145
                }
            }
```


### Issues Resolved
 resolves #173 
 resolves #136 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
