### PR TITLE
[Feature/agent_framework] Add Get Workflow API to retrieve a stored template by workflow id

### DIFF
--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -28,13 +28,13 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.rest.RestCreateWorkflowAction;
-import org.opensearch.flowframework.rest.RestGetWorkflowAction;
+import org.opensearch.flowframework.rest.RestGetWorkflowStateAction;
 import org.opensearch.flowframework.rest.RestProvisionWorkflowAction;
 import org.opensearch.flowframework.rest.RestSearchWorkflowAction;
 import org.opensearch.flowframework.transport.CreateWorkflowAction;
 import org.opensearch.flowframework.transport.CreateWorkflowTransportAction;
-import org.opensearch.flowframework.transport.GetWorkflowAction;
-import org.opensearch.flowframework.transport.GetWorkflowTransportAction;
+import org.opensearch.flowframework.transport.GetWorkflowStateAction;
+import org.opensearch.flowframework.transport.GetWorkflowStateTransportAction;
 import org.opensearch.flowframework.transport.ProvisionWorkflowAction;
 import org.opensearch.flowframework.transport.ProvisionWorkflowTransportAction;
 import org.opensearch.flowframework.transport.SearchWorkflowAction;
@@ -125,7 +125,7 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
             new RestCreateWorkflowAction(flowFrameworkFeatureEnabledSetting, settings, clusterService),
             new RestProvisionWorkflowAction(flowFrameworkFeatureEnabledSetting),
             new RestSearchWorkflowAction(flowFrameworkFeatureEnabledSetting),
-            new RestGetWorkflowAction(flowFrameworkFeatureEnabledSetting)
+            new RestGetWorkflowStateAction(flowFrameworkFeatureEnabledSetting)
         );
     }
 
@@ -135,7 +135,7 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
             new ActionHandler<>(CreateWorkflowAction.INSTANCE, CreateWorkflowTransportAction.class),
             new ActionHandler<>(ProvisionWorkflowAction.INSTANCE, ProvisionWorkflowTransportAction.class),
             new ActionHandler<>(SearchWorkflowAction.INSTANCE, SearchWorkflowTransportAction.class),
-            new ActionHandler<>(GetWorkflowAction.INSTANCE, GetWorkflowTransportAction.class)
+            new ActionHandler<>(GetWorkflowStateAction.INSTANCE, GetWorkflowStateTransportAction.class)
         );
     }
 

--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -28,13 +28,16 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.rest.RestCreateWorkflowAction;
+import org.opensearch.flowframework.rest.RestGetWorkflowAction;
 import org.opensearch.flowframework.rest.RestGetWorkflowStateAction;
 import org.opensearch.flowframework.rest.RestProvisionWorkflowAction;
 import org.opensearch.flowframework.rest.RestSearchWorkflowAction;
 import org.opensearch.flowframework.transport.CreateWorkflowAction;
 import org.opensearch.flowframework.transport.CreateWorkflowTransportAction;
+import org.opensearch.flowframework.transport.GetWorkflowAction;
 import org.opensearch.flowframework.transport.GetWorkflowStateAction;
 import org.opensearch.flowframework.transport.GetWorkflowStateTransportAction;
+import org.opensearch.flowframework.transport.GetWorkflowTransportAction;
 import org.opensearch.flowframework.transport.ProvisionWorkflowAction;
 import org.opensearch.flowframework.transport.ProvisionWorkflowTransportAction;
 import org.opensearch.flowframework.transport.SearchWorkflowAction;
@@ -125,7 +128,8 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
             new RestCreateWorkflowAction(flowFrameworkFeatureEnabledSetting, settings, clusterService),
             new RestProvisionWorkflowAction(flowFrameworkFeatureEnabledSetting),
             new RestSearchWorkflowAction(flowFrameworkFeatureEnabledSetting),
-            new RestGetWorkflowStateAction(flowFrameworkFeatureEnabledSetting)
+            new RestGetWorkflowStateAction(flowFrameworkFeatureEnabledSetting),
+            new RestGetWorkflowAction(flowFrameworkFeatureEnabledSetting)
         );
     }
 
@@ -135,7 +139,8 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
             new ActionHandler<>(CreateWorkflowAction.INSTANCE, CreateWorkflowTransportAction.class),
             new ActionHandler<>(ProvisionWorkflowAction.INSTANCE, ProvisionWorkflowTransportAction.class),
             new ActionHandler<>(SearchWorkflowAction.INSTANCE, SearchWorkflowTransportAction.class),
