### PR TITLE
Add Delete Workflow API

### DIFF
--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -28,6 +28,7 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.rest.RestCreateWorkflowAction;
+import org.opensearch.flowframework.rest.RestDeleteWorkflowAction;
 import org.opensearch.flowframework.rest.RestDeprovisionWorkflowAction;
 import org.opensearch.flowframework.rest.RestGetWorkflowAction;
 import org.opensearch.flowframework.rest.RestGetWorkflowStateAction;
@@ -36,6 +37,8 @@ import org.opensearch.flowframework.rest.RestSearchWorkflowAction;
 import org.opensearch.flowframework.rest.RestSearchWorkflowStateAction;
 import org.opensearch.flowframework.transport.CreateWorkflowAction;
 import org.opensearch.flowframework.transport.CreateWorkflowTransportAction;
+import org.opensearch.flowframework.transport.DeleteWorkflowAction;
+import org.opensearch.flowframework.transport.DeleteWorkflowTransportAction;
 import org.opensearch.flowframework.transport.DeprovisionWorkflowAction;
 import org.opensearch.flowframework.transport.DeprovisionWorkflowTransportAction;
 import org.opensearch.flowframework.transport.GetWorkflowAction;
@@ -139,6 +142,7 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
     ) {
         return ImmutableList.of(
             new RestCreateWorkflowAction(flowFrameworkFeatureEnabledSetting, settings, clusterService),
+            new RestDeleteWorkflowAction(flowFrameworkFeatureEnabledSetting),
             new RestProvisionWorkflowAction(flowFrameworkFeatureEnabledSetting),
             new RestDeprovisionWorkflowAction(flowFrameworkFeatureEnabledSetting),
             new RestSearchWorkflowAction(flowFrameworkFeatureEnabledSetting),
@@ -152,6 +156,7 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return ImmutableList.of(
             new ActionHandler<>(CreateWorkflowAction.INSTANCE, CreateWorkflowTransportAction.class),
+            new ActionHandler<>(DeleteWorkflowAction.INSTANCE, DeleteWorkflowTransportAction.class),
             new ActionHandler<>(ProvisionWorkflowAction.INSTANCE, ProvisionWorkflowTransportAction.class),
             new ActionHandler<>(DeprovisionWorkflowAction.INSTANCE, DeprovisionWorkflowTransportAction.class),
             new ActionHandler<>(SearchWorkflowAction.INSTANCE, SearchWorkflowTransportAction.class),

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.rest;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.transport.DeleteWorkflowAction;
+import org.opensearch.flowframework.transport.WorkflowRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
+import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
+
+/**
+ * Rest Action to facilitate requests to delete a stored template
+ */
+public class RestDeleteWorkflowAction extends BaseRestHandler {
+
+    private static final String DELETE_WORKFLOW_ACTION = "delete_workflow";
+    private static final Logger logger = LogManager.getLogger(RestDeleteWorkflowAction.class);
+    private FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting;
+
+    /**
+     * Instantiates a new RestDeleteWorkflowAction
+     * @param flowFrameworkFeatureEnabledSetting Whether this API is enabled
+     */
+    public RestDeleteWorkflowAction(FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting) {
+        this.flowFrameworkFeatureEnabledSetting = flowFrameworkFeatureEnabledSetting;
+    }
+
+    @Override
+    public String getName() {
+        return DELETE_WORKFLOW_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList.of(new Route(RestRequest.Method.DELETE, String.format(Locale.ROOT, "%s/{%s}", WORKFLOW_URI, WORKFLOW_ID)));
+    }
+
+    @Override
+    protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        String workflowId = request.param(WORKFLOW_ID);
+        try {
+            if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {
+                throw new FlowFrameworkException(
+                    "This API is disabled. To enable it, update the setting [" + FLOW_FRAMEWORK_ENABLED.getKey() + "] to true.",
+                    RestStatus.FORBIDDEN
+                );
+            }
+            // Validate content
+            if (request.hasContent()) {
+                throw new FlowFrameworkException("Invalid request format", RestStatus.BAD_REQUEST);
+            }
+            // Validate params
+            if (workflowId == null) {
+                throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);
+            }
+            WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null);
+            return channel -> client.execute(DeleteWorkflowAction.INSTANCE, workflowRequest, ActionListener.wrap(response -> {
+                XContentBuilder builder = response.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS);
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+            }, exception -> {
+                try {
+                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
+                        ? (FlowFrameworkException) exception
+                        : new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception));
+                    XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
+                    channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
+
+                } catch (IOException e) {
+                    logger.error("Failed to send back delete workflow exception", e);
+                    channel.sendResponse(new BytesRestResponse(ExceptionsHelper.status(e), e.getMessage()));
+                }
+            }));
+
+        } catch (FlowFrameworkException ex) {
+            return channel -> channel.sendResponse(
+                new BytesRestResponse(ex.getRestStatus(), ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS))
+            );
+        }
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowAction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.delete.DeleteResponse;
+
+import static org.opensearch.flowframework.common.CommonValue.TRANSPORT_ACTION_NAME_PREFIX;
+
+/**
+ * External Action for public facing RestGetWorkflowAction
+ */
+public class DeleteWorkflowAction extends ActionType<DeleteResponse> {
+    /** The name of this action */
+    public static final String NAME = TRANSPORT_ACTION_NAME_PREFIX + "workflow/delete";
+    /** An instance of this action */
+    public static final DeleteWorkflowAction INSTANCE = new DeleteWorkflowAction();
+
+    private DeleteWorkflowAction() {
+        super(NAME, DeleteResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.transport;
+
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.client.Client;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
+
+/**
+ * Transport action to retrieve a use case template within the Global Context
+ */
+public class DeleteWorkflowTransportAction extends HandledTransportAction<WorkflowRequest, DeleteResponse> {
+
+    private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
+    private final Client client;
+
+    /**
+     * Instantiates a new DeleteWorkflowTransportAction instance
+     * @param transportService the transport service
+     * @param actionFilters action filters
+     * @param flowFrameworkIndicesHandler The Flow Framework indices handler
+     * @param client the OpenSearch Client
+     */
+    @Inject
+    public DeleteWorkflowTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        FlowFrameworkIndicesHandler flowFrameworkIndicesHandler,
+        Client client
+    ) {
+        super(DeleteWorkflowAction.NAME, transportService, actionFilters, WorkflowRequest::new);
+        this.flowFrameworkIndicesHandler = flowFrameworkIndicesHandler;
+        this.client = client;
+    }
+
+    @Override
+    protected void doExecute(Task task, WorkflowRequest request, ActionListener<DeleteResponse> listener) {
+        if (flowFrameworkIndicesHandler.doesIndexExist(GLOBAL_CONTEXT_INDEX)) {
+            String workflowId = request.getWorkflowId();
+            DeleteRequest deleteRequest = new DeleteRequest(GLOBAL_CONTEXT_INDEX, workflowId);
+
+            ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext();
+            client.delete(deleteRequest, ActionListener.runBefore(listener, () -> context.restore()));
+        } else {
+            listener.onFailure(new FlowFrameworkException("There are no templates in the global context.", RestStatus.NOT_FOUND));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
@@ -131,7 +131,7 @@ public class DeprovisionWorkflowTransportAction extends HandledTransportAction<W
                 // Sort and validate graph
                 Workflow provisionWorkflow = template.workflows().get(PROVISION_WORKFLOW);
                 List<ProcessNode> provisionProcessSequence = workflowProcessSorter.sortProcessNodes(provisionWorkflow, workflowId);
-                workflowProcessSorter.validateGraph(provisionProcessSequence);
+                workflowProcessSorter.validate(provisionProcessSequence);
 
                 // We have a valid template and sorted nodes, get the created resources
                 getResourcesAndExecute(request.getWorkflowId(), provisionProcessSequence, listener);

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
@@ -82,8 +82,8 @@ public class FlowFrameworkPluginTests extends OpenSearchTestCase {
                 4,
                 ffp.createComponents(client, clusterService, threadPool, null, null, null, environment, null, null, null, null).size()
             );
-            assertEquals(7, ffp.getRestHandlers(settings, null, null, null, null, null, null).size());
-            assertEquals(7, ffp.getActions().size());
+            assertEquals(8, ffp.getRestHandlers(settings, null, null, null, null, null, null).size());
+            assertEquals(8, ffp.getActions().size());
             assertEquals(1, ffp.getExecutorBuilders(settings).size());
             assertEquals(5, ffp.getSettings().size());
         }

--- a/src/test/java/org/opensearch/flowframework/rest/RestDeleteWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestDeleteWorkflowActionTests.java
@@ -26,8 +26,8 @@ import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class RestGetWorkflowActionTests extends OpenSearchTestCase {
-    private RestGetWorkflowAction restGetWorkflowAction;
+public class RestDeleteWorkflowActionTests extends OpenSearchTestCase {
+    private RestDeleteWorkflowAction restDeleteWorkflowAction;
     private String getPath;
     private FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting;
     private NodeClient nodeClient;
@@ -39,44 +39,44 @@ public class RestGetWorkflowActionTests extends OpenSearchTestCase {
         this.getPath = String.format(Locale.ROOT, "%s/{%s}", WORKFLOW_URI, "workflow_id");
         flowFrameworkFeatureEnabledSetting = mock(FlowFrameworkFeatureEnabledSetting.class);
         when(flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()).thenReturn(true);
-        this.restGetWorkflowAction = new RestGetWorkflowAction(flowFrameworkFeatureEnabledSetting);
+        this.restDeleteWorkflowAction = new RestDeleteWorkflowAction(flowFrameworkFeatureEnabledSetting);
         this.nodeClient = mock(NodeClient.class);
     }
 
-    public void testRestGetWorkflowActionName() {
-        String name = restGetWorkflowAction.getName();
-        assertEquals("get_workflow", name);
+    public void testRestDeleteWorkflowActionName() {
+        String name = restDeleteWorkflowAction.getName();
+        assertEquals("delete_workflow", name);
     }
 
-    public void testRestGetWorkflowActionRoutes() {
-        List<RestHandler.Route> routes = restGetWorkflowAction.routes();
+    public void testRestDeleteWorkflowActionRoutes() {
+        List<RestHandler.Route> routes = restDeleteWorkflowAction.routes();
         assertEquals(1, routes.size());
-        assertEquals(RestRequest.Method.GET, routes.get(0).getMethod());
+        assertEquals(RestRequest.Method.DELETE, routes.get(0).getMethod());
         assertEquals(this.getPath, routes.get(0).getPath());
     }
 
     public void testInvalidRequestWithContent() {
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.DELETE)
             .withPath(this.getPath)
             .withContent(new BytesArray("request body"), MediaTypeRegistry.JSON)
             .build();
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
-            restGetWorkflowAction.handleRequest(request, channel, nodeClient);
+            restDeleteWorkflowAction.handleRequest(request, channel, nodeClient);
         });
-        assertEquals("request [GET /_plugins/_flow_framework/workflow/{workflow_id}] does not support having a body", ex.getMessage());
+        assertEquals("request [DELETE /_plugins/_flow_framework/workflow/{workflow_id}] does not support having a body", ex.getMessage());
     }
 
     public void testNullWorkflowId() throws Exception {
 
         // Request with no params
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.DELETE)
             .withPath(this.getPath)
             .build();
 
         FakeRestChannel channel = new FakeRestChannel(request, true, 1);
-        restGetWorkflowAction.handleRequest(request, channel, nodeClient);
+        restDeleteWorkflowAction.handleRequest(request, channel, nodeClient);
 
         assertEquals(1, channel.errors().get());
         assertEquals(RestStatus.BAD_REQUEST, channel.capturedResponse().status());
@@ -85,11 +85,11 @@ public class RestGetWorkflowActionTests extends OpenSearchTestCase {
 
     public void testFeatureFlagNotEnabled() throws Exception {
         when(flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()).thenReturn(false);
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.DELETE)
                 .withPath(this.getPath)
                 .build();
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
-        restGetWorkflowAction.handleRequest(request, channel, nodeClient);
+        restDeleteWorkflowAction.handleRequest(request, channel, nodeClient);
         assertEquals(RestStatus.FORBIDDEN, channel.capturedResponse().status());
         assertTrue(channel.capturedResponse().content().utf8ToString().contains("This API is disabled."));
     }

--- a/src/test/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportActionTests.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.transport;
+
+import org.opensearch.action.DocWriteResponse.Result;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.client.Client;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DeleteWorkflowTransportActionTests extends OpenSearchTestCase {
+
+    private Client client;
+    private DeleteWorkflowTransportAction deleteWorkflowTransportAction;
+    private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        this.client = mock(Client.class);
+        this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
+        this.deleteWorkflowTransportAction = new DeleteWorkflowTransportAction(
+            mock(TransportService.class),
+            mock(ActionFilters.class),
+            flowFrameworkIndicesHandler,
+            client
+        );
+
+        ThreadPool clientThreadPool = mock(ThreadPool.class);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+        when(client.threadPool()).thenReturn(clientThreadPool);
+        when(clientThreadPool.getThreadContext()).thenReturn(threadContext);
+
+    }
+
+    public void testDeleteWorkflowNoGlobalContext() {
+
+        when(flowFrameworkIndicesHandler.doesIndexExist(anyString())).thenReturn(false);
+        @SuppressWarnings("unchecked")
+        ActionListener<DeleteResponse> listener = mock(ActionListener.class);
+        WorkflowRequest workflowRequest = new WorkflowRequest("1", null);
+        deleteWorkflowTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener, times(1)).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("There are no templates in the global context."));
+    }
+
+    public void testDeleteWorkflowSuccess() {
+        String workflowId = "12345";
+        @SuppressWarnings("unchecked")
+        ActionListener<DeleteResponse> listener = mock(ActionListener.class);
+        WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null);
+
+        when(flowFrameworkIndicesHandler.doesIndexExist(anyString())).thenReturn(true);
+
+        // Stub client.delete to force on response
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> responseListener = invocation.getArgument(1);
+
+            ShardId shardId = new ShardId(new Index("indexName", "uuid"), 1);
+            responseListener.onResponse(new DeleteResponse(shardId, workflowId, 1, 1, 1, true));
+            return null;
+        }).when(client).delete(any(DeleteRequest.class), any());
+
+        deleteWorkflowTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
+
+        ArgumentCaptor<DeleteResponse> responseCaptor = ArgumentCaptor.forClass(DeleteResponse.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals(Result.DELETED, responseCaptor.getValue().getResult());
+    }
+
+    public void testDeleteWorkflowNotFound() {
+        String workflowId = "12345";
+        @SuppressWarnings("unchecked")
+        ActionListener<DeleteResponse> listener = mock(ActionListener.class);
+        WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null);
+
+        when(flowFrameworkIndicesHandler.doesIndexExist(anyString())).thenReturn(true);
+
+        // Stub client.delete to force on response
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> responseListener = invocation.getArgument(1);
+
+            ShardId shardId = new ShardId(new Index("indexName", "uuid"), 1);
+            responseListener.onResponse(new DeleteResponse(shardId, workflowId, 1, 1, 1, false));
+            return null;
+        }).when(client).delete(any(DeleteRequest.class), any());
+
+        deleteWorkflowTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
+
+        ArgumentCaptor<DeleteResponse> responseCaptor = ArgumentCaptor.forClass(DeleteResponse.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals(Result.NOT_FOUND, responseCaptor.getValue().getResult());
+    }
+}


