### PR TITLE
Add Util method to fetch inputs from parameters, content, and previous step output

### DIFF
--- a/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
@@ -8,21 +8,6 @@
  */
 package org.opensearch.flowframework.util;
 
-import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
-import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
-
-import java.io.IOException;
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.Client;
@@ -40,6 +25,21 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.workflow.WorkflowData;
 import org.opensearch.ml.common.agent.LLMSpec;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
+import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 
 /**
  * Utility methods for Template parsing

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -8,14 +8,20 @@
  */
 package org.opensearch.flowframework.workflow;
 
-import static org.opensearch.flowframework.common.CommonValue.ACTIONS_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.CREDENTIAL_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.PROTOCOL_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
-import static org.opensearch.flowframework.util.ParseUtils.getStringToStringMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.common.WorkflowResources;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.util.ParseUtils;
+import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.connector.ConnectorAction.ActionType;
+import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
+import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
 
 import java.io.IOException;
 import java.security.AccessController;
@@ -31,20 +37,14 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.opensearch.ExceptionsHelper;
-import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.flowframework.common.WorkflowResources;
-import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
-import org.opensearch.flowframework.util.ParseUtils;
-import org.opensearch.ml.client.MachineLearningNodeClient;
-import org.opensearch.ml.common.connector.ConnectorAction;
-import org.opensearch.ml.common.connector.ConnectorAction.ActionType;
-import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
-import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
+import static org.opensearch.flowframework.common.CommonValue.ACTIONS_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.CREDENTIAL_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.PROTOCOL_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
+import static org.opensearch.flowframework.util.ParseUtils.getStringToStringMap;
 
 /**
  * Step to create a connector for a remote model

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -154,11 +154,9 @@ public class CreateConnectorStep implements WorkflowStep {
                 credentials = getStringToStringMap(inputs.get(CREDENTIAL_FIELD), CREDENTIAL_FIELD);
                 actions = getConnectorActionList(inputs.get(ACTIONS_FIELD));
             } catch (IllegalArgumentException iae) {
-                createConnectorFuture.completeExceptionally(new FlowFrameworkException(iae.getMessage(), RestStatus.BAD_REQUEST));
-                return createConnectorFuture;
+                throw new FlowFrameworkException(iae.getMessage(), RestStatus.BAD_REQUEST);
             } catch (PrivilegedActionException pae) {
-                createConnectorFuture.completeExceptionally(new FlowFrameworkException(pae.getMessage(), RestStatus.UNAUTHORIZED));
-                return createConnectorFuture;
+                throw new FlowFrameworkException(pae.getMessage(), RestStatus.UNAUTHORIZED);
             }
 
             MLCreateConnectorInput mlInput = MLCreateConnectorInput.builder()

--- a/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
@@ -14,12 +14,13 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.transport.deploy.MLDeployModelResponse;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
@@ -71,20 +72,18 @@ public class DeployModelStep implements WorkflowStep {
             }
         };
 
-        String modelId = null;
+        Set<String> requiredKeys = Set.of(MODEL_ID);
+        Set<String> optionalKeys = Collections.emptySet();
 
-        // TODO: Recreating the list to get this compiling
-        // Need to refactor the below iteration to pull directly from the maps
-        List<WorkflowData> data = new ArrayList<>();
-        data.add(currentNodeInputs);
-        data.addAll(outputs.values());
+        Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
+            requiredKeys,
+            optionalKeys,
+            currentNodeInputs,
+            outputs,
+            previousNodeInputs
+        );
 
-        for (WorkflowData workflowData : data) {
-            if (workflowData.getContent().containsKey(MODEL_ID)) {
-                modelId = (String) workflowData.getContent().get(MODEL_ID);
-                break;
-            }
-        }
+        String modelId = (String) inputs.get(MODEL_ID);
 
         if (modelId != null) {
             mlClient.deploy(modelId, actionListener);

--- a/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -75,22 +74,21 @@ public class DeployModelStep implements WorkflowStep {
         Set<String> requiredKeys = Set.of(MODEL_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
-        Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
-            requiredKeys,
-            optionalKeys,
-            currentNodeInputs,
-            outputs,
-            previousNodeInputs
-        );
+        try {
+            Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
+                requiredKeys,
+                optionalKeys,
+                currentNodeInputs,
+                outputs,
+                previousNodeInputs
+            );
 
-        String modelId = (String) inputs.get(MODEL_ID);
+            String modelId = (String) inputs.get(MODEL_ID);
 
-        if (modelId != null) {
             mlClient.deploy(modelId, actionListener);
-        } else {
-            deployModelFuture.completeExceptionally(new FlowFrameworkException("Model ID is not provided", RestStatus.BAD_REQUEST));
+        } catch (FlowFrameworkException e) {
+            deployModelFuture.completeExceptionally(e);
         }
-
         return deployModelFuture;
     }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
@@ -8,19 +8,6 @@
  */
 package org.opensearch.flowframework.workflow;
 
