### PR TITLE
Consume REST params and consistently handle error messages

### DIFF
--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -78,6 +78,7 @@ public class RestCreateWorkflowAction extends AbstractWorkflowAction {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        String workflowId = request.param(WORKFLOW_ID);
         if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {
             FlowFrameworkException ffe = new FlowFrameworkException(
                 "This API is disabled. To enable it, set [" + FLOW_FRAMEWORK_ENABLED.getKey() + "] to true.",
@@ -88,8 +89,6 @@ public class RestCreateWorkflowAction extends AbstractWorkflowAction {
             );
         }
         try {
-
-            String workflowId = request.param(WORKFLOW_ID);
             Template template = Template.parse(request.content().utf8ToString());
             boolean dryRun = request.paramAsBoolean(DRY_RUN, false);
             boolean provision = request.paramAsBoolean(PROVISION_WORKFLOW, false);

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
@@ -72,7 +72,8 @@ public class RestDeleteWorkflowAction extends BaseRestHandler {
             }
             // Validate content
             if (request.hasContent()) {
-                throw new FlowFrameworkException("Invalid request format", RestStatus.BAD_REQUEST);
+                // BaseRestHandler will give appropriate error message
+                return channel -> channel.sendResponse(null);
             }
             // Validate params
             if (workflowId == null) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
@@ -67,7 +67,8 @@ public class RestDeprovisionWorkflowAction extends BaseRestHandler {
             }
             // Validate content
             if (request.hasContent()) {
-                throw new FlowFrameworkException("No request body is required", RestStatus.BAD_REQUEST);
+                // BaseRestHandler will give appropriate error message
+                return channel -> channel.sendResponse(null);
             }
             // Validate params
             if (workflowId == null) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
@@ -57,7 +57,7 @@ public class RestDeprovisionWorkflowAction extends BaseRestHandler {
 
     @Override
     protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-
+        String workflowId = request.param(WORKFLOW_ID);
         try {
             if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {
                 throw new FlowFrameworkException(
@@ -70,7 +70,6 @@ public class RestDeprovisionWorkflowAction extends BaseRestHandler {
                 throw new FlowFrameworkException("No request body is required", RestStatus.BAD_REQUEST);
             }
             // Validate params
-            String workflowId = request.param(WORKFLOW_ID);
             if (workflowId == null) {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);
             }

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
@@ -70,10 +70,10 @@ public class RestGetWorkflowAction extends BaseRestHandler {
                     RestStatus.FORBIDDEN
                 );
             }
-
             // Validate content
             if (request.hasContent()) {
-                throw new FlowFrameworkException("Invalid request format", RestStatus.BAD_REQUEST);
+                // BaseRestHandler will give appropriate error message
+                return channel -> channel.sendResponse(null);
             }
             // Validate params
             if (workflowId == null) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
@@ -86,7 +86,9 @@ public class RestGetWorkflowAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex = new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception));
+                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
+                        ? (FlowFrameworkException) exception
+                        : new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception));
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
 

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
@@ -62,7 +62,7 @@ public class RestGetWorkflowAction extends BaseRestHandler {
 
     @Override
     protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-
+        String workflowId = request.param(WORKFLOW_ID);
         try {
             if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {
                 throw new FlowFrameworkException(
@@ -76,7 +76,6 @@ public class RestGetWorkflowAction extends BaseRestHandler {
                 throw new FlowFrameworkException("Invalid request format", RestStatus.BAD_REQUEST);
             }
             // Validate params
-            String workflowId = request.param(WORKFLOW_ID);
             if (workflowId == null) {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);
             }

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
@@ -68,7 +68,8 @@ public class RestGetWorkflowStateAction extends BaseRestHandler {
 
             // Validate content
             if (request.hasContent()) {
-                throw new FlowFrameworkException("No request body present", RestStatus.BAD_REQUEST);
+                // BaseRestHandler will give appropriate error message
+                return channel -> channel.sendResponse(null);
             }
             // Validate params
             if (workflowId == null) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
@@ -83,7 +83,9 @@ public class RestGetWorkflowStateAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex = new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception));
+                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
+                        ? (FlowFrameworkException) exception
+                        : new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception));
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
 

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
@@ -57,7 +57,7 @@ public class RestGetWorkflowStateAction extends BaseRestHandler {
 
     @Override
     protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-
+        String workflowId = request.param(WORKFLOW_ID);
         try {
             if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {
                 throw new FlowFrameworkException(
@@ -71,7 +71,6 @@ public class RestGetWorkflowStateAction extends BaseRestHandler {
                 throw new FlowFrameworkException("No request body present", RestStatus.BAD_REQUEST);
             }
             // Validate params
-            String workflowId = request.param(WORKFLOW_ID);
             if (workflowId == null) {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);
             }

--- a/src/main/java/org/opensearch/flowframework/rest/RestProvisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestProvisionWorkflowAction.java
@@ -77,7 +77,8 @@ public class RestProvisionWorkflowAction extends BaseRestHandler {
             }
             // Validate content
             if (request.hasContent()) {
-                throw new FlowFrameworkException("Invalid request format", RestStatus.BAD_REQUEST);
+                // BaseRestHandler will give appropriate error message
+                return channel -> channel.sendResponse(null);
             }
             // Validate params
             if (workflowId == null) {

--- a/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStateActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStateActionTests.java
@@ -63,7 +63,7 @@ public class RestGetWorkflowStateActionTests extends OpenSearchTestCase {
     public void testNullWorkflowId() throws Exception {
 
         // Request with no params
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
             .withPath(this.getPath)
             .build();
 
@@ -76,7 +76,7 @@ public class RestGetWorkflowStateActionTests extends OpenSearchTestCase {
     }
 
     public void testInvalidRequestWithContent() {
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
             .withPath(this.getPath)
             .withContent(new BytesArray("request body"), MediaTypeRegistry.JSON)
             .build();
@@ -86,14 +86,14 @@ public class RestGetWorkflowStateActionTests extends OpenSearchTestCase {
             restGetWorkflowStateAction.handleRequest(request, channel, nodeClient);
         });
         assertEquals(
-            "request [POST /_plugins/_flow_framework/workflow/{workflow_id}/_status] does not support having a body",
+            "request [GET /_plugins/_flow_framework/workflow/{workflow_id}/_status] does not support having a body",
             ex.getMessage()
         );
     }
 
     public void testFeatureFlagNotEnabled() throws Exception {
         when(flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()).thenReturn(false);
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
                 .withPath(this.getPath)
                 .build();
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);


### PR DESCRIPTION
### Description

1. Always consumes the `workflow_id` param before any other error handling, so it doesn't get swallowed by BaseRestHandler consumed-param checks
2. Just returns a null response to the channel when there is no content, as the BaseRestHandler has an error for that
3. Keeps the FlowFrameworkException RestStatus in the response if that's what's thrown

### Issues Resolved

Fixes #274 
Fixes #292 
Fixes #293 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
