### PR TITLE
[Feature/agent_framework] Work around JceMasterKey locale bug

### DIFF
--- a/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
@@ -56,7 +56,9 @@ public class EncryptorUtils {
 
     private static final String ALGORITHM = "AES";
     private static final String PROVIDER = "Custom";
-    private static final String WRAPPING_ALGORITHM = "AES/GCM/NoPadding";
+    // Intentionally uppercase to work around localization bug
+    // https://github.com/aws/aws-encryption-sdk-java/issues/1879
+    private static final String WRAPPING_ALGORITHM = "AES/GCM/NOPADDING";
 
     private ClusterService clusterService;
     private Client client;


### PR DESCRIPTION
### Description

Works around an upstream bug where Locale is ignored in a string uppercase conversion by starting out with the string in upper case. 

No guarantee it will totally fix the problem but should mitigate it.  Bug also filed upstream at https://github.com/aws/aws-encryption-sdk-java/issues/1879

### Issues Resolved

Fixes #233 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