-import static org.opensearch.flowframework.common.CommonValue.ADD_ALL_BACKEND_ROLES;
-import static org.opensearch.flowframework.common.CommonValue.BACKEND_ROLES_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ACCESS_MODE;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_STATUS;
-import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -34,6 +21,19 @@ import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput.MLRegisterModelGroupInputBuilder;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupResponse;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.opensearch.flowframework.common.CommonValue.ADD_ALL_BACKEND_ROLES;
+import static org.opensearch.flowframework.common.CommonValue.BACKEND_ROLES_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_ACCESS_MODE;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_STATUS;
+import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 
 /**
  * Step to register a model group

--- a/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
@@ -8,33 +8,32 @@
  */
 package org.opensearch.flowframework.workflow;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.opensearch.ExceptionsHelper;
-import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.flowframework.common.WorkflowResources;
-import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
-import org.opensearch.ml.client.MachineLearningNodeClient;
-import org.opensearch.ml.common.AccessMode;
-import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput;
-import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput.MLRegisterModelGroupInputBuilder;
-import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupResponse;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
-
 import static org.opensearch.flowframework.common.CommonValue.ADD_ALL_BACKEND_ROLES;
 import static org.opensearch.flowframework.common.CommonValue.BACKEND_ROLES_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_ACCESS_MODE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.common.WorkflowResources;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.util.ParseUtils;
+import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.AccessMode;
+import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput;
+import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput.MLRegisterModelGroupInputBuilder;
+import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupResponse;
 
 /**
  * Step to register a model group
@@ -113,49 +112,23 @@ public class ModelGroupStep implements WorkflowStep {
             }
         };
 
-        String modelGroupName = null;
-        String description = null;
-        List<String> backendRoles = new ArrayList<>();
-        AccessMode modelAccessMode = null;
-        Boolean isAddAllBackendRoles = null;
+        Set<String> requiredKeys = Set.of(NAME_FIELD);
+        Set<String> optionalKeys = Set.of(DESCRIPTION_FIELD, BACKEND_ROLES_FIELD, MODEL_ACCESS_MODE, ADD_ALL_BACKEND_ROLES);
 
-        // TODO: Recreating the list to get this compiling
-        // Need to refactor the below iteration to pull directly from the maps
-        List<WorkflowData> data = new ArrayList<>();
-        data.add(currentNodeInputs);
-        data.addAll(outputs.values());
-
-        for (WorkflowData workflowData : data) {
-            Map<String, Object> content = workflowData.getContent();
-
-            for (Entry<String, Object> entry : content.entrySet()) {
-                switch (entry.getKey()) {
-                    case NAME_FIELD:
-                        modelGroupName = (String) content.get(NAME_FIELD);
-                        break;
-                    case DESCRIPTION_FIELD:
-                        description = (String) content.get(DESCRIPTION_FIELD);
-                        break;
-                    case BACKEND_ROLES_FIELD:
-                        backendRoles = getBackendRoles(content);
-                        break;
-                    case MODEL_ACCESS_MODE:
-                        modelAccessMode = (AccessMode) content.get(MODEL_ACCESS_MODE);
-                        break;
-                    case ADD_ALL_BACKEND_ROLES:
-                        isAddAllBackendRoles = (Boolean) content.get(ADD_ALL_BACKEND_ROLES);
-                        break;
-                    default:
-                        break;
-                }
-            }
-        }
-
-        if (modelGroupName == null) {
-            registerModelGroupFuture.completeExceptionally(
-                new FlowFrameworkException("Model group name is not provided", RestStatus.BAD_REQUEST)
+        try {
+            Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
+                requiredKeys,
+                optionalKeys,
+                currentNodeInputs,
+                outputs,
+                previousNodeInputs
             );
-        } else {
+            String modelGroupName = (String) inputs.get(NAME_FIELD);
+            String description = (String) inputs.get(DESCRIPTION_FIELD);
+            List<String> backendRoles = getBackendRoles(inputs);
+            AccessMode modelAccessMode = (AccessMode) inputs.get(MODEL_ACCESS_MODE);
+            Boolean isAddAllBackendRoles = (Boolean) inputs.get(ADD_ALL_BACKEND_ROLES);
+
             MLRegisterModelGroupInputBuilder builder = MLRegisterModelGroupInput.builder();
             builder.name(modelGroupName);
             if (description != null) {
@@ -173,6 +146,8 @@ public class ModelGroupStep implements WorkflowStep {
             MLRegisterModelGroupInput mlInput = builder.build();
 
             mlClient.registerModelGroup(mlInput, actionListener);
+        } catch (FlowFrameworkException e) {
+            registerModelGroupFuture.completeExceptionally(e);
         }
 
         return registerModelGroupFuture;

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalModelStep.java
@@ -8,24 +8,6 @@
  */
 package org.opensearch.flowframework.workflow;
 
