### PR TITLE
Updating state index after register agent

### DIFF
--- a/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
+++ b/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
@@ -33,7 +33,9 @@ public enum WorkflowResources {
     /** official workflow step name for creating an ingest-pipeline and associated created resource */
     CREATE_INGEST_PIPELINE("create_ingest_pipeline", "pipeline_id"),
     /** official workflow step name for creating an index and associated created resource */
-    CREATE_INDEX("create_index", "index_name");
+    CREATE_INDEX("create_index", "index_name"),
+    /** official workflow step name for register an agent and the associated created resource */
+    REGISTER_AGENT("register_agent", "agent_id");
 
     private final String workflowStep;
     private final String resourceCreated;

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -58,7 +58,7 @@ public class WorkflowStepFactory {
         stepMap.put(DeleteConnectorStep.NAME, () -> new DeleteConnectorStep(mlClient));
         stepMap.put(ModelGroupStep.NAME, () -> new ModelGroupStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(ToolStep.NAME, ToolStep::new);
-        stepMap.put(RegisterAgentStep.NAME, () -> new RegisterAgentStep(mlClient));
+        stepMap.put(RegisterAgentStep.NAME, () -> new RegisterAgentStep(mlClient, flowFrameworkIndicesHandler));
     }
 
     /**


### PR DESCRIPTION
### Description
Updates state index after registering the agent:


```
{
    “workflow_id”: “lkq0NowBMQTz3hqInBi1",
    “state”: “COMPLETED”,
    “provisioning_progress”: “DONE”,
    “provision_start_time”: 1701724860781,
    “provision_end_time”: 1701724860799,
    “resources_created”: [
        {
            “workflow_step_name”: “register_agent”,
            “workflow_step_id”: “sub_agent”,
            “agent_id”: “mEq0NowBMQTz3hqIsRh6”
        },
        {
            “workflow_step_name”: “register_agent”,
            “workflow_step_id”: “root_agent”,
            “agent_id”: “l0q0NowBMQTz3hqIsRhy”
        }
    ]
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