### PR DESCRIPTION
### Description

Adds an API to delete a workflow.  

It might be a good idea to warn users about losing track of provisioned resources and allow a "force" param.  However, there are many more issues associated with resources (overwriting, etc.) and I think such extra logic belongs in an overall new strategy to handle this, so for now it's just a plain vanilla delete.

### Issues Resolved

Fixes #23 
Part of overall meta issue #88 

### Interactive testing

Without feature flag enabled (note this reqiures reading the workflow_id param, see #292):
```
localhost:9200/_plugins/_flow_framework/workflow/foobar
```
```json
{
    "error": "This API is disabled. To enable it, update the setting [plugins.flow_framework.enabled] to true."
}
```
Enabled feature flag but no templates created:
```json
{
    "error": "There are no templates in the global context."
}
```
Create a template, id qU00aowBH9rhI2IwnrH3

Delete it:
```json
{
    "_index": ".plugins-ai-global-context",
    "_id": "qU00aowBH9rhI2IwnrH3",
    "_version": 2,
    "result": "deleted",
    "_shards": {
        "total": 1,
        "successful": 1,
        "failed": 0
    },
    "_seq_no": 2,
    "_primary_term": 1
}
```
Try to delete it again (it's not there):
```json
{
    "_index": ".plugins-ai-global-context",
    "_id": "qU00aowBH9rhI2IwnrH3",
    "_version": 1,
    "result": "not_found",
    "_shards": {
        "total": 1,
        "successful": 1,
        "failed": 0
    },
    "_seq_no": 3,
    "_primary_term": 1
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