-import static org.opensearch.flowframework.common.CommonValue.ALL_CONFIG;
-import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.EMBEDDING_DIMENSION;
-import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_ID;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
-import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
-import static org.opensearch.flowframework.common.CommonValue.URL;
-import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
-
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -48,6 +30,24 @@ import org.opensearch.ml.common.model.TextEmbeddingModelConfig.TextEmbeddingMode
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import static org.opensearch.flowframework.common.CommonValue.ALL_CONFIG;
+import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.EMBEDDING_DIMENSION;
+import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_ID;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
+import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
+import static org.opensearch.flowframework.common.CommonValue.URL;
+import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
 
 /**
  * Step to register a local model

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -8,18 +8,6 @@
  */
 package org.opensearch.flowframework.workflow;
 
-import static org.opensearch.flowframework.common.CommonValue.CONNECTOR_ID;
-import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_ID;
-import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
-
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -33,6 +21,18 @@ import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.opensearch.flowframework.common.CommonValue.CONNECTOR_ID;
+import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_ID;
+import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 
 /**
  * Step to register a remote model

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -8,34 +8,31 @@
  */
 package org.opensearch.flowframework.workflow;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.opensearch.ExceptionsHelper;
-import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.flowframework.common.WorkflowResources;
-import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
-import org.opensearch.ml.client.MachineLearningNodeClient;
-import org.opensearch.ml.common.FunctionName;
-import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
-import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
-import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
-
 import static org.opensearch.flowframework.common.CommonValue.CONNECTOR_ID;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_ID;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.common.WorkflowResources;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.util.ParseUtils;