-            new ActionHandler<>(GetWorkflowStateAction.INSTANCE, GetWorkflowStateTransportAction.class)
+            new ActionHandler<>(GetWorkflowStateAction.INSTANCE, GetWorkflowStateTransportAction.class),
+            new ActionHandler<>(GetWorkflowAction.INSTANCE, GetWorkflowTransportAction.class)
         );
     }
 

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
@@ -92,7 +92,7 @@ public class RestGetWorkflowAction extends BaseRestHandler {
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
 
                 } catch (IOException e) {
-                    logger.error("Failed to send back get template exception", e);
+                    logger.error("Failed to send back get workflow exception", e);
                     channel.sendResponse(new BytesRestResponse(ExceptionsHelper.status(e), e.getMessage()));
                 }
             }));

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.rest;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.transport.GetWorkflowAction;
+import org.opensearch.flowframework.transport.WorkflowRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
+import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
+
+/**
+ * Rest Action to facilitate requests to get a stored template
+ */
+public class RestGetWorkflowAction extends BaseRestHandler {
+
+    private static final String GET_WORKFLOW_ACTION = "get_workflow";
+    private static final Logger logger = LogManager.getLogger(RestGetWorkflowAction.class);
+    private FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting;
+
+    /**
+     * Instantiates a new RestGetWorkflowAction
+     * @param flowFrameworkFeatureEnabledSetting Whether this API is enabled
+     */
+    public RestGetWorkflowAction(FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting) {
+        this.flowFrameworkFeatureEnabledSetting = flowFrameworkFeatureEnabledSetting;
+    }
+
+    @Override
+    public String getName() {
+        return GET_WORKFLOW_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList.of(new Route(RestRequest.Method.GET, String.format(Locale.ROOT, "%s/{%s}", WORKFLOW_URI, WORKFLOW_ID)));
+    }
+
+    @Override
+    protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+
+        try {
+            if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {
+                throw new FlowFrameworkException(
+                    "This API is disabled. To enable it, update the setting [" + FLOW_FRAMEWORK_ENABLED.getKey() + "] to true.",
+                    RestStatus.FORBIDDEN
+                );
+            }
+
+            // Validate content
+            if (request.hasContent()) {
+                throw new FlowFrameworkException("Invalid request format", RestStatus.BAD_REQUEST);
+            }
+            // Validate params
+            String workflowId = request.param(WORKFLOW_ID);
+            if (workflowId == null) {
+                throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);
+            }
+
+            WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null);
+            return channel -> client.execute(GetWorkflowAction.INSTANCE, workflowRequest, ActionListener.wrap(response -> {
+                XContentBuilder builder = response.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS);
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+            }, exception -> {
+                try {
+                    FlowFrameworkException ex = new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception));
+                    XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
+                    channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
+
+                } catch (IOException e) {
+                    logger.error("Failed to send back get template exception", e);
+                    channel.sendResponse(new BytesRestResponse(ExceptionsHelper.status(e), e.getMessage()));
+                }
+            }));
+
+        } catch (FlowFrameworkException ex) {
+            return channel -> channel.sendResponse(
+                new BytesRestResponse(ex.getRestStatus(), ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS))
+            );
+        }
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
@@ -19,8 +19,8 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.transport.GetWorkflowAction;
-import org.opensearch.flowframework.transport.GetWorkflowRequest;
+import org.opensearch.flowframework.transport.GetWorkflowStateAction;
+import org.opensearch.flowframework.transport.GetWorkflowStateRequest;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
@@ -36,23 +36,23 @@ import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRA
 /**
  * Rest Action to facilitate requests to get a workflow status
  */
