### PR TITLE
Update CI to test on JDK 21

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 20]
+        java: [11, 21]
         include:
           - os: ubuntu-latest
             java: 17
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 20]
+        java: [11, 21]
         include:
           - os: ubuntu-latest
             java: 17


### PR DESCRIPTION
### Description

Switches testing from JDK 20 (EOL) to JDK 21 (LTS)

Matches OpenSearch JDK testing: https://github.com/opensearch-project/OpenSearch/blob/3c14cc187525fde6cc24fd5e3acec18c44ce9a1d/.github/workflows/precommit.yml#L10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