+import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
+import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
+import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 
 /**
  * Step to register a remote model
@@ -115,48 +112,23 @@ public class RegisterRemoteModelStep implements WorkflowStep {
             }
         };
 
-        String modelName = null;
-        FunctionName functionName = null;
-        String modelGroupId = null;
-        String description = null;
-        String connectorId = null;
+        Set<String> requiredKeys = Set.of(NAME_FIELD, FUNCTION_NAME, CONNECTOR_ID);
+        Set<String> optionalKeys = Set.of(MODEL_GROUP_ID, DESCRIPTION_FIELD);
 
-        // TODO: Recreating the list to get this compiling
-        // Need to refactor the below iteration to pull directly from the maps
-        List<WorkflowData> data = new ArrayList<>();
-        data.add(currentNodeInputs);
-        data.addAll(outputs.values());
+        try {
+            Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
+                requiredKeys,
+                optionalKeys,
+                currentNodeInputs,
+                outputs,
+                previousNodeInputs
+            );
 
-        // TODO : Handle inline connector configuration : https://github.com/opensearch-project/flow-framework/issues/149
-
-        for (WorkflowData workflowData : data) {
-
-            Map<String, Object> content = workflowData.getContent();
-            for (Entry<String, Object> entry : content.entrySet()) {
-                switch (entry.getKey()) {
-                    case NAME_FIELD:
-                        modelName = (String) content.get(NAME_FIELD);
-                        break;
-                    case FUNCTION_NAME:
-                        functionName = FunctionName.from(((String) content.get(FUNCTION_NAME)).toUpperCase(Locale.ROOT));
-                        break;
-                    case MODEL_GROUP_ID:
-                        modelGroupId = (String) content.get(MODEL_GROUP_ID);
-                        break;
-                    case DESCRIPTION_FIELD:
-                        description = (String) content.get(DESCRIPTION_FIELD);
-                        break;
-                    case CONNECTOR_ID:
-                        connectorId = (String) content.get(CONNECTOR_ID);
-                        break;
-                    default:
-                        break;
-
-                }
-            }
-        }
-
-        if (Stream.of(modelName, functionName, connectorId).allMatch(x -> x != null)) {
+            String modelName = (String) inputs.get(NAME_FIELD);
+            FunctionName functionName = FunctionName.from(((String) inputs.get(FUNCTION_NAME)).toUpperCase(Locale.ROOT));
+            String modelGroupId = (String) inputs.get(MODEL_GROUP_ID);
+            String description = (String) inputs.get(DESCRIPTION_FIELD);
+            String connectorId = (String) inputs.get(CONNECTOR_ID);
 
             MLRegisterModelInputBuilder builder = MLRegisterModelInput.builder()
                 .functionName(functionName)
@@ -172,12 +144,10 @@ public class RegisterRemoteModelStep implements WorkflowStep {
             MLRegisterModelInput mlInput = builder.build();
 
             mlClient.register(mlInput, actionListener);
-        } else {
-            registerRemoteModelFuture.completeExceptionally(
-                new FlowFrameworkException("Required fields are not provided", RestStatus.BAD_REQUEST)
-            );
-        }
 
+        } catch (FlowFrameworkException e) {
+            registerRemoteModelFuture.completeExceptionally(e);
+        }
         return registerRemoteModelFuture;
     }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
@@ -21,8 +21,8 @@ public interface WorkflowStep {
      * Triggers the actual processing of the building block.
      * @param currentNodeId The id of the node executing this step
      * @param currentNodeInputs Input params and content for this node, from workflow parsing
-     * @param previousNodeInputs Input params for this node that come from previous steps
      * @param outputs WorkflowData content of previous steps.
+     * @param previousNodeInputs Input params for this node that come from previous steps
      * @return A CompletableFuture of the building block. This block should return immediately, but not be completed until the step executes, containing either the step's output data or {@link WorkflowData#EMPTY} which may be passed to follow-on steps.
      * @throws IOException on a failure.
      */

--- a/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
@@ -8,11 +8,6 @@
  */
 package org.opensearch.flowframework.util;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.util.Map;
