### PR TITLE
Add Delete Connector Step

### DIFF
--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.ml.client.MachineLearningNodeClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.opensearch.flowframework.common.CommonValue.CONNECTOR_ID;
+
+/**
+ * Step to delete a connector for a remote model
+ */
+public class DeleteConnectorStep implements WorkflowStep {
+
+    private static final Logger logger = LogManager.getLogger(DeleteConnectorStep.class);
+
+    private MachineLearningNodeClient mlClient;
+
+    static final String NAME = "delete_connector";
+
+    /**
+     * Instantiate this class
+     * @param mlClient Machine Learning client to perform the deletion
+     */
+    public DeleteConnectorStep(MachineLearningNodeClient mlClient) {
+        this.mlClient = mlClient;
+    }
+
+    @Override
+    public CompletableFuture<WorkflowData> execute(List<WorkflowData> data) throws IOException {
+        CompletableFuture<WorkflowData> deleteConnectorFuture = new CompletableFuture<>();
+
+        ActionListener<DeleteResponse> actionListener = new ActionListener<>() {
+
+            @Override
+            public void onResponse(DeleteResponse deleteResponse) {
+                deleteConnectorFuture.complete(
+                    new WorkflowData(Map.ofEntries(Map.entry("connector_id", deleteResponse.getId())), data.get(0).getWorkflowId())
+                );
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error("Failed to delete connector");
+                deleteConnectorFuture.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
+            }
+        };
+
+        Optional<String> connectorId = data.stream()
+            .map(WorkflowData::getContent)
+            .filter(m -> m.containsKey(CONNECTOR_ID))
+            .map(m -> m.get(CONNECTOR_ID).toString())
+            .findFirst();
+
+        if (connectorId.isPresent()) {
+            mlClient.deleteConnector(connectorId.get(), actionListener);
+        } else {
+            deleteConnectorFuture.completeExceptionally(
+                new FlowFrameworkException("Required field " + CONNECTOR_ID + " is not provided", RestStatus.BAD_REQUEST)
+            );
+        }
+
+        return deleteConnectorFuture;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -25,7 +25,6 @@ import java.util.Map;
 public class WorkflowStepFactory {
 
     private final Map<String, WorkflowStep> stepMap = new HashMap<>();
-    private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
     /**
      * Instantiate this class.
@@ -43,17 +42,6 @@ public class WorkflowStepFactory {
         MachineLearningNodeClient mlClient,
         FlowFrameworkIndicesHandler flowFrameworkIndicesHandler
     ) {
-        this.flowFrameworkIndicesHandler = flowFrameworkIndicesHandler;
-        populateMap(settings, clusterService, client, mlClient, flowFrameworkIndicesHandler);
-    }
-
-    private void populateMap(
-        Settings settings,
-        ClusterService clusterService,
-        Client client,
-        MachineLearningNodeClient mlClient,
-        FlowFrameworkIndicesHandler flowFrameworkIndicesHandler
-    ) {
         stepMap.put(NoOpStep.NAME, new NoOpStep());
         stepMap.put(CreateIndexStep.NAME, new CreateIndexStep(clusterService, client));
         stepMap.put(CreateIngestPipelineStep.NAME, new CreateIngestPipelineStep(client));
@@ -61,6 +49,7 @@ public class WorkflowStepFactory {
         stepMap.put(RegisterRemoteModelStep.NAME, new RegisterRemoteModelStep(mlClient));
         stepMap.put(DeployModelStep.NAME, new DeployModelStep(mlClient));
         stepMap.put(CreateConnectorStep.NAME, new CreateConnectorStep(mlClient, flowFrameworkIndicesHandler));
+        stepMap.put(DeleteConnectorStep.NAME, new DeleteConnectorStep(mlClient));
         stepMap.put(ModelGroupStep.NAME, new ModelGroupStep(mlClient));
         stepMap.put(GetMLTaskStep.NAME, new GetMLTaskStep(settings, clusterService, mlClient));
     }
@@ -79,7 +68,7 @@ public class WorkflowStepFactory {
 
     /**
      * Gets the step map
-     * @return the step map
+     * @return a read-only copy of the step map
      */
     public Map<String, WorkflowStep> getStepMap() {
         return Map.copyOf(this.stepMap);

--- a/src/main/resources/mappings/workflow-steps.json
+++ b/src/main/resources/mappings/workflow-steps.json
@@ -39,6 +39,14 @@
             "connector_id"
         ]
     },
+    "delete_connector": {
+        "inputs": [
+            "connector_id"
+        ],
+        "outputs":[
+            "connector_id"
+        ]
+    },
     "register_local_model": {
         "inputs":[
             "name",

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.common.CommonValue;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+
+public class DeleteConnectorStepTests extends OpenSearchTestCase {
+    private WorkflowData inputData;
+
+    @Mock
+    MachineLearningNodeClient machineLearningNodeClient;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        MockitoAnnotations.openMocks(this);
+
+        inputData = new WorkflowData(Map.of(CommonValue.CONNECTOR_ID, "test"), "test-id");
+    }
+
+    public void testDeleteConnector() throws IOException, ExecutionException, InterruptedException {
+
+        String connectorId = "connectorId";
+        DeleteConnectorStep deleteConnectorStep = new DeleteConnectorStep(machineLearningNodeClient);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ActionListener<DeleteResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> actionListener = invocation.getArgument(1);
+            ShardId shardId = new ShardId(new Index("indexName", "uuid"), 1);
+            DeleteResponse output = new DeleteResponse(shardId, connectorId, 1, 1, 1, true);
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).deleteConnector(any(String.class), actionListenerCaptor.capture());
+
+        CompletableFuture<WorkflowData> future = deleteConnectorStep.execute(List.of(inputData));
+
+        verify(machineLearningNodeClient).deleteConnector(any(String.class), actionListenerCaptor.capture());
+
+        assertTrue(future.isDone());
+        assertEquals(connectorId, future.get().getContent().get("connector_id"));
+
+    }
+
+    public void testDeleteConnectorFailure() throws IOException {
+        DeleteConnectorStep deleteConnectorStep = new DeleteConnectorStep(machineLearningNodeClient);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ActionListener<DeleteResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLCreateConnectorResponse> actionListener = invocation.getArgument(1);
+            actionListener.onFailure(new FlowFrameworkException("Failed to create connector", RestStatus.INTERNAL_SERVER_ERROR));
+            return null;
+        }).when(machineLearningNodeClient).deleteConnector(any(String.class), actionListenerCaptor.capture());
+
+        CompletableFuture<WorkflowData> future = deleteConnectorStep.execute(List.of(inputData));
+
+        verify(machineLearningNodeClient).deleteConnector(any(String.class), actionListenerCaptor.capture());
+
+        assertTrue(future.isCompletedExceptionally());
+        ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
+        assertTrue(ex.getCause() instanceof FlowFrameworkException);
+        assertEquals("Failed to create connector", ex.getCause().getMessage());
+    }
+}