-public class RestGetWorkflowAction extends BaseRestHandler {
+public class RestGetWorkflowStateAction extends BaseRestHandler {
 
-    private static final String GET_WORKFLOW_ACTION = "get_workflow";
-    private static final Logger logger = LogManager.getLogger(RestGetWorkflowAction.class);
+    private static final String GET_WORKFLOW_STATE_ACTION = "get_workflow_state";
+    private static final Logger logger = LogManager.getLogger(RestGetWorkflowStateAction.class);
     private FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting;
 
     /**
-     * Instantiates a new RestGetWorkflowAction
+     * Instantiates a new RestGetWorkflowStateAction
      * @param flowFrameworkFeatureEnabledSetting Whether this API is enabled
      */
-    public RestGetWorkflowAction(FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting) {
+    public RestGetWorkflowStateAction(FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting) {
         this.flowFrameworkFeatureEnabledSetting = flowFrameworkFeatureEnabledSetting;
     }
 
     @Override
     public String getName() {
-        return GET_WORKFLOW_ACTION;
+        return GET_WORKFLOW_STATE_ACTION;
     }
 
     @Override
@@ -77,8 +77,8 @@ public class RestGetWorkflowAction extends BaseRestHandler {
             }
 
             boolean all = request.paramAsBoolean("all", false);
-            GetWorkflowRequest getWorkflowRequest = new GetWorkflowRequest(workflowId, all);
-            return channel -> client.execute(GetWorkflowAction.INSTANCE, getWorkflowRequest, ActionListener.wrap(response -> {
+            GetWorkflowStateRequest getWorkflowRequest = new GetWorkflowStateRequest(workflowId, all);
+            return channel -> client.execute(GetWorkflowStateAction.INSTANCE, getWorkflowRequest, ActionListener.wrap(response -> {
                 XContentBuilder builder = response.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS);
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
@@ -103,7 +103,6 @@ public class RestGetWorkflowAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return ImmutableList.of(
-            // Provision workflow from indexed use case template
             new Route(RestRequest.Method.GET, String.format(Locale.ROOT, "%s/{%s}/%s", WORKFLOW_URI, WORKFLOW_ID, "_status"))
         );
     }

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowAction.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.transport;
+
+import org.opensearch.action.ActionType;
+
+import static org.opensearch.flowframework.common.CommonValue.TRANSPORT_ACTION_NAME_PREFIX;
+
+/**
+ * External Action for public facing RestGetWorkflowAction
+ */
+public class GetWorkflowAction extends ActionType<GetWorkflowResponse> {
+    /** The name of this action */
+    public static final String NAME = TRANSPORT_ACTION_NAME_PREFIX + "workflow/get";
+    /** An instance of this action */
+    public static final GetWorkflowAction INSTANCE = new GetWorkflowAction();
+
+    private GetWorkflowAction() {
+        super(NAME, GetWorkflowResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowResponse.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowResponse.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.transport;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.flowframework.model.Template;
+
+import java.io.IOException;
+
+/**
+ * Transport Response from getting a template
+ */
+public class GetWorkflowResponse extends ActionResponse implements ToXContentObject {
+
+    /** The template */
+    private Template template;
+
+    /**
+     * Instantiates a new GetWorkflowResponse from an input stream
+     * @param in the input stream to read from
+     * @throws IOException if the template json cannot be read from the input stream
+     */
+    public GetWorkflowResponse(StreamInput in) throws IOException {
+        super(in);
+        this.template = Template.parse(in.readString());
+    }
+
+    /**
+     * Instantiates a new GetWorkflowResponse
+     * @param template the template
+     */
+    public GetWorkflowResponse(Template template) {
+        this.template = template;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(template.toJson());
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
+        return this.template.toXContent(xContentBuilder, params);
+    }
+
+    /**
+     * Gets the template
+     * @return the template
+     */
+    public Template getTemplate() {
+        return this.template;
+    }
+
+}

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateAction.java
@@ -13,15 +13,15 @@ import org.opensearch.action.ActionType;
 import static org.opensearch.flowframework.common.CommonValue.TRANSPORT_ACTION_NAME_PREFIX;
 
 /**
- * External Action for public facing RestGetWorkflowAction
+ * External Action for public facing RestGetWorkflowStateAction
  */
-public class GetWorkflowAction extends ActionType<GetWorkflowResponse> {
+public class GetWorkflowStateAction extends ActionType<GetWorkflowStateResponse> {
     /** The name of this action */
-    public static final String NAME = TRANSPORT_ACTION_NAME_PREFIX + "workflow/get";
+    public static final String NAME = TRANSPORT_ACTION_NAME_PREFIX + "workflow_state/get";
     /** An instance of this action */
-    public static final GetWorkflowAction INSTANCE = new GetWorkflowAction();
+    public static final GetWorkflowStateAction INSTANCE = new GetWorkflowStateAction();
 
-    private GetWorkflowAction() {
-        super(NAME, GetWorkflowResponse::new);
+    private GetWorkflowStateAction() {
+        super(NAME, GetWorkflowStateResponse::new);
     }
 }

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateAction.java
@@ -16,6 +16,8 @@ import static org.opensearch.flowframework.common.CommonValue.TRANSPORT_ACTION_N
  * External Action for public facing RestGetWorkflowStateAction
  */
 public class GetWorkflowStateAction extends ActionType<GetWorkflowStateResponse> {
+    // TODO : If the template body is returned as part of the GetWorkflowStateAction,
+    // it is necessary to ensure the user has permissions for workflow/get
     /** The name of this action */
     public static final String NAME = TRANSPORT_ACTION_NAME_PREFIX + "workflow_state/get";
     /** An instance of this action */

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateRequest.java
@@ -17,9 +17,9 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import java.io.IOException;
 
 /**
- * Transport Request to get a workflow or workflow status
+ * Transport Request to get a workflow status
  */
-public class GetWorkflowRequest extends ActionRequest {
+public class GetWorkflowStateRequest extends ActionRequest {
 
     /**
      * The documentId of the workflow entry within the Global Context index
@@ -33,21 +33,21 @@ public class GetWorkflowRequest extends ActionRequest {
     private boolean all;
 
     /**
-     * Instantiates a new GetWorkflowRequest
+     * Instantiates a new GetWorkflowStateRequest
      * @param workflowId the documentId of the workflow
      * @param all whether the get request is looking for all fields in status
      */
-    public GetWorkflowRequest(@Nullable String workflowId, boolean all) {
+    public GetWorkflowStateRequest(@Nullable String workflowId, boolean all) {
         this.workflowId = workflowId;
         this.all = all;
     }
 
     /**
-     * Instantiates a new GetWorkflowRequest request
+     * Instantiates a new GetWorkflowStateRequest request
      * @param in The input stream to read from
      * @throws IOException If the stream cannot be read properly
      */
-    public GetWorkflowRequest(StreamInput in) throws IOException {
+    public GetWorkflowStateRequest(StreamInput in) throws IOException {
         super(in);
         this.workflowId = in.readString();
         this.all = in.readBoolean();

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateResponse.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateResponse.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 /**
  * Transport Response from getting a workflow status
  */
-public class GetWorkflowResponse extends ActionResponse implements ToXContentObject {
+public class GetWorkflowStateResponse extends ActionResponse implements ToXContentObject {
 
     /** The workflow state */
     public WorkflowState workflowState;
@@ -28,22 +28,22 @@ public class GetWorkflowResponse extends ActionResponse implements ToXContentObj
     public boolean allStatus;
 
     /**
-     * Instantiates a new GetWorkflowResponse from an input stream
+     * Instantiates a new GetWorkflowStateResponse from an input stream
      * @param in the input stream to read from
      * @throws IOException if the workflowId cannot be read from the input stream
      */
-    public GetWorkflowResponse(StreamInput in) throws IOException {
+    public GetWorkflowStateResponse(StreamInput in) throws IOException {
         super(in);
         workflowState = new WorkflowState(in);
         allStatus = in.readBoolean();
     }
 
     /**
-     * Instatiates a new GetWorkflowResponse from an input stream
+     * Instatiates a new GetWorkflowStateResponse from an input stream
      * @param workflowState the workflow state object
      * @param allStatus whether to return all fields in state index
      */
-    public GetWorkflowResponse(WorkflowState workflowState, boolean allStatus) {
+    public GetWorkflowStateResponse(WorkflowState workflowState, boolean allStatus) {
         if (allStatus) {
             this.workflowState = workflowState;
         } else {

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportAction.java
@@ -38,34 +38,34 @@ import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_IND
  * Transport Action to get a specific workflow. Currently, we only support the action with _status
  * in the API path but will add the ability to get the workflow and not just the status in the future
  */
-public class GetWorkflowTransportAction extends HandledTransportAction<GetWorkflowRequest, GetWorkflowResponse> {
+public class GetWorkflowStateTransportAction extends HandledTransportAction<GetWorkflowStateRequest, GetWorkflowStateResponse> {
 
-    private final Logger logger = LogManager.getLogger(GetWorkflowTransportAction.class);
+    private final Logger logger = LogManager.getLogger(GetWorkflowStateTransportAction.class);
 
     private final Client client;
     private final NamedXContentRegistry xContentRegistry;
 
     /**
-     * Intantiates a new CreateWorkflowTransportAction
+     * Intantiates a new GetWorkflowStateTransportAction
      * @param transportService The TransportService
      * @param actionFilters action filters
      * @param client The client used to make the request to OS
      * @param xContentRegistry contentRegister to parse get response
      */
     @Inject
-    public GetWorkflowTransportAction(
+    public GetWorkflowStateTransportAction(
         TransportService transportService,
         ActionFilters actionFilters,
         Client client,
         NamedXContentRegistry xContentRegistry
     ) {
-        super(GetWorkflowAction.NAME, transportService, actionFilters, GetWorkflowRequest::new);
+        super(GetWorkflowStateAction.NAME, transportService, actionFilters, GetWorkflowStateRequest::new);
         this.client = client;
         this.xContentRegistry = xContentRegistry;
     }
 
     @Override
-    protected void doExecute(Task task, GetWorkflowRequest request, ActionListener<GetWorkflowResponse> listener) {
+    protected void doExecute(Task task, GetWorkflowStateRequest request, ActionListener<GetWorkflowStateResponse> listener) {
         String workflowId = request.getWorkflowId();
         User user = ParseUtils.getUserContext(client);
         GetRequest getRequest = new GetRequest(WORKFLOW_STATE_INDEX).id(workflowId);
@@ -75,7 +75,7 @@ public class GetWorkflowTransportAction extends HandledTransportAction<GetWorkfl
                     try (XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, r.getSourceAsBytesRef())) {
                         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                         WorkflowState workflowState = WorkflowState.parse(parser);
-                        listener.onResponse(new GetWorkflowResponse(workflowState, request.getAll()));
+                        listener.onResponse(new GetWorkflowStateResponse(workflowState, request.getAll()));
                     } catch (Exception e) {
                         logger.error("Failed to parse workflowState" + r.getId(), e);
                         listener.onFailure(new FlowFrameworkException("Failed to parse workflowState" + r.getId(), RestStatus.BAD_REQUEST));

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowTransportAction.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.transport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.client.Client;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.model.Template;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
+
+/**
+ * Transport action to retrieve a use case template within the Global Context
+ */
+public class GetWorkflowTransportAction extends HandledTransportAction<WorkflowRequest, GetWorkflowResponse> {
+
+    private final Logger logger = LogManager.getLogger(GetWorkflowTransportAction.class);
+    private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
+    private final Client client;
+
+    /**
+     * Instantiates a new GetWorkflowTransportAction instance
+     * @param transportService the transport service
+     * @param actionFilters action filters
+     * @param flowFrameworkIndicesHandler The Flow Framework indices handler
+     * @param client the Opensearch Client
+     */
+    @Inject
+    public GetWorkflowTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        FlowFrameworkIndicesHandler flowFrameworkIndicesHandler,
+        Client client
+    ) {
+        super(GetWorkflowAction.NAME, transportService, actionFilters, WorkflowRequest::new);
+        this.flowFrameworkIndicesHandler = flowFrameworkIndicesHandler;
+        this.client = client;
+    }
+
+    @Override
+    protected void doExecute(Task task, WorkflowRequest request, ActionListener<GetWorkflowResponse> listener) {
+        if (flowFrameworkIndicesHandler.doesIndexExist(GLOBAL_CONTEXT_INDEX)) {
+
+            String workflowId = request.getWorkflowId();
+            GetRequest getRequest = new GetRequest(GLOBAL_CONTEXT_INDEX, workflowId);
+
+            // Retrieve workflow by ID
+            try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+                client.get(getRequest, ActionListener.wrap(response -> {
+                    context.restore();
+
+                    if (!response.isExists()) {
+                        listener.onFailure(
+                            new FlowFrameworkException(
+                                "Failed to retrieve template (" + workflowId + ") from global context.",
+                                RestStatus.NOT_FOUND
+                            )
+                        );
+                    } else {
+                        listener.onResponse(new GetWorkflowResponse(Template.parse(response.getSourceAsString())));
+                    }
+                }, exception -> {
+                    logger.error("Failed to retrieve template from global context.", exception);
+                    listener.onFailure(new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception)));
+                }));
+            } catch (Exception e) {
+                logger.error("Failed to retrieve template from global context.", e);
+                listener.onFailure(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
+            }
+
+        } else {
+            listener.onFailure(new FlowFrameworkException("There are no templates in the global_context", RestStatus.NOT_FOUND));
+        }
+
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
@@ -81,8 +81,8 @@ public class FlowFrameworkPluginTests extends OpenSearchTestCase {
                 4,
                 ffp.createComponents(client, clusterService, threadPool, null, null, null, environment, null, null, null, null).size()
             );
-            assertEquals(4, ffp.getRestHandlers(settings, null, null, null, null, null, null).size());
-            assertEquals(4, ffp.getActions().size());
+            assertEquals(5, ffp.getRestHandlers(settings, null, null, null, null, null, null).size());
+            assertEquals(5, ffp.getActions().size());
             assertEquals(1, ffp.getExecutorBuilders(settings).size());
             assertEquals(4, ffp.getSettings().size());
         }

--- a/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowActionTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.rest;
+
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestChannel;
+import org.opensearch.test.rest.FakeRestRequest;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RestGetWorkflowActionTests extends OpenSearchTestCase {
+    private RestGetWorkflowAction restGetWorkflowAction;
+    private String getPath;
+    private FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting;
+    private NodeClient nodeClient;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        this.getPath = String.format(Locale.ROOT, "%s/{%s}", WORKFLOW_URI, "workflow_id");
+        flowFrameworkFeatureEnabledSetting = mock(FlowFrameworkFeatureEnabledSetting.class);
+        when(flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()).thenReturn(true);
+        this.restGetWorkflowAction = new RestGetWorkflowAction(flowFrameworkFeatureEnabledSetting);
+        this.nodeClient = mock(NodeClient.class);
+    }
+
+    public void testRestGetWorkflowActionName() {
+        String name = restGetWorkflowAction.getName();
+        assertEquals("get_workflow", name);
+    }
+
+    public void testRestGetWorkflowActionRoutes() {
+        List<RestHandler.Route> routes = restGetWorkflowAction.routes();
+        assertEquals(1, routes.size());
+        assertEquals(RestRequest.Method.GET, routes.get(0).getMethod());
+        assertEquals(this.getPath, routes.get(0).getPath());
+    }
+
+    public void testInvalidRequestWithContent() {
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath(this.getPath)
+            .withContent(new BytesArray("request body"), MediaTypeRegistry.JSON)
+            .build();
+
+        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
+            restGetWorkflowAction.handleRequest(request, channel, nodeClient);
+        });
+        assertEquals("request [POST /_plugins/_flow_framework/workflow/{workflow_id}] does not support having a body", ex.getMessage());
+    }
+
+    public void testNullWorkflowId() throws Exception {
+
+        // Request with no params
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath(this.getPath)
+            .build();
+
+        FakeRestChannel channel = new FakeRestChannel(request, true, 1);
+        restGetWorkflowAction.handleRequest(request, channel, nodeClient);
+
+        assertEquals(1, channel.errors().get());
+        assertEquals(RestStatus.BAD_REQUEST, channel.capturedResponse().status());
+        assertTrue(channel.capturedResponse().content().utf8ToString().contains("workflow_id cannot be null"));
+    }
+
+    public void testFeatureFlagNotEnabled() throws Exception {
+        when(flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()).thenReturn(false);
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+                .withPath(this.getPath)
+                .build();
+        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
+        restGetWorkflowAction.handleRequest(request, channel, nodeClient);
+        assertEquals(RestStatus.FORBIDDEN, channel.capturedResponse().status());
+        assertTrue(channel.capturedResponse().content().utf8ToString().contains("This API is disabled."));
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStateActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStateActionTests.java
@@ -26,8 +26,8 @@ import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class RestGetWorkflowActionTests extends OpenSearchTestCase {
-    private RestGetWorkflowAction restGetWorkflowAction;
+public class RestGetWorkflowStateActionTests extends OpenSearchTestCase {
+    private RestGetWorkflowStateAction restGetWorkflowStateAction;
     private String getPath;
     private NodeClient nodeClient;
     private FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting;
@@ -39,22 +39,22 @@ public class RestGetWorkflowActionTests extends OpenSearchTestCase {
         this.getPath = String.format(Locale.ROOT, "%s/{%s}/%s", WORKFLOW_URI, "workflow_id", "_status");
         flowFrameworkFeatureEnabledSetting = mock(FlowFrameworkFeatureEnabledSetting.class);
         when(flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()).thenReturn(true);
-        this.restGetWorkflowAction = new RestGetWorkflowAction(flowFrameworkFeatureEnabledSetting);
+        this.restGetWorkflowStateAction = new RestGetWorkflowStateAction(flowFrameworkFeatureEnabledSetting);
         this.nodeClient = mock(NodeClient.class);
     }
 
     public void testConstructor() {
-        RestGetWorkflowAction getWorkflowAction = new RestGetWorkflowAction(flowFrameworkFeatureEnabledSetting);
+        RestGetWorkflowStateAction getWorkflowAction = new RestGetWorkflowStateAction(flowFrameworkFeatureEnabledSetting);
         assertNotNull(getWorkflowAction);
     }
 
-    public void testRestGetWorkflowActionName() {
-        String name = restGetWorkflowAction.getName();
-        assertEquals("get_workflow", name);
+    public void testRestGetWorkflowStateActionName() {
+        String name = restGetWorkflowStateAction.getName();
+        assertEquals("get_workflow_state", name);
     }
 
-    public void testRestGetWorkflowActionRoutes() {
-        List<RestHandler.Route> routes = restGetWorkflowAction.routes();
+    public void testRestGetWorkflowStateActionRoutes() {
+        List<RestHandler.Route> routes = restGetWorkflowStateAction.routes();
         assertEquals(1, routes.size());
         assertEquals(RestRequest.Method.GET, routes.get(0).getMethod());
         assertEquals(this.getPath, routes.get(0).getPath());
@@ -68,7 +68,7 @@ public class RestGetWorkflowActionTests extends OpenSearchTestCase {
             .build();
 
         FakeRestChannel channel = new FakeRestChannel(request, true, 1);
-        restGetWorkflowAction.handleRequest(request, channel, nodeClient);
+        restGetWorkflowStateAction.handleRequest(request, channel, nodeClient);
 
         assertEquals(1, channel.errors().get());
         assertEquals(RestStatus.BAD_REQUEST, channel.capturedResponse().status());
@@ -83,7 +83,7 @@ public class RestGetWorkflowActionTests extends OpenSearchTestCase {
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
-            restGetWorkflowAction.handleRequest(request, channel, nodeClient);
+            restGetWorkflowStateAction.handleRequest(request, channel, nodeClient);
         });
         assertEquals(
             "request [POST /_plugins/_flow_framework/workflow/{workflow_id}/_status] does not support having a body",
@@ -97,7 +97,7 @@ public class RestGetWorkflowActionTests extends OpenSearchTestCase {
                 .withPath(this.getPath)
                 .build();
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
-        restGetWorkflowAction.handleRequest(request, channel, nodeClient);
+        restGetWorkflowStateAction.handleRequest(request, channel, nodeClient);
         assertEquals(RestStatus.FORBIDDEN, channel.capturedResponse().status());
         assertTrue(channel.capturedResponse().content().utf8ToString().contains("This API is disabled."));
     }

--- a/src/test/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportActionTests.java
@@ -37,14 +37,14 @@ import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
+public class GetWorkflowStateTransportActionTests extends OpenSearchTestCase {
 
-    private GetWorkflowTransportAction getWorkflowTransportAction;
+    private GetWorkflowStateTransportAction getWorkflowStateTransportAction;
     private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
     private Client client;
     private ThreadPool threadPool;
     private ThreadContext threadContext;
-    private ActionListener<GetWorkflowResponse> response;
+    private ActionListener<GetWorkflowStateResponse> response;
     private Task task;
 
     @Override
@@ -52,7 +52,7 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
         super.setUp();
         this.client = mock(Client.class);
         this.threadPool = mock(ThreadPool.class);
-        this.getWorkflowTransportAction = new GetWorkflowTransportAction(
+        this.getWorkflowStateTransportAction = new GetWorkflowStateTransportAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
             client,
@@ -65,9 +65,9 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
         when(client.threadPool()).thenReturn(clientThreadPool);
         when(clientThreadPool.getThreadContext()).thenReturn(threadContext);
 
-        response = new ActionListener<GetWorkflowResponse>() {
+        response = new ActionListener<GetWorkflowStateResponse>() {
             @Override
-            public void onResponse(GetWorkflowResponse getResponse) {
+            public void onResponse(GetWorkflowStateResponse getResponse) {
                 assertTrue(true);
             }
 
@@ -78,27 +78,27 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
     }
 
     public void testGetTransportAction() throws IOException {
-        GetWorkflowRequest getWorkflowRequest = new GetWorkflowRequest("1234", false);
-        getWorkflowTransportAction.doExecute(task, getWorkflowRequest, response);
+        GetWorkflowStateRequest getWorkflowRequest = new GetWorkflowStateRequest("1234", false);
+        getWorkflowStateTransportAction.doExecute(task, getWorkflowRequest, response);
     }
 
     public void testGetAction() {
-        Assert.assertNotNull(GetWorkflowAction.INSTANCE.name());
-        Assert.assertEquals(GetWorkflowAction.INSTANCE.name(), GetWorkflowAction.NAME);
+        Assert.assertNotNull(GetWorkflowStateAction.INSTANCE.name());
+        Assert.assertEquals(GetWorkflowStateAction.INSTANCE.name(), GetWorkflowStateAction.NAME);
     }
 
-    public void testGetAnomalyDetectorRequest() throws IOException {
-        GetWorkflowRequest request = new GetWorkflowRequest("1234", false);
+    public void testGetWorkflowStateRequest() throws IOException {
+        GetWorkflowStateRequest request = new GetWorkflowStateRequest("1234", false);
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
         StreamInput input = out.bytes().streamInput();
-        GetWorkflowRequest newRequest = new GetWorkflowRequest(input);
+        GetWorkflowStateRequest newRequest = new GetWorkflowStateRequest(input);
         Assert.assertEquals(request.getWorkflowId(), newRequest.getWorkflowId());
         Assert.assertEquals(request.getAll(), newRequest.getAll());
         Assert.assertNull(newRequest.validate());
     }
 
-    public void testGetAnomalyDetectorResponse() throws IOException {
+    public void testGetWorkflowStateResponse() throws IOException {
         BytesStreamOutput out = new BytesStreamOutput();
         String workflowId = randomAlphaOfLength(5);
         WorkflowState workFlowState = new WorkflowState(
@@ -113,10 +113,10 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
             Collections.emptyList()
         );
 
-        GetWorkflowResponse response = new GetWorkflowResponse(workFlowState, false);
+        GetWorkflowStateResponse response = new GetWorkflowStateResponse(workFlowState, false);
         response.writeTo(out);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), writableRegistry());
-        GetWorkflowResponse newResponse = new GetWorkflowResponse(input);
+        GetWorkflowStateResponse newResponse = new GetWorkflowStateResponse(input);
         XContentBuilder builder = TestHelpers.builder();
         Assert.assertNotNull(newResponse.toXContent(builder, ToXContent.EMPTY_PARAMS));
 

--- a/src/test/java/org/opensearch/flowframework/transport/GetWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/GetWorkflowTransportActionTests.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.transport;
+
+import org.opensearch.Version;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.client.Client;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.flowframework.TestHelpers;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.model.Template;
+import org.opensearch.flowframework.model.Workflow;
+import org.opensearch.flowframework.model.WorkflowEdge;
+import org.opensearch.flowframework.model.WorkflowNode;
+import org.opensearch.index.get.GetResult;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.util.List;
+import java.util.Map;
+
+import org.mockito.ArgumentCaptor;
+
+import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
+
+    private ThreadPool threadPool;
+    private Client client;
+    private GetWorkflowTransportAction getTemplateTransportAction;
+    private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
+    private Template template;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        this.threadPool = mock(ThreadPool.class);
+        this.client = mock(Client.class);
+        this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
+        this.getTemplateTransportAction = new GetWorkflowTransportAction(
+            mock(TransportService.class),
+            mock(ActionFilters.class),
+            flowFrameworkIndicesHandler,
+            client
+        );
+
+        Version templateVersion = Version.fromString("1.0.0");
+        List<Version> compatibilityVersions = List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0"));
+        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Map.of(), Map.of("foo", "bar"));
+        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Map.of(), Map.of("baz", "qux"));
+        WorkflowEdge edgeAB = new WorkflowEdge("A", "B");
+        List<WorkflowNode> nodes = List.of(nodeA, nodeB);
+        List<WorkflowEdge> edges = List.of(edgeAB);
+        Workflow workflow = new Workflow(Map.of("key", "value"), nodes, edges);
+
+        this.template = new Template(
+            "test",
+            "description",
+            "use case",
+            templateVersion,
+            compatibilityVersions,
+            Map.of("provision", workflow),
+            Map.of(),
+            TestHelpers.randomUser()
+        );
+
+        ThreadPool clientThreadPool = mock(ThreadPool.class);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+        when(client.threadPool()).thenReturn(clientThreadPool);
+        when(clientThreadPool.getThreadContext()).thenReturn(threadContext);
+
+    }
+
+    public void testGetWorkflowNoGlobalContext() {
+
+        when(flowFrameworkIndicesHandler.doesIndexExist(anyString())).thenReturn(false);
+        @SuppressWarnings("unchecked")
+        ActionListener<GetWorkflowResponse> listener = mock(ActionListener.class);
+        WorkflowRequest workflowRequest = new WorkflowRequest("1", null);
+        getTemplateTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener, times(1)).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("There are no templates in the global_context"));
+    }
+
+    public void testGetWorkflowSuccess() {
+        String workflowId = "12345";
+        @SuppressWarnings("unchecked")
+        ActionListener<GetWorkflowResponse> listener = mock(ActionListener.class);
+        WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null);
+
+        when(flowFrameworkIndicesHandler.doesIndexExist(anyString())).thenReturn(true);
+
+        // Stub client.get to force on response
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> responseListener = invocation.getArgument(1);
+
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            this.template.toXContent(builder, null);
+            BytesReference templateBytesRef = BytesReference.bytes(builder);
+            GetResult getResult = new GetResult(GLOBAL_CONTEXT_INDEX, workflowId, 1, 1, 1, true, templateBytesRef, null, null);
+            responseListener.onResponse(new GetResponse(getResult));
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        getTemplateTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
+
+        ArgumentCaptor<GetWorkflowResponse> templateCaptor = ArgumentCaptor.forClass(GetWorkflowResponse.class);
+        verify(listener, times(1)).onResponse(templateCaptor.capture());
+        assertEquals(this.template.name(), templateCaptor.getValue().getTemplate().name());
+    }
+
+    public void testGetWorkflowFailure() {
+        String workflowId = "12345";
+        @SuppressWarnings("unchecked")
+        ActionListener<GetWorkflowResponse> listener = mock(ActionListener.class);
+        WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null);
+
+        when(flowFrameworkIndicesHandler.doesIndexExist(anyString())).thenReturn(true);
+
+        // Stub client.get to force on failure
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> responseListener = invocation.getArgument(1);
+            responseListener.onFailure(new Exception("Failed to retrieve template from global context."));
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        getTemplateTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener, times(1)).onFailure(exceptionCaptor.capture());
+        assertEquals("Failed to retrieve template from global context.", exceptionCaptor.getValue().getMessage());
+    }
+}


### PR DESCRIPTION
### Description
Closes https://github.com/opensearch-project/flow-framework/pull/263 in favor of this PR

Adds a Get Workflow API that retrieves a workflow from the Global Context index. We've decided to instead just rename the Get Workflow State API implementation and keep this and the Get Workflow API separate (separate handlers, separate request response classes, separate transport action handlers). I have updated the `RestGetWorkflowAction` -> `RestGetWorkflowStateAction`, `GetWorkflowTransportAction` -> `GetWorkflowStateTransportAction`, `GetWorkflowRequest` -> `GetWorkflowStateRequest`, etc.

The name `RestGetWorkflowAction`, `GetWorkflowTransportAction` will be used for this PR's API

Creating a workflow : 
```
curl -i -XPOST "localhost:9200/_plugins/_flow_framework/workflow" -H "Content-Type:application/json" --data '{"name":"create-connector-register-deploy-model","description":"test case","use_case":"TEST_CASE","version":{"template":"1.0.0","compatibility":["2.12.0","3.0.0"]},"workflows":{"provision":{"nodes":[{"id":"workflow_step_1","type":"create_connector","user_inputs":{"name":"OpenAI Chat Connector","description":"The connector to public OpenAI model service for GPT 3.5","version":"1","protocol":"http","parameters":{"endpoint":"api.openai.com","model":"gpt-3.5-turbo"},"credential":{"openAI_key":"12345"},"actions":[{"action_type":"predict","method":"POST","url":"https://${parameters.endpoint}/v1/chat/completions"}]}},{"id":"workflow_step_2","type":"register_remote_model","previous_node_inputs":{"workflow_step_1":"connector_id"},"user_inputs":{"name":"openAI-gpt-3.5-turbo","function_name":"remote","description":"test model"}},{"id":"workflow_step_3","type":"deploy_model","previous_node_inputs":{"workflow_step_2":"model_id"}}],"edges":[{"source":"workflow_step_1","dest":"workflow_step_2"},{"source":"workflow_step_2","dest":"workflow_step_3"}]}}}'

HTTP/1.1 201 Created
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 38

{"workflow_id":"__uoRowBLOZlW2X2X4im"}
```

Using the API : 
```
curl -i -XGET "localhost:9200/_plugins/_flow_framework/workflow/__uoRowBLOZlW2X2X4im?pretty"
HTTP/1.1 200 OK
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 2484

{
  "name" : "create-connector-register-deploy-model",
  "description" : "test case",
  "use_case" : "TEST_CASE",
  "version" : {
    "template" : "1.0.0",
    "compatibility" : [
      "2.12.0",
      "3.0.0"
    ]
  },
  "workflows" : {
    "provision" : {
      "user_params" : { },
      "nodes" : [
        {
          "id" : "workflow_step_1",
          "type" : "create_connector",
          "previous_node_inputs" : { },
          "user_inputs" : {
            "version" : "1",
            "parameters" : {
              "endpoint" : "api.openai.com",
              "model" : "gpt-3.5-turbo"
            },
            "credential" : {
              "openAI_key" : "AgV46GVJBK4J44APXADtgnCL3TpjQn59H+D2LBqffMkNOXcAXwABABVhd3MtY3J5cHRvLXB1YmxpYy1rZXkAREF1Q2ova3V5MFFZTEFhNERFMTVnMTFkL294MVhpRThVbnhrUHRNa25La2FFR0plSUhSSGRYZmxyWHJ1UmxnVEFDZz09AAEABkN1c3RvbQAUAAAAgAAAAAz4p8I4uGUKqBgB9/QAMDD0u3curGLdlCnrFHA/DVwS/RglaBi8AR5zZ8brKLReZz0YMoUpz/WJtk6KS0qZJwIAABAABJG/gOTF0lfyyCaxDSa1AX33c/1Kcj4hdExYfrqsod+UsRXA5v3hEIYePQi5ocm1/////wAAAAEAAAAAAAAAAAAAAAEAAAAFe3SLotpwFZUcsTiNmxOrsRUeasZ1AGcwZQIwRYI4qrpwzybOuQ0X3C99Oz612jfVx6m0PJg8iOaezz6LYcXU+AiawjFxQLeDtW5pAjEA5Tj7d7G3ubFg8drykv2VT5u9bATBHP0CVWDi2fgrH6etA65kDY3NIqOcvGiwkT7H"
            },
            "actions" : [
              {
                "method" : "POST",
                "action_type" : "predict",
                "url" : "https://${parameters.endpoint}/v1/chat/completions"
              }
            ],
            "description" : "The connector to public OpenAI model service for GPT 3.5",
            "protocol" : "http",
            "name" : "OpenAI Chat Connector"
          }
        },
        {
          "id" : "workflow_step_2",
          "type" : "register_remote_model",
          "previous_node_inputs" : {
            "workflow_step_1" : "connector_id"
          },
          "user_inputs" : {
            "name" : "openAI-gpt-3.5-turbo",
            "description" : "test model",
            "function_name" : "remote"
          }
        },
        {
          "id" : "workflow_step_3",
          "type" : "deploy_model",
          "previous_node_inputs" : {
            "workflow_step_2" : "model_id"
          },
          "user_inputs" : { }
        }
      ],
      "edges" : [
        {
          "source" : "workflow_step_1",
          "dest" : "workflow_step_2"
        },
        {
          "source" : "workflow_step_2",
          "dest" : "workflow_step_3"
        }
      ]
    }
  }
}
```

### Issues Resolved
https://github.com/opensearch-project/flow-framework/issues/170
Part of #88 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
