### PR TITLE
Improve workflow step execute API

### DIFF
--- a/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
@@ -17,6 +17,7 @@ import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.transport.deploy.MLDeployModelResponse;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -41,7 +42,12 @@ public class DeployModelStep implements WorkflowStep {
     }
 
     @Override
-    public CompletableFuture<WorkflowData> execute(List<WorkflowData> data) {
+    public CompletableFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs
+    ) {
 
         CompletableFuture<WorkflowData> deployModelFuture = new CompletableFuture<>();
 
@@ -52,7 +58,8 @@ public class DeployModelStep implements WorkflowStep {
                 deployModelFuture.complete(
                     new WorkflowData(
                         Map.ofEntries(Map.entry("deploy_model_status", mlDeployModelResponse.getStatus())),
-                        data.get(0).getWorkflowId()
+                        currentNodeInputs.getWorkflowId(),
+                        currentNodeInputs.getNodeId()
                     )
                 );
             }
@@ -65,6 +72,12 @@ public class DeployModelStep implements WorkflowStep {
         };
 
         String modelId = null;
+
+        // TODO: Recreating the list to get this compiling
+        // Need to refactor the below iteration to pull directly from the maps
+        List<WorkflowData> data = new ArrayList<>();
+        data.add(currentNodeInputs);
+        data.addAll(outputs.values());
 
         for (WorkflowData workflowData : data) {
             if (workflowData.getContent().containsKey(MODEL_ID)) {

--- a/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
@@ -53,7 +53,12 @@ public class ModelGroupStep implements WorkflowStep {
     }
 
     @Override
-    public CompletableFuture<WorkflowData> execute(List<WorkflowData> data) throws IOException {
+    public CompletableFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs
+    ) throws IOException {
 
         CompletableFuture<WorkflowData> registerModelGroupFuture = new CompletableFuture<>();
 
@@ -67,7 +72,8 @@ public class ModelGroupStep implements WorkflowStep {
                             Map.entry("model_group_id", mlRegisterModelGroupResponse.getModelGroupId()),
                             Map.entry("model_group_status", mlRegisterModelGroupResponse.getStatus())
                         ),
-                        data.get(0).getWorkflowId()
+                        currentNodeInputs.getWorkflowId(),
+                        currentNodeInputs.getNodeId()
                     )
                 );
             }
@@ -84,6 +90,12 @@ public class ModelGroupStep implements WorkflowStep {
         List<String> backendRoles = new ArrayList<>();
         AccessMode modelAccessMode = null;
         Boolean isAddAllBackendRoles = null;
+
+        // TODO: Recreating the list to get this compiling
+        // Need to refactor the below iteration to pull directly from the maps
+        List<WorkflowData> data = new ArrayList<>();
+        data.add(currentNodeInputs);
+        data.addAll(outputs.values());
 
         for (WorkflowData workflowData : data) {
             Map<String, Object> content = workflowData.getContent();

--- a/src/main/java/org/opensearch/flowframework/workflow/NoOpStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/NoOpStep.java
@@ -9,7 +9,7 @@
 package org.opensearch.flowframework.workflow;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -21,7 +21,12 @@ public class NoOpStep implements WorkflowStep {
     public static final String NAME = "noop";
 
     @Override
-    public CompletableFuture<WorkflowData> execute(List<WorkflowData> data) throws IOException {
+    public CompletableFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs
+    ) throws IOException {
         return CompletableFuture.completedFuture(WorkflowData.EMPTY);
     }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalModelStep.java
@@ -24,6 +24,7 @@ import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -64,7 +65,12 @@ public class RegisterLocalModelStep implements WorkflowStep {
     }
 
     @Override
-    public CompletableFuture<WorkflowData> execute(List<WorkflowData> data) {
+    public CompletableFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs
+    ) {
 
         CompletableFuture<WorkflowData> registerLocalModelFuture = new CompletableFuture<>();
 
@@ -78,7 +84,8 @@ public class RegisterLocalModelStep implements WorkflowStep {
                             Map.entry(TASK_ID, mlRegisterModelResponse.getTaskId()),
                             Map.entry(REGISTER_MODEL_STATUS, mlRegisterModelResponse.getStatus())
                         ),
-                        data.get(0).getWorkflowId()
+                        currentNodeInputs.getWorkflowId(),
+                        currentNodeInputs.getNodeId()
                     )
                 );
             }
@@ -101,6 +108,12 @@ public class RegisterLocalModelStep implements WorkflowStep {
         FrameworkType frameworkType = null;
         String allConfig = null;
         String url = null;
+
+        // TODO: Recreating the list to get this compiling
+        // Need to refactor the below iteration to pull directly from the maps
+        List<WorkflowData> data = new ArrayList<>();
+        data.add(currentNodeInputs);
+        data.addAll(outputs.values());
 
         for (WorkflowData workflowData : data) {
             Map<String, Object> content = workflowData.getContent();

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -20,6 +20,7 @@ import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -55,7 +56,12 @@ public class RegisterRemoteModelStep implements WorkflowStep {
     }
 
     @Override
-    public CompletableFuture<WorkflowData> execute(List<WorkflowData> data) {
+    public CompletableFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs
+    ) {
 
         CompletableFuture<WorkflowData> registerRemoteModelFuture = new CompletableFuture<>();
 
@@ -69,7 +75,8 @@ public class RegisterRemoteModelStep implements WorkflowStep {
                             Map.entry(MODEL_ID, mlRegisterModelResponse.getModelId()),
                             Map.entry(REGISTER_MODEL_STATUS, mlRegisterModelResponse.getStatus())
                         ),
-                        data.get(0).getWorkflowId()
+                        currentNodeInputs.getWorkflowId(),
+                        currentNodeInputs.getNodeId()
                     )
                 );
             }
@@ -86,6 +93,12 @@ public class RegisterRemoteModelStep implements WorkflowStep {
         String modelGroupId = null;
         String description = null;
         String connectorId = null;
+
+        // TODO: Recreating the list to get this compiling
+        // Need to refactor the below iteration to pull directly from the maps
+        List<WorkflowData> data = new ArrayList<>();
+        data.add(currentNodeInputs);
+        data.addAll(outputs.values());
 
         // TODO : Handle inline connector configuration : https://github.com/opensearch-project/flow-framework/issues/149
 

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowData.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowData.java
@@ -28,18 +28,21 @@ public class WorkflowData {
 
     @Nullable
     private String workflowId;
+    @Nullable
+    private String nodeId;
 
     private WorkflowData() {
-        this(Collections.emptyMap(), Collections.emptyMap(), "");
+        this(Collections.emptyMap(), Collections.emptyMap(), null, null);
     }
 
     /**
      * Instantiate this object with content and empty params.
      * @param content The content map
      * @param workflowId The workflow ID associated with this step
+     * @param nodeId The node ID associated with this step
      */
-    public WorkflowData(Map<String, Object> content, @Nullable String workflowId) {
-        this(content, Collections.emptyMap(), workflowId);
+    public WorkflowData(Map<String, Object> content, @Nullable String workflowId, @Nullable String nodeId) {
+        this(content, Collections.emptyMap(), workflowId, nodeId);
     }
 
     /**
@@ -47,11 +50,13 @@ public class WorkflowData {
      * @param content The content map
      * @param params The params map
      * @param workflowId The workflow ID associated with this step
+     * @param nodeId The node ID associated with this step
      */
-    public WorkflowData(Map<String, Object> content, Map<String, String> params, @Nullable String workflowId) {
+    public WorkflowData(Map<String, Object> content, Map<String, String> params, @Nullable String workflowId, @Nullable String nodeId) {
         this.content = Map.copyOf(content);
         this.params = Map.copyOf(params);
         this.workflowId = workflowId;
+        this.nodeId = nodeId;
     }
 
     /**
@@ -72,11 +77,20 @@ public class WorkflowData {
     };
 
     /**
-     * Returns the workflowId associated with this workflow.
+     * Returns the workflowId associated with this data.
      * @return the workflowId of this data.
      */
     @Nullable
     public String getWorkflowId() {
         return this.workflowId;
+    };
+
+    /**
+     * Returns the nodeId associated with this data.
+     * @return the nodeId of this data.
+     */
+    @Nullable
+    public String getNodeId() {
+        return this.nodeId;
     };
 }

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -70,7 +70,7 @@ public class WorkflowProcessSorter {
         Map<String, ProcessNode> idToNodeMap = new HashMap<>();
         for (WorkflowNode node : sortedNodes) {
             WorkflowStep step = workflowStepFactory.createStep(node.type());
-            WorkflowData data = new WorkflowData(node.userInputs(), workflow.userParams(), workflowId);
+            WorkflowData data = new WorkflowData(node.userInputs(), workflow.userParams(), workflowId, node.id());
             List<ProcessNode> predecessorNodes = workflow.edges()
                 .stream()
                 .filter(e -> e.destination().equals(node.id()))

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
@@ -22,7 +22,7 @@ public interface WorkflowStep {
      * @param currentNodeId The id of the node executing this step
      * @param currentNodeInputs Input params and content for this node, from workflow parsing
      * @param previousNodeInputs Input params for this node that come from previous steps
-     * @param output WorkflowData content of previous steps.
+     * @param outputs WorkflowData content of previous steps.
      * @return A CompletableFuture of the building block. This block should return immediately, but not be completed until the step executes, containing either the step's output data or {@link WorkflowData#EMPTY} which may be passed to follow-on steps.
      * @throws IOException on a failure.
      */

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
@@ -9,7 +9,7 @@
 package org.opensearch.flowframework.workflow;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -19,11 +19,19 @@ public interface WorkflowStep {
 
     /**
      * Triggers the actual processing of the building block.
-     * @param data representing input params and content, or output content of previous steps. The first element of the list is data (if any) provided from parsing the template, and may be {@link WorkflowData#EMPTY}.
+     * @param currentNodeId The id of the node executing this step
+     * @param currentNodeInputs Input params and content for this node, from workflow parsing
+     * @param previousNodeInputs Input params for this node that come from previous steps
+     * @param output WorkflowData content of previous steps.
      * @return A CompletableFuture of the building block. This block should return immediately, but not be completed until the step executes, containing either the step's output data or {@link WorkflowData#EMPTY} which may be passed to follow-on steps.
      * @throws IOException on a failure.
      */
-    CompletableFuture<WorkflowData> execute(List<WorkflowData> data) throws IOException;
+    CompletableFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs
+    ) throws IOException;
 
     /**
      * Gets the name of the workflow step.

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
@@ -20,7 +20,7 @@ import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -71,7 +71,8 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
                 Map.entry(CommonValue.CREDENTIALS_FIELD, credentials),
                 Map.entry(CommonValue.ACTIONS_FIELD, actions)
             ),
-            "test-id"
+            "test-id",
+            "test-node-id"
         );
     }
 
@@ -90,7 +91,12 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), actionListenerCaptor.capture());
 
-        CompletableFuture<WorkflowData> future = createConnectorStep.execute(List.of(inputData));
+        CompletableFuture<WorkflowData> future = createConnectorStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), actionListenerCaptor.capture());
 
@@ -111,7 +117,12 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), actionListenerCaptor.capture());
 
-        CompletableFuture<WorkflowData> future = createConnectorStep.execute(List.of(inputData));
+        CompletableFuture<WorkflowData> future = createConnectorStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), actionListenerCaptor.capture());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
@@ -24,8 +24,8 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -69,7 +69,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         MockitoAnnotations.openMocks(this);
-        inputData = new WorkflowData(Map.ofEntries(Map.entry("index_name", "demo"), Map.entry("type", "knn")), "test-id");
+        inputData = new WorkflowData(Map.ofEntries(Map.entry("index_name", "demo"), Map.entry("type", "knn")), "test-id", "test-node-id");
         clusterService = mock(ClusterService.class);
         client = mock(Client.class);
         adminClient = mock(AdminClient.class);
@@ -91,7 +91,12 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
     public void testCreateIndexStep() throws ExecutionException, InterruptedException {
         @SuppressWarnings({ "unchecked" })
         ArgumentCaptor<ActionListener<CreateIndexResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
-        CompletableFuture<WorkflowData> future = createIndexStep.execute(List.of(inputData));
+        CompletableFuture<WorkflowData> future = createIndexStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
         assertFalse(future.isDone());
         verify(indicesAdminClient, times(1)).create(any(CreateIndexRequest.class), actionListenerCaptor.capture());
         actionListenerCaptor.getValue().onResponse(new CreateIndexResponse(true, true, "demo"));
@@ -106,7 +111,12 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
     public void testCreateIndexStepFailure() throws ExecutionException, InterruptedException {
         @SuppressWarnings({ "unchecked" })
         ArgumentCaptor<ActionListener<CreateIndexResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
-        CompletableFuture<WorkflowData> future = createIndexStep.execute(List.of(inputData));
+        CompletableFuture<WorkflowData> future = createIndexStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
         assertFalse(future.isDone());
         verify(indicesAdminClient, times(1)).create(any(CreateIndexRequest.class), actionListenerCaptor.capture());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
@@ -16,7 +16,7 @@ import org.opensearch.client.ClusterAdminClient;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -51,11 +51,12 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
                 Map.entry("input_field_name", "inputField"),
                 Map.entry("output_field_name", "outputField")
             ),
-            "test-id"
+            "test-id",
+            "test-node-id"
         );
 
         // Set output data to returned pipelineId
-        outpuData = new WorkflowData(Map.ofEntries(Map.entry("pipeline_id", "pipelineId")), "test-id");
+        outpuData = new WorkflowData(Map.ofEntries(Map.entry("pipeline_id", "pipelineId")), "test-id", "test-node-id");
 
         client = mock(Client.class);
         adminClient = mock(AdminClient.class);
@@ -71,7 +72,12 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ActionListener<AcknowledgedResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
-        CompletableFuture<WorkflowData> future = createIngestPipelineStep.execute(List.of(inputData));
+        CompletableFuture<WorkflowData> future = createIngestPipelineStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         assertFalse(future.isDone());
 
@@ -89,7 +95,12 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ActionListener<AcknowledgedResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
-        CompletableFuture<WorkflowData> future = createIngestPipelineStep.execute(List.of(inputData));
+        CompletableFuture<WorkflowData> future = createIngestPipelineStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         assertFalse(future.isDone());
 
@@ -115,10 +126,16 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
                 Map.entry("type", "text_embedding"),
                 Map.entry("model_id", "model_id")
             ),
-            "test-id"
+            "test-id",
+            "test-node-id"
         );
 
-        CompletableFuture<WorkflowData> future = createIngestPipelineStep.execute(List.of(incorrectData));
+        CompletableFuture<WorkflowData> future = createIngestPipelineStep.execute(
+            incorrectData.getNodeId(),
+            incorrectData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
         assertTrue(future.isDone() && future.isCompletedExceptionally());
 
         ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
@@ -19,7 +19,7 @@ import org.opensearch.ml.common.MLTaskType;
 import org.opensearch.ml.common.transport.deploy.MLDeployModelResponse;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -44,7 +44,7 @@ public class DeployModelStepTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        inputData = new WorkflowData(Map.ofEntries(Map.entry("model_id", "modelId")), "test-id");
+        inputData = new WorkflowData(Map.ofEntries(Map.entry("model_id", "modelId")), "test-id", "test-node-id");
 
         MockitoAnnotations.openMocks(this);
 
@@ -67,7 +67,12 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).deploy(eq("modelId"), actionListenerCaptor.capture());
 
-        CompletableFuture<WorkflowData> future = deployModel.execute(List.of(inputData));
+        CompletableFuture<WorkflowData> future = deployModel.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         verify(machineLearningNodeClient).deploy(eq("modelId"), actionListenerCaptor.capture());
 
@@ -87,7 +92,12 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).deploy(eq("modelId"), actionListenerCaptor.capture());
 
-        CompletableFuture<WorkflowData> future = deployModel.execute(List.of(inputData));
+        CompletableFuture<WorkflowData> future = deployModel.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         verify(machineLearningNodeClient).deploy(eq("modelId"), actionListenerCaptor.capture());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
@@ -20,7 +20,7 @@ import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupRespon
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -29,7 +29,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
@@ -54,7 +53,8 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
                 Map.entry("access_mode", AccessMode.PUBLIC),
                 Map.entry("add_all_backend_roles", false)
             ),
-            "test-id"
+            "test-id",
+            "test-node-id"
         );
 
     }
@@ -75,7 +75,12 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
 
-        CompletableFuture<WorkflowData> future = modelGroupStep.execute(List.of(inputData));
+        CompletableFuture<WorkflowData> future = modelGroupStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         verify(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
 
@@ -97,7 +102,12 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
 
-        CompletableFuture<WorkflowData> future = modelGroupStep.execute(List.of(inputData));
+        CompletableFuture<WorkflowData> future = modelGroupStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         verify(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
 
@@ -111,7 +121,12 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
     public void testRegisterModelGroupWithNoName() throws IOException {
         ModelGroupStep modelGroupStep = new ModelGroupStep(machineLearningNodeClient);
 
-        CompletableFuture<WorkflowData> future = modelGroupStep.execute(List.of(inputDataWithNoName));
+        CompletableFuture<WorkflowData> future = modelGroupStep.execute(
+            inputDataWithNoName.getNodeId(),
+            inputDataWithNoName,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());

--- a/src/test/java/org/opensearch/flowframework/workflow/NoOpStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/NoOpStepTests.java
@@ -19,7 +19,12 @@ public class NoOpStepTests extends OpenSearchTestCase {
     public void testNoOpStep() throws IOException {
         NoOpStep noopStep = new NoOpStep();
         assertEquals(NoOpStep.NAME, noopStep.getName());
-        CompletableFuture<WorkflowData> future = noopStep.execute(Collections.emptyList());
+        CompletableFuture<WorkflowData> future = noopStep.execute(
+            "nodeId",
+            WorkflowData.EMPTY,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
         assertTrue(future.isDone());
         assertFalse(future.isCompletedExceptionally());
     }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
@@ -20,7 +20,7 @@ import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -70,7 +70,8 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
                 Map.entry("framework_type", "sentence_transformers"),
                 Map.entry("url", "something.com")
             ),
-            "test-id"
+            "test-id",
+            "test-node-id"
         );
 
     }
@@ -87,7 +88,12 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
 
-        CompletableFuture<WorkflowData> future = registerLocalModelStep.execute(List.of(workflowData));
+        CompletableFuture<WorkflowData> future = registerLocalModelStep.execute(
+            workflowData.getNodeId(),
+            workflowData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
         verify(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
 
         assertTrue(future.isDone());
@@ -105,7 +111,12 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
 
-        CompletableFuture<WorkflowData> future = this.registerLocalModelStep.execute(List.of(workflowData));
+        CompletableFuture<WorkflowData> future = this.registerLocalModelStep.execute(
+            workflowData.getNodeId(),
+            workflowData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
         assertTrue(future.isDone());
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -114,7 +125,12 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
     }
 
     public void testMissingInputs() {
-        CompletableFuture<WorkflowData> future = registerLocalModelStep.execute(List.of(WorkflowData.EMPTY));
+        CompletableFuture<WorkflowData> future = registerLocalModelStep.execute(
+            "nodeId",
+            WorkflowData.EMPTY,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
         assertTrue(future.isDone());
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -18,7 +18,7 @@ import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -55,7 +55,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
                 Map.entry("description", "description"),
                 Map.entry("connector_id", "abcdefg")
             ),
-            "test-id"
+            "test-id",
+            "test-node-id"
         );
     }
 
@@ -72,7 +73,12 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(mlNodeClient).register(any(MLRegisterModelInput.class), any());
 
-        CompletableFuture<WorkflowData> future = this.registerRemoteModelStep.execute(List.of(workflowData));
+        CompletableFuture<WorkflowData> future = this.registerRemoteModelStep.execute(
+            workflowData.getNodeId(),
+            workflowData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         verify(mlNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
 
@@ -90,7 +96,12 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(mlNodeClient).register(any(MLRegisterModelInput.class), any());
 
-        CompletableFuture<WorkflowData> future = this.registerRemoteModelStep.execute(List.of(workflowData));
+        CompletableFuture<WorkflowData> future = this.registerRemoteModelStep.execute(
+            workflowData.getNodeId(),
+            workflowData,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
         assertTrue(future.isDone());
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -100,7 +111,12 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
     }
 
     public void testMissingInputs() {
-        CompletableFuture<WorkflowData> future = this.registerRemoteModelStep.execute(List.of(WorkflowData.EMPTY));
+        CompletableFuture<WorkflowData> future = this.registerRemoteModelStep.execute(
+            "nodeId",
+            WorkflowData.EMPTY,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
         assertTrue(future.isDone());
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowDataTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowDataTests.java
@@ -26,14 +26,17 @@ public class WorkflowDataTests extends OpenSearchTestCase {
         assertTrue(empty.getContent().isEmpty());
 
         Map<String, Object> expectedContent = Map.of("baz", new String[] { "qux", "quxx" });
-        WorkflowData contentOnly = new WorkflowData(expectedContent, "test-id-123");
+        WorkflowData contentOnly = new WorkflowData(expectedContent, null, null);
         assertTrue(contentOnly.getParams().isEmpty());
         assertEquals(expectedContent, contentOnly.getContent());
+        assertNull(contentOnly.getWorkflowId());
+        assertNull(contentOnly.getNodeId());
 
         Map<String, String> expectedParams = Map.of("foo", "bar");
-        WorkflowData contentAndParams = new WorkflowData(expectedContent, expectedParams, "test-id-123");
+        WorkflowData contentAndParams = new WorkflowData(expectedContent, expectedParams, "test-id-123", "test-node-id");
         assertEquals(expectedParams, contentAndParams.getParams());
         assertEquals(expectedContent, contentAndParams.getContent());
         assertEquals("test-id-123", contentAndParams.getWorkflowId());
+        assertEquals("test-node-id", contentAndParams.getNodeId());
     }
 }


### PR DESCRIPTION
### Description

Changes the workflow step `execute()` API to:
 - pass a `nodeId` to identify the step uniquely
 - improve on the workflowdata list by passing the input data and previous node data separately
 - adds a map for previous step inputs

### Issues Resolved

Part of #210 

Submitting with the API change first in order to get compiling classes with the new API, to enable in-progress work to update the API and work in parallel.

Left a TODO to improve the parsing for collecting previous data from the list; for now, recreating the workflow data list to preserve the previous behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
