### PR TITLE
Permit ordering of tools in register agent step

### DIFF
--- a/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.flowframework.common.CommonValue.TOOLS_FIELD;
 import static org.opensearch.flowframework.util.ParseUtils.buildStringToObjectMap;
 import static org.opensearch.flowframework.util.ParseUtils.buildStringToStringMap;
 import static org.opensearch.flowframework.util.ParseUtils.parseStringToObjectMap;
@@ -93,6 +94,10 @@ public class WorkflowNode implements ToXContentObject {
                     for (PipelineProcessor p : (PipelineProcessor[]) e.getValue()) {
                         xContentBuilder.value(p);
                     }
+                } else if (TOOLS_FIELD.equals(e.getKey())) {
+                    for (String t : (String[]) e.getValue()) {
+                        xContentBuilder.value(t);
+                    }
                 } else {
                     for (Map<?, ?> map : (Map<?, ?>[]) e.getValue()) {
                         buildStringToObjectMap(xContentBuilder, map);
@@ -151,6 +156,12 @@ public class WorkflowNode implements ToXContentObject {
                                         processorList.add(PipelineProcessor.parse(parser));
                                     }
                                     userInputs.put(inputFieldName, processorList.toArray(new PipelineProcessor[0]));
+                                } else if (TOOLS_FIELD.equals(inputFieldName)) {
+                                    List<String> toolsList = new ArrayList<>();
+                                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                                        toolsList.add(parser.text());
+                                    }
+                                    userInputs.put(inputFieldName, toolsList.toArray(new String[0]));
                                 } else {
                                     List<Map<String, Object>> mapList = new ArrayList<>();
                                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
@@ -173,6 +184,11 @@ public class WorkflowNode implements ToXContentObject {
                                     case DOUBLE:
                                         userInputs.put(inputFieldName, parser.doubleValue());
                                         break;
+                                    case BIG_INTEGER:
+                                        userInputs.put(inputFieldName, parser.bigIntegerValue());
+                                        break;
+                                    default:
+                                        throw new IOException("Unable to parse field [" + inputFieldName + "] in a node object.");
                                 }
                                 break;
                             default:

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowNodeTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowNodeTests.java
@@ -31,7 +31,8 @@ public class WorkflowNodeTests extends OpenSearchTestCase {
                 Map.entry("bar", Map.of("key", "value")),
                 Map.entry("baz", new Map<?, ?>[] { Map.of("A", "a"), Map.of("B", "b") }),
                 Map.entry("processors", new PipelineProcessor[] { new PipelineProcessor("test-type", Map.of("key2", "value2")) }),
-                Map.entry("created_time", 1689793598499L)
+                Map.entry("created_time", 1689793598499L),
+                Map.entry("tools", new String[] { "foo", "bar" })
             )
         );
         assertEquals("A", nodeA.id());
@@ -46,6 +47,7 @@ public class WorkflowNodeTests extends OpenSearchTestCase {
         assertEquals("test-type", pp[0].type());
         assertEquals(Map.of("key2", "value2"), pp[0].params());
         assertEquals(1689793598499L, map.get("created_time"));
+        assertArrayEquals(new String[] { "foo", "bar" }, (String[]) map.get("tools"));
 
         // node equality is based only on ID
         WorkflowNode nodeA2 = new WorkflowNode("A", "a2-type", Map.of(), Map.of("bar", "baz"));
@@ -63,6 +65,7 @@ public class WorkflowNodeTests extends OpenSearchTestCase {
         assertTrue(json.contains("\"bar\":{\"key\":\"value\"}"));
         assertTrue(json.contains("\"processors\":[{\"type\":\"test-type\",\"params\":{\"key2\":\"value2\"}}]"));
         assertTrue(json.contains("\"created_time\":1689793598499"));
+        assertTrue(json.contains("\"tools\":[\"foo\",\"bar\"]"));
 
         WorkflowNode nodeX = WorkflowNode.parse(TemplateTestJsonUtil.jsonToParser(json));
         assertEquals("A", nodeX.id());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -15,10 +15,8 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
-import org.opensearch.ml.common.agent.LLMSpec;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLMemorySpec;
-import org.opensearch.ml.common.agent.MLToolSpec;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentResponse;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -54,10 +52,6 @@ public class RegisterAgentTests extends OpenSearchTestCase {
         this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
         MockitoAnnotations.openMocks(this);
 
-        MLToolSpec tools = new MLToolSpec("tool1", "CatIndexTool", "desc", Collections.emptyMap(), false);
-
-        LLMSpec llmSpec = new LLMSpec("xyz", Collections.emptyMap());
-
         Map<?, ?> mlMemorySpec = Map.ofEntries(
             Map.entry(MLMemorySpec.MEMORY_TYPE_FIELD, "type"),
             Map.entry(MLMemorySpec.SESSION_ID_FIELD, "abc"),
@@ -71,7 +65,7 @@ public class RegisterAgentTests extends OpenSearchTestCase {
                 Map.entry("type", "type"),
                 Map.entry("llm.model_id", "xyz"),
                 Map.entry("llm.parameters", Collections.emptyMap()),
-                Map.entry("tools", tools),
+                Map.entry("tools", new String[] { "abc", "xyz" }),
                 Map.entry("parameters", Collections.emptyMap()),
                 Map.entry("memory", mlMemorySpec),
                 Map.entry("created_time", 1689793598499L),


### PR DESCRIPTION
### Description

Allows users to include an optional "tools" field in the register agent node.  If present, any previous nodes listed in that array will be used in order prior to any other tools listed in previous inputs.  Duplicates will be ignored ("tools" field takes priority).

### Issues Resolved

Fixes #281 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
