### PR TITLE
Only update state index on register agent

### DIFF
--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -234,7 +234,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                     Instant.now().toEpochMilli()
                 ),
                 ActionListener.wrap(updateResponse -> {
-                    logger.info("updated workflow {} state to {}", workflowId, State.COMPLETED);
+                    logger.info("updated workflow {} state to {}", workflowId, State.FAILED);
                 }, exceptionState -> { logger.error("Failed to update workflow state : {}", exceptionState.getMessage(), ex); })
             );
         }

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -20,6 +20,7 @@ import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
 
 import java.util.Map;
@@ -59,6 +60,24 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
     }
 
     /**
+     * Completes the future for either deploy or register local model step
+     * @param resourceName resource name for the given step
+     * @param nodeId node ID of the given step
+     * @param workflowId workflow ID of the given workflow
+     * @param response Response from ml commons get Task API
+     * @param future CompletableFuture of the given step
+     */
+    public void completeFuture(String resourceName, String nodeId, String workflowId, MLTask response, CompletableFuture future) {
+        future.complete(
+            new WorkflowData(
+                Map.ofEntries(Map.entry(resourceName, response.getModelId()), Map.entry(REGISTER_MODEL_STATUS, response.getState().name())),
+                workflowId,
+                nodeId
+            )
+        );
+    }
+
+    /**
      * Retryable get ml task
      * @param workflowId the workflow id
      * @param nodeId the workflow node id
@@ -91,31 +110,25 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
                 try {
                     logger.info(workflowStep + " successful for {} and modelId {}", workflowId, response.getModelId());
                     String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
-                    flowFrameworkIndicesHandler.updateResourceInStateIndex(
-                        workflowId,
-                        nodeId,
-                        getName(),
-                        response.getTaskId(),
-                        ActionListener.wrap(updateResponse -> {
-                            logger.info("successfully updated resources created in state index: {}", updateResponse.getIndex());
-                            future.complete(
-                                new WorkflowData(
-                                    Map.ofEntries(
-                                        Map.entry(resourceName, response.getModelId()),
-                                        Map.entry(REGISTER_MODEL_STATUS, response.getState().name())
-                                    ),
-                                    workflowId,
-                                    nodeId
-                                )
-                            );
-                        }, exception -> {
-                            logger.error("Failed to update new created resource", exception);
-                            future.completeExceptionally(
-                                new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception))
-                            );
-                        })
-                    );
-
+                    if (resourceName != WorkflowResources.DEPLOY_MODEL.getWorkflowStep()) {
+                        completeFuture(resourceName, nodeId, workflowId, response, future);
+                    } else {
+                        flowFrameworkIndicesHandler.updateResourceInStateIndex(
+                            workflowId,
+                            nodeId,
+                            getName(),
+                            response.getTaskId(),
+                            ActionListener.wrap(updateResponse -> {
+                                logger.info("successfully updated resources created in state index: {}", updateResponse.getIndex());
+                                completeFuture(resourceName, nodeId, workflowId, response, future);
+                            }, exception -> {
+                                logger.error("Failed to update new created resource", exception);
+                                future.completeExceptionally(
+                                    new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception))
+                                );
+                            })
+                        );
+                    }
                 } catch (Exception e) {
                     logger.error("Failed to parse and update new created resource", e);
                     future.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -110,7 +110,7 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
                 try {
                     logger.info(workflowStep + " successful for {} and modelId {}", workflowId, response.getModelId());
                     String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
-                    if (resourceName != WorkflowResources.DEPLOY_MODEL.getWorkflowStep()) {
+                    if (getName().equals(WorkflowResources.DEPLOY_MODEL.getWorkflowStep())) {
                         completeFuture(resourceName, nodeId, workflowId, response, future);
                     } else {
                         flowFrameworkIndicesHandler.updateResourceInStateIndex(

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import static org.opensearch.flowframework.common.CommonValue.AGENT_ID;
 import static org.opensearch.flowframework.common.CommonValue.APP_TYPE_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.CREATED_TIME;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
@@ -89,18 +88,9 @@ public class RegisterAgentStep implements WorkflowStep {
         ActionListener<MLRegisterAgentResponse> actionListener = new ActionListener<>() {
             @Override
             public void onResponse(MLRegisterAgentResponse mlRegisterAgentResponse) {
-                logger.info("Agent registration successful for the agent {}", mlRegisterAgentResponse.getAgentId());
-                registerAgentModelFuture.complete(
-                    new WorkflowData(
-                        Map.ofEntries(Map.entry(AGENT_ID, mlRegisterAgentResponse.getAgentId())),
-                        currentNodeInputs.getWorkflowId(),
-                        currentNodeInputs.getNodeId()
-                    )
-                );
-
                 try {
                     String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
-                    logger.info("Created connector successfully");
+                    logger.info("Agent registration successful for the agent {}", mlRegisterAgentResponse.getAgentId());
                     flowFrameworkIndicesHandler.updateResourceInStateIndex(
                         currentNodeInputs.getWorkflowId(),
                         currentNodeId,


### PR DESCRIPTION
### Description
Doesn't update state index if we are deploying a model, only on the register step
fixes logs regarding a failed provisioning
```
Provisioning failed for workflow: vst5N4wBXkf_uA_9Zltj
java.util.concurrent.CompletionException: java.util.concurrent.ExecutionException: org.opensearch.flowframework.exception.FlowFrameworkException: Can't find class for type https
	at java.util.concurrent.CompletableFuture.reportJoin(CompletableFuture.java:413) ~[?:?]
	at java.util.concurrent.CompletableFuture.join(CompletableFuture.java:2118) ~[?:?]
	at java.util.ArrayList.forEach(ArrayList.java:1511) ~[?:?]
	at org.opensearch.flowframework.transport.ProvisionWorkflowTransportAction.executeWorkflow(ProvisionWorkflowTransportAction.java:205) [opensearch-flow-framework-2.11.0.0-SNAPSHOT.jar:2.11.0.0-SNAPSHOT]
	at org.opensearch.flowframework.transport.ProvisionWorkflowTransportAction.lambda$executeWorkflowAsync$4(ProvisionWorkflowTransportAction.java:171) [opensearch-flow-framework-2.11.0.0-SNAPSHOT.jar:2.11.0.0-SNAPSHOT]
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:849) [opensearch-2.11.0.jar:2.11.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: java.util.concurrent.ExecutionException: org.opensearch.flowframework.exception.FlowFrameworkException: Can't find class for type https
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396) ~[?:?]
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073) ~[?:?]
	at org.opensearch.flowframework.workflow.ProcessNode.lambda$execute$2(ProcessNode.java:177) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804) ~[?:?]
	... 4 more
Caused by: org.opensearch.flowframework.exception.FlowFrameworkException: Can't find class for type https
	at org.opensearch.flowframework.workflow.CreateConnectorStep$1.onFailure(CreateConnectorStep.java:120) ~[?:?]
	at org.opensearch.ml.client.MachineLearningNodeClient.lambda$wrapActionListener$22(MachineLearningNodeClient.java:393) ~[?:?]
	at org.opensearch.core.action.ActionListener$1.onFailure(ActionListener.java:90) ~[opensearch-core-2.11.0.jar:2.11.0]
	at org.opensearch.action.support.TransportAction$1.onFailure(TransportAction.java:122) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.ml.action.connector.TransportCreateConnectorAction.doExecute(TransportCreateConnectorAction.java:118) ~[?:?]
	at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:218) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.indexmanagement.rollup.actionfilter.FieldCapsFilter.apply(FieldCapsFilter.kt:118) ~[?:?]
	at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:216) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.indexmanagement.controlcenter.notification.filter.IndexOperationActionFilter.apply(IndexOperationActionFilter.kt:39) ~[?:?]
	at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:216) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.performanceanalyzer.action.PerformanceAnalyzerActionFilter.apply(PerformanceAnalyzerActionFilter.java:78) ~[?:?]
	at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:216) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.action.support.TransportAction.execute(TransportAction.java:188) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.action.support.TransportAction.execute(TransportAction.java:107) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.client.node.NodeClient.executeLocally(NodeClient.java:110) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.client.node.NodeClient.doExecute(NodeClient.java:97) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:476) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.ml.client.MachineLearningNodeClient.createConnector(MachineLearningNodeClient.java:254) ~[?:?]
	at org.opensearch.flowframework.workflow.CreateConnectorStep.execute(CreateConnectorStep.java:172) ~[?:?]
	at org.opensearch.flowframework.workflow.ProcessNode.lambda$execute$2(ProcessNode.java:170) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804) ~[?:?]
	... 4 more
[2023-12-05T00:55:57,324][INFO ][o.o.f.t.ProvisionWorkflowTransportAction] [dev-dsk-amgalitz-2a-7bcc8589.us-west-2.amazon.com] updated workflow vst5N4wBXkf_uA_9Zltj state to FAILED
[2023-12-05T00:55:59,729][INFO ][o.o.m.c.MLSyncUpCron     ] [dev-dsk-amgalitz-2a-7bcc8589.us-west-2.amazon.com] ML configuration already initialized, no action needed
```

```
{
    "workflow_id": "-bOJN4wBXUgiQ-ZyDYZf",
    "state": "COMPLETED",
    "provisioning_progress": "DONE",
    "provision_start_time": 1701738784231,
    "provision_end_time": 1701738790096,
    "resources_created": [
        {
            "workflow_step_name": "register_agent",
            "workflow_step_id": "workflow_step_6",
            "agent_id": "-rOJN4wBXUgiQ-ZyJoYb"
        },
        {
            "workflow_step_name": "create_connector",
            "workflow_step_id": "workflow_step_1",
            "connector_id": "-7OJN4wBXUgiQ-ZyJ4bX"
        },
        {
            "workflow_step_name": "register_remote_model",
            "workflow_step_id": "workflow_step_2",
            "model_id": "_bOJN4wBXUgiQ-ZyKIa3"
        },
        {
            "workflow_step_name": "register_agent",
            "workflow_step_id": "workflow_step_8",
            "agent_id": "_7OJN4wBXUgiQ-ZyPIaq"
        }
    ]
}
```
### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
