### PR TITLE
[Feature/agent_framework] Add Delete Model Step

### DIFF
--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.util.ParseUtils;
+import org.opensearch.ml.client.MachineLearningNodeClient;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
+
+/**
+ * Step to delete a model for a remote model
+ */
+public class DeleteModelStep implements WorkflowStep {
+
+    private static final Logger logger = LogManager.getLogger(DeleteModelStep.class);
+
+    private MachineLearningNodeClient mlClient;
+
+    static final String NAME = "delete_model";
+
+    /**
+     * Instantiate this class
+     * @param mlClient Machine Learning client to perform the deletion
+     */
+    public DeleteModelStep(MachineLearningNodeClient mlClient) {
+        this.mlClient = mlClient;
+    }
+
+    @Override
+    public CompletableFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs
+    ) throws IOException {
+        CompletableFuture<WorkflowData> deleteModelFuture = new CompletableFuture<>();
+
+        ActionListener<DeleteResponse> actionListener = new ActionListener<>() {
+
+            @Override
+            public void onResponse(DeleteResponse deleteResponse) {
+                deleteModelFuture.complete(
+                    new WorkflowData(
+                        Map.ofEntries(Map.entry(MODEL_ID, deleteResponse.getId())),
+                        currentNodeInputs.getWorkflowId(),
+                        currentNodeInputs.getNodeId()
+                    )
+                );
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error("Failed to delete model");
+                deleteModelFuture.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
+            }
+        };
+
+        Set<String> requiredKeys = Set.of(MODEL_ID);
+        Set<String> optionalKeys = Collections.emptySet();
+
+        try {
+            Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
+                requiredKeys,
+                optionalKeys,
+                currentNodeInputs,
+                outputs,
+                previousNodeInputs
+            );
+
+            String modelId = inputs.get(MODEL_ID).toString();
+
+            mlClient.deleteModel(modelId, actionListener);
+        } catch (FlowFrameworkException e) {
+            deleteModelFuture.completeExceptionally(e);
+        }
+        return deleteModelFuture;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -51,6 +51,7 @@ public class WorkflowStepFactory {
             () -> new RegisterLocalModelStep(settings, clusterService, mlClient, flowFrameworkIndicesHandler)
         );
         stepMap.put(RegisterRemoteModelStep.NAME, () -> new RegisterRemoteModelStep(mlClient, flowFrameworkIndicesHandler));
+        stepMap.put(DeleteModelStep.NAME, () -> new DeleteModelStep(mlClient));
         stepMap.put(DeployModelStep.NAME, () -> new DeployModelStep(mlClient));
         stepMap.put(UndeployModelStep.NAME, () -> new UndeployModelStep(mlClient));
         stepMap.put(CreateConnectorStep.NAME, () -> new CreateConnectorStep(mlClient, flowFrameworkIndicesHandler));

--- a/src/main/resources/mappings/workflow-steps.json
+++ b/src/main/resources/mappings/workflow-steps.json
@@ -75,6 +75,14 @@
             "register_model_status"
         ]
     },
