### PR TITLE
Change thread queue to 100 and fix headers parsing bug

### DIFF
--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -158,7 +158,7 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
                 settings,
                 PROVISION_THREAD_POOL,
                 OpenSearchExecutors.allocatedProcessors(settings),
-                10,
+                100,
                 FLOW_FRAMEWORK_THREAD_POOL_PREFIX + PROVISION_THREAD_POOL
             )
         );

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
@@ -24,7 +24,9 @@ import java.util.Map.Entry;
 import java.util.Objects;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.flowframework.util.ParseUtils.buildStringToObjectMap;
 import static org.opensearch.flowframework.util.ParseUtils.buildStringToStringMap;
+import static org.opensearch.flowframework.util.ParseUtils.parseStringToObjectMap;
 import static org.opensearch.flowframework.util.ParseUtils.parseStringToStringMap;
 
 /**
@@ -93,7 +95,7 @@ public class WorkflowNode implements ToXContentObject {
                     }
                 } else {
                     for (Map<?, ?> map : (Map<?, ?>[]) e.getValue()) {
-                        buildStringToStringMap(xContentBuilder, map);
+                        buildStringToObjectMap(xContentBuilder, map);
                     }
                 }
                 xContentBuilder.endArray();
@@ -150,9 +152,9 @@ public class WorkflowNode implements ToXContentObject {
                                     }
                                     userInputs.put(inputFieldName, processorList.toArray(new PipelineProcessor[0]));
                                 } else {
-                                    List<Map<String, String>> mapList = new ArrayList<>();
+                                    List<Map<String, Object>> mapList = new ArrayList<>();
                                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                                        mapList.add(parseStringToStringMap(parser));
+                                        mapList.add(parseStringToObjectMap(parser));
                                     }
                                     userInputs.put(inputFieldName, mapList.toArray(new Map[0]));
                                 }

--- a/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
@@ -60,6 +60,16 @@ public class ParseUtilsTests extends OpenSearchTestCase {
         assertNull(instant);
     }
 
+    public void testBuildAndParseStringToStringMap() throws IOException {
+        Map<String, String> stringMap = Map.ofEntries(Map.entry("one", "two"));
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        ParseUtils.buildStringToStringMap(builder, stringMap);
+        XContentParser parser = this.createParser(builder);
+        parser.nextToken();
+        Map<String, String> parsedMap = ParseUtils.parseStringToStringMap(parser);
+        assertEquals(stringMap.get("one"), parsedMap.get("one"));
+    }
+
     public void testGetInputsFromPreviousSteps() {
         WorkflowData currentNodeInputs = new WorkflowData(
             Map.ofEntries(Map.entry("content1", 1), Map.entry("param1", 2), Map.entry("content3", "${{step1.output1}}")),


### PR DESCRIPTION
### Description
I changed the provision thread queue to 100. This is because currently the size queue of 10 is too low. Basically right now if all the threads are busy and If an 11th request comes, the request will be just lost completely if we have no extra queue or re-route logic of our own. Currently we have no extra re-route logic but I think expanding the queue to a size of 100 to allow more provisioning should be sufficient for now. We should probably come back to this after doing more intense load testing.

I also additionally added a StringToObjectMap parser and builder so we can handle cases where we encounter an Object[] that these objects can be either be Map<String, String> or Map<String, Map<String, String>> like in the case of create connector actions

```
    "actions": [
        {
            "action_type": "predict",
            "method": "POST",
            "url": "https://${parameters.endpoint}/v1/chat/completions",
            "headers": {
                "Authorization": "Bearer ${credential.openAI_key}"
            },
            "request_body": "{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages} }"
        }
    ]
 ```
           
I tested manually through API calls, however I didn't add a UT for the StringToObject because I didn't want to use reflection to check the object type here, since its a generic object.             
           
           
### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
