### PR TITLE
[Feature/agent_framework] Adding installed plugins validation

### DIFF
--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -113,7 +113,13 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
             mlClient,
             flowFrameworkIndicesHandler
         );
-        WorkflowProcessSorter workflowProcessSorter = new WorkflowProcessSorter(workflowStepFactory, threadPool, clusterService, settings);
+        WorkflowProcessSorter workflowProcessSorter = new WorkflowProcessSorter(
+            workflowStepFactory,
+            threadPool,
+            clusterService,
+            client,
+            settings
+        );
 
         return ImmutableList.of(workflowStepFactory, workflowProcessSorter, encryptorUtils, flowFrameworkIndicesHandler);
     }

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowStepValidator.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowStepValidator.java
@@ -25,18 +25,23 @@ public class WorkflowStepValidator {
     private static final String INPUTS_FIELD = "inputs";
     /** Outputs field name */
     private static final String OUTPUTS_FIELD = "outputs";
+    /** Required Plugins field name */
+    private static final String REQUIRED_PLUGINS = "required_plugins";
 
     private List<String> inputs;
     private List<String> outputs;
+    private List<String> requiredPlugins;
 
     /**
      * Intantiate the object representing a Workflow Step validator
      * @param inputs the workflow step inputs
      * @param outputs the workflow step outputs
+     * @param requiredPlugins the required plugins for this workflow step
      */
-    public WorkflowStepValidator(List<String> inputs, List<String> outputs) {
+    public WorkflowStepValidator(List<String> inputs, List<String> outputs, List<String> requiredPlugins) {
         this.inputs = inputs;
         this.outputs = outputs;
+        this.requiredPlugins = requiredPlugins;
     }
 
     /**
@@ -48,6 +53,7 @@ public class WorkflowStepValidator {
     public static WorkflowStepValidator parse(XContentParser parser) throws IOException {
         List<String> parsedInputs = new ArrayList<>();
         List<String> parsedOutputs = new ArrayList<>();
+        List<String> requiredPlugins = new ArrayList<>();
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -66,11 +72,17 @@ public class WorkflowStepValidator {
                         parsedOutputs.add(parser.text());
                     }
                     break;
+                case REQUIRED_PLUGINS:
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        requiredPlugins.add(parser.text());
+                    }
+                    break;
                 default:
                     throw new IOException("Unable to parse field [" + fieldName + "] in a WorkflowStepValidator object.");
             }
         }
-        return new WorkflowStepValidator(parsedInputs, parsedOutputs);
+        return new WorkflowStepValidator(parsedInputs, parsedOutputs, requiredPlugins);
     }
 
     /**
@@ -87,5 +99,13 @@ public class WorkflowStepValidator {
      */
     public List<String> getOutputs() {
         return List.copyOf(outputs);
+    }
+
+    /**
+     * Get the required plugins
+     * @return the outputs
+     */
+    public List<String> getRequiredPlugins() {
+        return List.copyOf(requiredPlugins);
     }
 }

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -243,7 +243,7 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
     private void validateWorkflows(Template template) throws Exception {
         for (Workflow workflow : template.workflows().values()) {
             List<ProcessNode> sortedNodes = workflowProcessSorter.sortProcessNodes(workflow, null);
-            workflowProcessSorter.validateGraph(sortedNodes);
+            workflowProcessSorter.validate(sortedNodes);
         }
     }
 

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -123,6 +123,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                 Workflow provisionWorkflow = template.workflows().get(PROVISION_WORKFLOW);
                 List<ProcessNode> provisionProcessSequence = workflowProcessSorter.sortProcessNodes(provisionWorkflow, workflowId);
                 workflowProcessSorter.validateGraph(provisionProcessSequence);
+                workflowProcessSorter.validatePluginsInstalled(provisionProcessSequence);
 
                 flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(
                     workflowId,

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -122,8 +122,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                 // Sort and validate graph
                 Workflow provisionWorkflow = template.workflows().get(PROVISION_WORKFLOW);
                 List<ProcessNode> provisionProcessSequence = workflowProcessSorter.sortProcessNodes(provisionWorkflow, workflowId);
-                workflowProcessSorter.validateGraph(provisionProcessSequence);
-                workflowProcessSorter.validatePluginsInstalled(provisionProcessSequence);
+                workflowProcessSorter.validate(provisionProcessSequence);
 
                 flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(
                     workflowId,

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -136,13 +136,23 @@ public class WorkflowProcessSorter {
     }
 
     /**
+     * Validates inputs and ensures the required plugins are installed for each step in a topologically sorted graph
+     * @param processNodes the topologically sorted list of process nodes
+     * @throws Exception if validation fails
+     */
+    public void validate(List<ProcessNode> processNodes) throws Exception {
+        WorkflowValidator validator = WorkflowValidator.parse("mappings/workflow-steps.json");
+        validatePluginsInstalled(processNodes, validator);
+        validateGraph(processNodes, validator);
+    }
+
+    /**
      * Validates a sorted workflow, determines if each process node's required plugins are currently installed
      * @param processNodes A list of process nodes
+     * @param validator The validation definitions for the workflow steps
      * @throws Exception on validation failure
      */
-    public void validatePluginsInstalled(List<ProcessNode> processNodes) throws Exception {
-
-        WorkflowValidator validator = WorkflowValidator.parse("mappings/workflow-steps.json");
+    public void validatePluginsInstalled(List<ProcessNode> processNodes, WorkflowValidator validator) throws Exception {
 
         // Retrieve node information to ascertain installed plugins
         NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
@@ -191,11 +201,10 @@ public class WorkflowProcessSorter {
     /**
      * Validates a sorted workflow, determines if each process node's user inputs and predecessor outputs match the expected workflow step inputs
      * @param processNodes A list of process nodes
+     * @param validator The validation definitions for the workflow steps
      * @throws Exception on validation failure
      */
-    public void validateGraph(List<ProcessNode> processNodes) throws Exception {
-
-        WorkflowValidator validator = WorkflowValidator.parse("mappings/workflow-steps.json");
+    public void validateGraph(List<ProcessNode> processNodes, WorkflowValidator validator) throws Exception {
 
         // Iterate through process nodes in graph
         for (ProcessNode processNode : processNodes) {

--- a/src/main/resources/mappings/workflow-steps.json
+++ b/src/main/resources/mappings/workflow-steps.json
@@ -1,7 +1,8 @@
 {
     "noop": {
         "inputs":[],
-        "outputs":[]
+        "outputs":[],
+        "required_plugins":[]
     },
     "create_index": {
         "inputs":[
@@ -10,7 +11,8 @@
         ],
         "outputs":[
             "index_name"
-        ]
+        ],
+        "required_plugins":[]
     },
     "create_ingest_pipeline": {
         "inputs":[
@@ -23,7 +25,8 @@
         ],
         "outputs":[
             "pipeline_id"
-        ]
+        ],
+        "required_plugins":[]
     },
     "create_connector": {
         "inputs":[
@@ -37,6 +40,9 @@
         ],
         "outputs":[
             "connector_id"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     },
     "delete_connector": {
@@ -45,6 +51,9 @@
         ],
         "outputs":[
             "connector_id"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     },
     "register_local_model": {
@@ -62,6 +71,9 @@
         "outputs":[
             "model_id",
             "register_model_status"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     },
     "register_remote_model": {
@@ -73,6 +85,9 @@
         "outputs": [
             "model_id",
             "register_model_status"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     },
     "delete_model": {
@@ -81,6 +96,9 @@
         ],
         "outputs":[
             "model_id"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     },
     "deploy_model": {
@@ -89,6 +107,9 @@
         ],
         "outputs":[
             "deploy_model_status"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     },
     "undeploy_model": {
@@ -97,6 +118,9 @@
         ],
         "outputs":[
             "success"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     },
     "register_model_group": {
@@ -106,6 +130,9 @@
         "outputs":[
             "model_group_id",
             "model_group_status"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     },
     "register_agent": {
@@ -121,6 +148,9 @@
         ],
         "outputs":[
             "agent_id"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     },
     "delete_agent": {
@@ -129,6 +159,9 @@
         ],
         "outputs":[
             "agent_id"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     },
     "create_tool": {
@@ -137,6 +170,9 @@
         ],
         "outputs": [
             "tools"
+        ],
+        "required_plugins":[
+            "opensearch-ml"
         ]
     }
 }

--- a/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
@@ -455,8 +455,6 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             MAX_WORKFLOWS.get(settings)
         );
 
-        // Bypass dryRun, we should not be invoking the actual validation in this transport action unit test
-
         // Bypass checkMaxWorkflows and force onResponse
         doAnswer(invocation -> {
             ActionListener<Boolean> checkMaxWorkflowListener = invocation.getArgument(2);

--- a/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
@@ -92,7 +92,13 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
-        this.workflowProcessSorter = new WorkflowProcessSorter(mock(WorkflowStepFactory.class), threadPool, clusterService, settings);
+        this.workflowProcessSorter = new WorkflowProcessSorter(
+            mock(WorkflowStepFactory.class),
+            threadPool,
+            clusterService,
+            client,
+            settings
+        );
         this.createWorkflowTransportAction = spy(
             new CreateWorkflowTransportAction(
                 mock(TransportService.class),

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -100,7 +100,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             mlClient,
             flowFrameworkIndicesHandler
         );
-        workflowProcessSorter = new WorkflowProcessSorter(factory, testThreadPool, clusterService, settings);
+        workflowProcessSorter = new WorkflowProcessSorter(factory, testThreadPool, clusterService, client, settings);
     }
 
     @AfterClass


### PR DESCRIPTION
### Description
This PR adds a new field `required_plugins` to the `workflow_step` json which is used to determine if the workflow step's corresponding plugin is currently installed within the local node. Additionally, this PR adds validation when `creating` (with validation) and `provisioning` to check if the given graph has all the required plugins prior to executing. 

The following example uses a create connector node with an intentionally modified required plugin named `test-plugin` to demonstrate how the validation works : 

Creating the workflow : 
```
curl -i -XPOST "localhost:9200/_plugins/_flow_framework/workflow" -H "Content-Type:application/json" --data '{"name":"create-connector-register-deploy-model","description":"test case","use_case":"TEST_CASE","version":{"template":"1.0.0","compatibility":["2.12.0","3.0.0"]},"workflows":{"provision":{"nodes":[{"id":"workflow_step_1","type":"create_connector","user_inputs":{"name":"OpenAI Chat Connector","description":"The connector to public OpenAI model service for GPT 3.5","version":"1","protocol":"http","parameters":{"endpoint":"api.openai.com","model":"gpt-3.5-turbo"},"credential":{"openAI_key":"12345"},"actions":[{"action_type":"predict","method":"POST","url":"https://${parameters.endpoint}/v1/chat/completions"}]}},{"id":"workflow_step_2","type":"register_remote_model","previous_node_inputs":{"workflow_step_1":"connector_id"},"user_inputs":{"name":"openAI-gpt-3.5-turbo","function_name":"remote","description":"test model"}},{"id":"workflow_step_3","type":"deploy_model","previous_node_inputs":{"workflow_step_2":"model_id"}}],"edges":[{"source":"workflow_step_1","dest":"workflow_step_2"},{"source":"workflow_step_2","dest":"workflow_step_3"}]}}}'

HTTP/1.1 201 Created
content-type: application/json; charset=UTF-8
content-length: 38

{"workflow_id":"n-jqaYwBsLRi2-luOv83"}
```
Provisioning the workflow results in an error that states that the `create_connector` step requires the `test-plugin` to be installed
```
curl -i -XPOST "localhost:9200/_plugins/_flow_framework/workflow/n-jqaYwBsLRi2-luOv83/_provision"
HTTP/1.1 400 Bad Request
content-type: application/json; charset=UTF-8
content-length: 108

{"error":"The workflowStep create_connector requires the following plugins to be installed : [test-plugin]"}
```


### Issues Resolved
https://github.com/opensearch-project/flow-framework/issues/126
Part of #88 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