### PR DESCRIPTION
### Description

Adds a Delete Connector workflow step.

### Issues Resolved

In support of #89 

```
curl -i -XPOST "localhost:9200/_plugins/_flow_framework/workflow" -H "Content-Type:application/json" --data '
{
  "name": "create-connector-register-deploy-model",
  "description": "test case",
  "use_case": "TEST_CASE",
  "version": {
    "template": "1.0.0",
    "compatibility": [
      "2.11.0",
      "3.0.0"
    ]
  },
  "workflows": {
    "provision": {
      "nodes": [
        {
          "id": "workflow_step_1",
          "type": "create_connector",
          "user_inputs": {
            "name": "OpenAI Chat Connector",
            "description": "The connector to public OpenAI model service for GPT 3.5",
            "version": "1.0.0",
            "protocol": "http",
            "parameters": {
              "endpoint": "api.openai.com",
              "model": "gpt-3.5-turbo"
            },
            "credential": {
              "openAI_key": "12345"
            },
            "actions": [
              {
                "action_type": "predict",
                "method": "POST",
                "url": "https://${parameters.endpoint}/v1/chat/completions"
              }
            ]
          }
        },
        {
          "id": "workflow_step_2",
          "type": "delete_connector",
          "previous_node_inputs": {
            "workflow_step_1": "connector_id"
          }
        }
      ]
    }
  }
}'

curl -i -XPOST "localhost:9200/_plugins/_flow_framework/workflow/-f6-GIwBk0tyGR8GjdmT/_provision"
```
Output:
```
[2023-11-28T17:49:23,179][INFO ][o.o.f.t.ProvisionWorkflowTransportAction] [88665a43e3fa] Queueing process [workflow_step_1]. Can start immediately!
[2023-11-28T17:49:23,181][INFO ][o.o.f.t.ProvisionWorkflowTransportAction] [88665a43e3fa] Queueing process [workflow_step_2]. Must wait for [workflow_step_1] to complete first.
[2023-11-28T17:49:23,181][INFO ][o.o.f.w.ProcessNode      ] [88665a43e3fa] Starting workflow_step_1.
[2023-11-28T17:49:23,182][INFO ][o.o.m.a.c.TransportCreateConnectorAction] [88665a43e3fa] connector created, indexing into the connector system index
[2023-11-28T17:49:23,319][INFO ][o.o.f.t.ProvisionWorkflowTransportAction] [88665a43e3fa] updated workflow -f6-GIwBk0tyGR8GjdmT state to PROVISIONING
[2023-11-28T17:49:23,340][INFO ][o.o.m.a.c.TransportCreateConnectorAction] [88665a43e3fa] Connector saved into index, result:CREATED, connector id: -_7EGIwBk0tyGR8GPdlu
[2023-11-28T17:49:23,359][INFO ][o.o.f.w.CreateConnectorStep] [88665a43e3fa] Created connector successfully
[2023-11-28T17:49:23,359][INFO ][o.o.f.w.ProcessNode      ] [88665a43e3fa] Finished workflow_step_1.
[2023-11-28T17:49:23,359][INFO ][o.o.f.w.ProcessNode      ] [88665a43e3fa] Starting workflow_step_2.
[2023-11-28T17:49:23,422][INFO ][o.o.m.a.c.DeleteConnectorTransportAction] [88665a43e3fa] Completed Delete Connector Request, connector id:-_7EGIwBk0tyGR8GPdlu deleted
[2023-11-28T17:49:23,442][INFO ][o.o.f.t.ProvisionWorkflowTransportAction] [88665a43e3fa] Provisioning completed successfully for workflow -f6-GIwBk0tyGR8GjdmT
[2023-11-28T17:49:23,442][INFO ][o.o.f.w.ProcessNode      ] [88665a43e3fa] Finished workflow_step_2.
[2023-11-28T17:49:23,542][INFO ][o.o.f.w.CreateConnectorStep] [88665a43e3fa] updated resources created of -f6-GIwBk0tyGR8GjdmT
[2023-11-28T17:49:23,605][INFO ][o.o.f.t.ProvisionWorkflowTransportAction] [88665a43e3fa] updated workflow -f6-GIwBk0tyGR8GjdmT state to COMPLETED
```
Output with invalid connector id:
```
[2023-11-28T17:39:38,768][INFO ][o.o.f.t.ProvisionWorkflowTransportAction] [88665a43e3fa] Queueing process [workflow_step_1]. Can start immediately!
[2023-11-28T17:39:38,769][INFO ][o.o.f.t.ProvisionWorkflowTransportAction] [88665a43e3fa] Queueing process [workflow_step_2]. Must wait for [workflow_step_1] to complete first.
[2023-11-28T17:39:38,769][INFO ][o.o.f.w.ProcessNode      ] [88665a43e3fa] Starting workflow_step_1.
[2023-11-28T17:39:38,856][INFO ][o.o.f.t.ProvisionWorkflowTransportAction] [88665a43e3fa] updated workflow 67m7GIwB4pgpFwKmABmZ state to PROVISIONING
[2023-11-28T17:39:38,880][INFO ][o.o.m.a.c.TransportCreateConnectorAction] [88665a43e3fa] connector created, indexing into the connector system index
[2023-11-28T17:39:38,891][INFO ][o.o.p.PluginsService     ] [88665a43e3fa] PluginService:onIndexModule index:[.plugins-ml-connector/URKg7xTpT4uKPi1bJNwTLw]
[2023-11-28T17:39:38,899][INFO ][o.o.c.m.MetadataCreateIndexService] [88665a43e3fa] [.plugins-ml-connector] creating index, cause [api], templates [], shards [1]/[1]
[2023-11-28T17:39:38,900][INFO ][o.o.c.r.a.AllocationService] [88665a43e3fa] updating number_of_replicas to [0] for indices [.plugins-ml-connector]
[2023-11-28T17:39:38,974][INFO ][o.o.p.PluginsService     ] [88665a43e3fa] PluginService:onIndexModule index:[.plugins-ml-connector/URKg7xTpT4uKPi1bJNwTLw]
[2023-11-28T17:39:39,387][INFO ][o.o.c.r.a.AllocationService] [88665a43e3fa] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[.plugins-ml-connector][0]]]).
[2023-11-28T17:39:39,482][INFO ][o.o.m.e.i.MLIndicesHandler] [88665a43e3fa] create index:.plugins-ml-connector
[2023-11-28T17:39:39,584][INFO ][o.o.m.a.c.TransportCreateConnectorAction] [88665a43e3fa] Connector saved into index, result:CREATED, connector id: 7Lm7GIwB4pgpFwKmVRlt
[2023-11-28T17:39:39,603][INFO ][o.o.f.w.CreateConnectorStep] [88665a43e3fa] Created connector successfully
[2023-11-28T17:39:39,603][INFO ][o.o.f.w.ProcessNode      ] [88665a43e3fa] Finished workflow_step_1.
[2023-11-28T17:39:39,603][INFO ][o.o.f.w.ProcessNode      ] [88665a43e3fa] Starting workflow_step_2.
[2023-11-28T17:39:39,648][INFO ][o.o.m.a.c.DeleteConnectorTransportAction] [88665a43e3fa] Connector id:test not found
[2023-11-28T17:39:39,668][INFO ][o.o.f.t.ProvisionWorkflowTransportAction] [88665a43e3fa] Provisioning completed successfully for workflow 67m7GIwB4pgpFwKmABmZ
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