-import java.util.Set;
-
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -20,6 +15,11 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.workflow.WorkflowData;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
 
 public class ParseUtilsTests extends OpenSearchTestCase {
     public void testToInstant() throws IOException {

--- a/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
@@ -8,13 +8,18 @@
  */
 package org.opensearch.flowframework.util;
 
-import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.test.OpenSearchTestCase;
-
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.workflow.WorkflowData;
+import org.opensearch.test.OpenSearchTestCase;
 
 public class ParseUtilsTests extends OpenSearchTestCase {
     public void testToInstant() throws IOException {
@@ -53,5 +58,51 @@ public class ParseUtilsTests extends OpenSearchTestCase {
         parser.nextToken();
         Instant instant = ParseUtils.parseInstant(parser);
         assertNull(instant);
+    }
+
+    public void testGetInputsFromPreviousSteps() {
+        WorkflowData currentNodeInputs = new WorkflowData(
+            Map.ofEntries(Map.entry("content1", 1), Map.entry("param1", 2), Map.entry("content3", "${{step1.output1}}")),
+            Map.of("param1", "value1"),
+            "workflowId",
+            "nodeId"
+        );
+        Map<String, WorkflowData> outputs = Map.ofEntries(
+            Map.entry(
+                "step1",
+                new WorkflowData(
+                    Map.ofEntries(Map.entry("output1", "outputvalue1"), Map.entry("output2", "step1outputvalue2")),
+                    "workflowId",
+                    "step1"
+                )
+            ),
+            Map.entry("step2", new WorkflowData(Map.of("output2", "step2outputvalue2"), "workflowId", "step2"))
+        );
+        Map<String, String> previousNodeInputs = Map.of("step2", "output2");
+        Set<String> requiredKeys = Set.of("param1", "content1");
+        Set<String> optionalKeys = Set.of("output1", "output2", "content3", "no-output");
+
+        Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
+            requiredKeys,
+            optionalKeys,
+            currentNodeInputs,
+            outputs,
+            previousNodeInputs
+        );
+
+        assertEquals("value1", inputs.get("param1"));
+        assertEquals(1, inputs.get("content1"));
+        assertEquals("outputvalue1", inputs.get("output1"));
+        assertEquals("step2outputvalue2", inputs.get("output2"));
+        assertEquals("outputvalue1", inputs.get("content3"));
+        assertNull(inputs.get("no-output"));
+
+        Set<String> missingRequiredKeys = Set.of("not-here");
+        FlowFrameworkException e = assertThrows(
+            FlowFrameworkException.class,
+            () -> ParseUtils.getInputsFromPreviousSteps(missingRequiredKeys, optionalKeys, currentNodeInputs, outputs, previousNodeInputs)
+        );
+        assertEquals("Missing required inputs [not-here] in workflow [workflowId] node [nodeId]", e.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, e.getRestStatus());
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
@@ -13,7 +13,6 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.flowframework.common.CommonValue;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
@@ -44,7 +43,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
 
         MockitoAnnotations.openMocks(this);
 
-        inputData = new WorkflowData(Map.of(CommonValue.CONNECTOR_ID, "test"), "test-id", "test-node-id");
+        inputData = new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id");
     }
 
     public void testDeleteConnector() throws IOException, ExecutionException, InterruptedException {
@@ -86,7 +85,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
-        assertEquals("Required field connector_id is not provided", ex.getCause().getMessage());
+        assertEquals("Missing required inputs [connector_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
     }
 
     public void testDeleteConnectorFailure() throws IOException {

--- a/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
@@ -41,8 +41,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class ModelGroupStepTests extends OpenSearchTestCase {
-    private WorkflowData inputData = WorkflowData.EMPTY;
-    private WorkflowData inputDataWithNoName = WorkflowData.EMPTY;
+    private WorkflowData inputData;
+    private WorkflowData inputDataWithNoName;
 
     @Mock
     MachineLearningNodeClient machineLearningNodeClient;
@@ -65,7 +65,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
             "test-id",
             "test-node-id"
         );
-
+        inputDataWithNoName = new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id");
     }
 
     public void testRegisterModelGroup() throws ExecutionException, InterruptedException, IOException {
@@ -146,7 +146,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
-        assertEquals("Model group name is not provided", ex.getCause().getMessage());
+        assertEquals("Missing required inputs [name] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
     }
 
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
@@ -237,7 +237,7 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
     public void testMissingInputs() {
         CompletableFuture<WorkflowData> future = registerLocalModelStep.execute(
             "nodeId",
-            WorkflowData.EMPTY,
+            new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id"),
             Collections.emptyMap(),
             Collections.emptyMap()
         );
@@ -245,7 +245,19 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
-        assertEquals("Required fields are not provided", ex.getCause().getMessage());
+        assertTrue(ex.getCause().getMessage().startsWith("Missing required inputs ["));
+        for (String s : new String[] {
+            "model_format",
+            "name",
+            "model_type",
+            "embedding_dimension",
+            "framework_type",
+            "model_group_id",
+            "version",
+            "url",
+            "model_content_hash_value" }) {
+            assertTrue(ex.getCause().getMessage().contains(s));
+        }
+        assertTrue(ex.getCause().getMessage().endsWith("] in workflow [test-id] node [test-node-id]"));
     }
-
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -127,7 +127,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
     public void testMissingInputs() {
         CompletableFuture<WorkflowData> future = this.registerRemoteModelStep.execute(
             "nodeId",
-            WorkflowData.EMPTY,
+            new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id"),
             Collections.emptyMap(),
             Collections.emptyMap()
         );
@@ -135,7 +135,11 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
-        assertEquals("Required fields are not provided", ex.getCause().getMessage());
+        assertTrue(ex.getCause().getMessage().startsWith("Missing required inputs ["));
+        for (String s : new String[] { "name", "function_name", "connector_id" }) {
+            assertTrue(ex.getCause().getMessage().contains(s));
+        }
+        assertTrue(ex.getCause().getMessage().endsWith("] in workflow [test-id] node [test-node-id]"));
     }
 
 }


### PR DESCRIPTION
### Description

Adds a Util method to fetch required and optional inputs.  Priority is given to:
 - Output of previous input steps explicitly stated in the template
 - The current node's input parameters (from template)
 - The current node's input content (from template)
 - Any matching key in any previous step output

If the fetched value is of the form `${{ foo.bar }}` then it fetches the value of key `bar` from step `foo`.

In addition to the parsing method, I've implemented it in some of the existing steps as an example.  Some implementations break existing step tests (because missing input exceptions are different) and can be done later; doing them while awaiting review, but merging this earlier will permit it to be used for current step development.

### Issues Resolved

Fixes #210 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