+    "delete_model": {
+        "inputs": [
+            "model_id"
+        ],
+        "outputs":[
+            "model_id"
+        ]
+    },
     "deploy_model": {
         "inputs":[
             "model_id"

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
@@ -30,7 +30,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
-public class DeleteConnectorStepTests extends OpenSearchTestCase {
+public class DeleteModelStepTests extends OpenSearchTestCase {
     private WorkflowData inputData;
 
     @Mock
@@ -45,36 +45,36 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
         inputData = new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id");
     }
 
-    public void testDeleteConnector() throws IOException, ExecutionException, InterruptedException {
+    public void testDeleteModel() throws IOException, ExecutionException, InterruptedException {
 
-        String connectorId = randomAlphaOfLength(5);
-        DeleteConnectorStep deleteConnectorStep = new DeleteConnectorStep(machineLearningNodeClient);
+        String modelId = randomAlphaOfLength(5);
+        DeleteModelStep deleteModelStep = new DeleteModelStep(machineLearningNodeClient);
 
         doAnswer(invocation -> {
-            String connectorIdArg = invocation.getArgument(0);
+            String modelIdArg = invocation.getArgument(0);
             ActionListener<DeleteResponse> actionListener = invocation.getArgument(1);
             ShardId shardId = new ShardId(new Index("indexName", "uuid"), 1);
-            DeleteResponse output = new DeleteResponse(shardId, connectorIdArg, 1, 1, 1, true);
+            DeleteResponse output = new DeleteResponse(shardId, modelIdArg, 1, 1, 1, true);
             actionListener.onResponse(output);
             return null;
-        }).when(machineLearningNodeClient).deleteConnector(any(String.class), any());
+        }).when(machineLearningNodeClient).deleteModel(any(String.class), any());
 
-        CompletableFuture<WorkflowData> future = deleteConnectorStep.execute(
+        CompletableFuture<WorkflowData> future = deleteModelStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of("step_1", new WorkflowData(Map.of("connector_id", connectorId), "workflowId", "nodeId")),
-            Map.of("step_1", "connector_id")
+            Map.of("step_1", new WorkflowData(Map.of("model_id", modelId), "workflowId", "nodeId")),
+            Map.of("step_1", "model_id")
         );
-        verify(machineLearningNodeClient).deleteConnector(any(String.class), any());
+        verify(machineLearningNodeClient).deleteModel(any(String.class), any());
 
         assertTrue(future.isDone());
-        assertEquals(connectorId, future.get().getContent().get("connector_id"));
+        assertEquals(modelId, future.get().getContent().get("model_id"));
     }
 
-    public void testNoConnectorIdInOutput() throws IOException {
-        DeleteConnectorStep deleteConnectorStep = new DeleteConnectorStep(machineLearningNodeClient);
+    public void testNoModelIdInOutput() throws IOException {
+        DeleteModelStep deleteModelStep = new DeleteModelStep(machineLearningNodeClient);
 
-        CompletableFuture<WorkflowData> future = deleteConnectorStep.execute(
+        CompletableFuture<WorkflowData> future = deleteModelStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -84,30 +84,30 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
-        assertEquals("Missing required inputs [connector_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
+        assertEquals("Missing required inputs [model_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
     }
 
-    public void testDeleteConnectorFailure() throws IOException {
-        DeleteConnectorStep deleteConnectorStep = new DeleteConnectorStep(machineLearningNodeClient);
+    public void testDeleteModelFailure() throws IOException {
+        DeleteModelStep deleteModelStep = new DeleteModelStep(machineLearningNodeClient);
 
         doAnswer(invocation -> {
             ActionListener<DeleteResponse> actionListener = invocation.getArgument(1);
-            actionListener.onFailure(new FlowFrameworkException("Failed to delete connector", RestStatus.INTERNAL_SERVER_ERROR));
+            actionListener.onFailure(new FlowFrameworkException("Failed to delete model", RestStatus.INTERNAL_SERVER_ERROR));
             return null;
-        }).when(machineLearningNodeClient).deleteConnector(any(String.class), any());
+        }).when(machineLearningNodeClient).deleteModel(any(String.class), any());
 
-        CompletableFuture<WorkflowData> future = deleteConnectorStep.execute(
+        CompletableFuture<WorkflowData> future = deleteModelStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of("step_1", new WorkflowData(Map.of("connector_id", "test"), "workflowId", "nodeId")),
-            Map.of("step_1", "connector_id")
+            Map.of("step_1", new WorkflowData(Map.of("model_id", "test"), "workflowId", "nodeId")),
+            Map.of("step_1", "model_id")
         );
 
-        verify(machineLearningNodeClient).deleteConnector(any(String.class), any());
+        verify(machineLearningNodeClient).deleteModel(any(String.class), any());
 
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
-        assertEquals("Failed to delete connector", ex.getCause().getMessage());
+        assertEquals("Failed to delete model", ex.getCause().getMessage());
     }
 }


### PR DESCRIPTION
### Description

Adds a workflow step to delete a model (opposite of register).

Fun fact: this is an exact copy-paste of delete connector, with case-sensitive search and replace of "connector" with "model".  Yay API consistency.

### Issues Resolved

Part of #89

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
