### PR TITLE
Refactor RetryableWorkflowStep to avoid recursion and subclass specifics

### DIFF
--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -113,6 +113,7 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
         FlowFrameworkIndicesHandler flowFrameworkIndicesHandler = new FlowFrameworkIndicesHandler(client, clusterService, encryptorUtils);
         WorkflowStepFactory workflowStepFactory = new WorkflowStepFactory(
             settings,
+            threadPool,
             clusterService,
             client,
             mlClient,

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -125,8 +125,9 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
                             future.completeExceptionally(new FlowFrameworkException(errorMessage, RestStatus.BAD_REQUEST));
                             break;
                         case CANCELLED:
-                            logger.error("{} task was cancelled.", workflowStep);
-                            FutureUtils.cancel(future);
+                            errorMessage = workflowStep + " task was cancelled.";
+                            logger.error(errorMessage);
+                            future.completeExceptionally(new FlowFrameworkException(errorMessage, RestStatus.REQUEST_TIMEOUT));
                             break;
                         default:
                             // Task started or running, do nothing

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -125,7 +125,7 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
                             future.completeExceptionally(new FlowFrameworkException(errorMessage, RestStatus.BAD_REQUEST));
                             break;
                         case CANCELLED:
-                            logger.error(workflowStep + " task was cancelled.");
+                            logger.error("{} task was cancelled.", workflowStep);
                             FutureUtils.cancel(future);
                             break;
                         default:
@@ -141,6 +141,7 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
                     Thread.sleep(5000);
                 } catch (InterruptedException e) {
                     FutureUtils.cancel(future);
+                    Thread.currentThread().interrupt();
                 }
             }
             if (!future.isDone()) {

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -19,15 +19,16 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
-import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.opensearch.flowframework.common.CommonValue.PROVISION_THREAD_POOL;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_GET_TASK_REQUEST_RETRY;
-import static org.opensearch.flowframework.common.WorkflowResources.DEPLOY_MODEL;
 import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 
 /**
@@ -39,20 +40,24 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
     protected volatile Integer maxRetry;
     private final MachineLearningNodeClient mlClient;
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
+    private ThreadPool threadPool;
 
     /**
      * Instantiates a new Retryable workflow step
      * @param settings Environment settings
+     * @param threadPool The OpenSearch thread pool
      * @param clusterService the cluster service
      * @param mlClient machine learning client
      * @param flowFrameworkIndicesHandler FlowFrameworkIndicesHandler class to update system indices
      */
     protected AbstractRetryableWorkflowStep(
         Settings settings,
+        ThreadPool threadPool,
         ClusterService clusterService,
         MachineLearningNodeClient mlClient,
         FlowFrameworkIndicesHandler flowFrameworkIndicesHandler
     ) {
+        this.threadPool = threadPool;
         this.maxRetry = MAX_GET_TASK_REQUEST_RETRY.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_GET_TASK_REQUEST_RETRY, it -> maxRetry = it);
         this.mlClient = mlClient;
@@ -65,7 +70,6 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
      * @param nodeId the workflow node id
      * @param future the workflow step future
      * @param taskId the ml task id
-     * @param retries the current number of request retries
      * @param workflowStep the workflow step which requires a retry get ml task functionality
      */
     protected void retryableGetMlTask(
@@ -73,74 +77,84 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
         String nodeId,
         CompletableFuture<WorkflowData> future,
         String taskId,
-        int retries,
         String workflowStep
     ) {
-        mlClient.getTask(taskId, ActionListener.wrap(response -> {
-            MLTaskState currentState = response.getState();
-            if (currentState != MLTaskState.COMPLETED) {
-                if (Stream.of(MLTaskState.FAILED, MLTaskState.COMPLETED_WITH_ERROR).anyMatch(x -> x == currentState)) {
-                    // Model registration failed or completed with errors
-                    String errorMessage = workflowStep + " failed with error : " + response.getError();
+        AtomicInteger retries = new AtomicInteger();
+        CompletableFuture.runAsync(() -> {
+            while (retries.getAndIncrement() < this.maxRetry && !future.isDone()) {
+                mlClient.getTask(taskId, ActionListener.wrap(response -> {
+                    switch (response.getState()) {
+                        case COMPLETED:
+                            try {
+                                String resourceName = getResourceByWorkflowStep(getName());
+                                String id = getResourceId(response);
+                                logger.info("{} successful for {} and {} {}", workflowStep, workflowId, resourceName, id);
+                                flowFrameworkIndicesHandler.updateResourceInStateIndex(
+                                    workflowId,
+                                    nodeId,
+                                    getName(),
+                                    id,
+                                    ActionListener.wrap(updateResponse -> {
+                                        logger.info("successfully updated resources created in state index: {}", updateResponse.getIndex());
+                                        future.complete(
+                                            new WorkflowData(
+                                                Map.ofEntries(
+                                                    Map.entry(resourceName, id),
+                                                    Map.entry(REGISTER_MODEL_STATUS, response.getState().name())
+                                                ),
+                                                workflowId,
+                                                nodeId
+                                            )
+                                        );
+                                    }, exception -> {
+                                        logger.error("Failed to update new created resource", exception);
+                                        future.completeExceptionally(
+                                            new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception))
+                                        );
+                                    })
+                                );
+                            } catch (Exception e) {
+                                logger.error("Failed to parse and update new created resource", e);
+                                future.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
+                            }
+                            break;
+                        case FAILED:
+                        case COMPLETED_WITH_ERROR:
+                            String errorMessage = workflowStep + " failed with error : " + response.getError();
+                            logger.error(errorMessage);
+                            future.completeExceptionally(new FlowFrameworkException(errorMessage, RestStatus.BAD_REQUEST));
+                            break;
+                        case CANCELLED:
+                            logger.error(workflowStep + " task was cancelled.");
+                            FutureUtils.cancel(future);
+                            break;
+                        default:
+                            // Task started or running, do nothing
+                    }
+                }, exception -> {
+                    String errorMessage = workflowStep + " failed with error : " + exception.getMessage();
                     logger.error(errorMessage);
                     future.completeExceptionally(new FlowFrameworkException(errorMessage, RestStatus.BAD_REQUEST));
-                } else {
-                    // Task still in progress, attempt retry
-                    throw new IllegalStateException(workflowStep + " is not yet completed");
-                }
-            } else {
-                try {
-                    logger.info(workflowStep + " successful for {} and modelId {}", workflowId, response.getModelId());
-                    String resourceName = getResourceByWorkflowStep(getName());
-                    String id;
-                    if (getName().equals(DEPLOY_MODEL.getWorkflowStep())) {
-                        id = response.getModelId();
-                    } else {
-                        id = response.getTaskId();
-                    }
-                    flowFrameworkIndicesHandler.updateResourceInStateIndex(
-                        workflowId,
-                        nodeId,
-                        getName(),
-                        id,
-                        ActionListener.wrap(updateResponse -> {
-                            logger.info("successfully updated resources created in state index: {}", updateResponse.getIndex());
-                            future.complete(
-                                new WorkflowData(
-                                    Map.ofEntries(
-                                        Map.entry(resourceName, response.getModelId()),
-                                        Map.entry(REGISTER_MODEL_STATUS, response.getState().name())
-                                    ),
-                                    workflowId,
-                                    nodeId
-                                )
-                            );
-                        }, exception -> {
-                            logger.error("Failed to update new created resource", exception);
-                            future.completeExceptionally(
-                                new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception))
-                            );
-                        })
-                    );
-                } catch (Exception e) {
-                    logger.error("Failed to parse and update new created resource", e);
-                    future.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
-                }
-            }
-        }, exception -> {
-            if (retries < maxRetry) {
-                // Sleep thread prior to retrying request
+                }));
+                // Wait long enough for future to possibly complete
                 try {
                     Thread.sleep(5000);
-                } catch (Exception e) {
+                } catch (InterruptedException e) {
                     FutureUtils.cancel(future);
                 }
-                retryableGetMlTask(workflowId, nodeId, future, taskId, retries + 1, workflowStep);
-            } else {
-                logger.error("Failed to retrieve" + workflowStep + ",maximum retries exceeded");
-                future.completeExceptionally(new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception)));
             }
-        }));
+            if (!future.isDone()) {
+                String errorMessage = workflowStep + " did not complete after " + maxRetry + " retries";
+                logger.error(errorMessage);
+                future.completeExceptionally(new FlowFrameworkException(errorMessage, RestStatus.REQUEST_TIMEOUT));
+            }
+        }, threadPool.executor(PROVISION_THREAD_POOL));
     }
 
+    /**
+     * Returns the resourceId associated with the task
+     * @param response The Task response
+     * @return the resource ID, such as a model id
+     */
+    protected abstract String getResourceId(MLTask response);
 }

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalModelStep.java
@@ -18,6 +18,7 @@ import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.model.MLModelFormat;
@@ -37,6 +38,7 @@ import static org.opensearch.flowframework.common.CommonValue.ALL_CONFIG;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.EMBEDDING_DIMENSION;
 import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
+import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
@@ -123,7 +125,7 @@ public class RegisterLocalModelStep extends AbstractRetryableWorkflowStep {
             MODEL_CONTENT_HASH_VALUE,
             URL
         );
-        Set<String> optionalKeys = Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, ALL_CONFIG);
+        Set<String> optionalKeys = Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, ALL_CONFIG, FUNCTION_NAME);
 
         try {
             Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
@@ -145,6 +147,7 @@ public class RegisterLocalModelStep extends AbstractRetryableWorkflowStep {
             FrameworkType frameworkType = FrameworkType.from((String) inputs.get(FRAMEWORK_TYPE));
             String allConfig = (String) inputs.get(ALL_CONFIG);
             String url = (String) inputs.get(URL);
+            String functionName = (String) inputs.get(FUNCTION_NAME);
 
             // Create Model configuration
             TextEmbeddingModelConfigBuilder modelConfigBuilder = TextEmbeddingModelConfig.builder()
@@ -161,12 +164,17 @@ public class RegisterLocalModelStep extends AbstractRetryableWorkflowStep {
                 .modelName(modelName)
                 .version(modelVersion)
                 .modelFormat(modelFormat)
-                .modelGroupId(modelGroupId)
                 .hashValue(modelContentHashValue)
                 .modelConfig(modelConfig)
                 .url(url);
             if (description != null) {
                 mlInputBuilder.description(description);
+            }
+            if (modelGroupId != null) {
+                mlInputBuilder.modelGroupId(modelGroupId);
+            }
+            if (functionName != null) {
+                mlInputBuilder.functionName(FunctionName.from(functionName));
             }
 
             MLRegisterModelInput mlInput = mlInputBuilder.build();

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -15,6 +15,7 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,6 +32,7 @@ public class WorkflowStepFactory {
      * Instantiate this class.
      *
      * @param settings The OpenSearch settings
+     * @param threadPool The OpenSearch thread pool
      * @param clusterService The OpenSearch cluster service
      * @param client The OpenSearch client steps can use
      * @param mlClient Machine Learning client to perform ml operations
@@ -38,6 +40,7 @@ public class WorkflowStepFactory {
      */
     public WorkflowStepFactory(
         Settings settings,
+        ThreadPool threadPool,
         ClusterService clusterService,
         Client client,
         MachineLearningNodeClient mlClient,
@@ -48,11 +51,14 @@ public class WorkflowStepFactory {
         stepMap.put(CreateIngestPipelineStep.NAME, () -> new CreateIngestPipelineStep(client, flowFrameworkIndicesHandler));
         stepMap.put(
             RegisterLocalModelStep.NAME,
-            () -> new RegisterLocalModelStep(settings, clusterService, mlClient, flowFrameworkIndicesHandler)
+            () -> new RegisterLocalModelStep(settings, threadPool, clusterService, mlClient, flowFrameworkIndicesHandler)
         );
         stepMap.put(RegisterRemoteModelStep.NAME, () -> new RegisterRemoteModelStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(DeleteModelStep.NAME, () -> new DeleteModelStep(mlClient));
-        stepMap.put(DeployModelStep.NAME, () -> new DeployModelStep(settings, clusterService, mlClient, flowFrameworkIndicesHandler));
+        stepMap.put(
+            DeployModelStep.NAME,
+            () -> new DeployModelStep(settings, threadPool, clusterService, mlClient, flowFrameworkIndicesHandler)
+        );
         stepMap.put(UndeployModelStep.NAME, () -> new UndeployModelStep(mlClient));
         stepMap.put(CreateConnectorStep.NAME, () -> new CreateConnectorStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(DeleteConnectorStep.NAME, () -> new DeleteConnectorStep(mlClient));

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowValidatorTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowValidatorTests.java
@@ -20,6 +20,7 @@ import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -71,6 +72,7 @@ public class WorkflowValidatorTests extends OpenSearchTestCase {
 
     public void testWorkflowStepFactoryHasValidators() throws IOException {
 
+        ThreadPool threadPool = mock(ThreadPool.class);
         ClusterService clusterService = mock(ClusterService.class);
         ClusterAdminClient clusterAdminClient = mock(ClusterAdminClient.class);
         AdminClient adminClient = mock(AdminClient.class);
@@ -89,6 +91,7 @@ public class WorkflowValidatorTests extends OpenSearchTestCase {
 
         WorkflowStepFactory workflowStepFactory = new WorkflowStepFactory(
             Settings.EMPTY,
+            threadPool,
             clusterService,
             client,
             mlClient,

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
@@ -15,6 +15,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
@@ -25,12 +26,17 @@ import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.AfterClass;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -38,6 +44,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
+import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
+import static org.opensearch.flowframework.common.CommonValue.PROVISION_THREAD_POOL;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_GET_TASK_REQUEST_RETRY;
@@ -54,6 +62,7 @@ import static org.mockito.Mockito.when;
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class RegisterLocalModelStepTests extends OpenSearchTestCase {
 
+    private static TestThreadPool testThreadPool;
     private RegisterLocalModelStep registerLocalModelStep;
     private WorkflowData workflowData;
     private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
@@ -72,13 +81,24 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
             Stream.of(MAX_GET_TASK_REQUEST_RETRY)
         ).collect(Collectors.toSet());
 
-        // Set max request retry setting to 0 to avoid sleeping the thread during unit test failure cases
-        Settings testMaxRetrySetting = Settings.builder().put(MAX_GET_TASK_REQUEST_RETRY.getKey(), 0).build();
+        // Set max request retry setting to 1 to limit sleeping the thread to one retry iteration
+        Settings testMaxRetrySetting = Settings.builder().put(MAX_GET_TASK_REQUEST_RETRY.getKey(), 1).build();
         ClusterSettings clusterSettings = new ClusterSettings(testMaxRetrySetting, settingsSet);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
+        testThreadPool = new TestThreadPool(
+            RegisterLocalModelStepTests.class.getName(),
+            new FixedExecutorBuilder(
+                Settings.EMPTY,
+                PROVISION_THREAD_POOL,
+                OpenSearchExecutors.allocatedProcessors(Settings.EMPTY),
+                100,
+                FLOW_FRAMEWORK_THREAD_POOL_PREFIX + PROVISION_THREAD_POOL
+            )
+        );
         this.registerLocalModelStep = new RegisterLocalModelStep(
             testMaxRetrySetting,
+            testThreadPool,
             clusterService,
             machineLearningNodeClient,
             flowFrameworkIndicesHandler
@@ -101,6 +121,11 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
             "test-node-id"
         );
 
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        ThreadPool.terminate(testThreadPool, 500, TimeUnit.MILLISECONDS);
     }
 
     public void testRegisterLocalModelSuccess() throws Exception {
@@ -152,15 +177,14 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap()
         );
-        ;
+
+        future.join();
+
         verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
         verify(machineLearningNodeClient, times(1)).getTask(any(), any());
 
-        assertTrue(future.isDone());
-        assertFalse(future.isCompletedExceptionally());
         assertEquals(modelId, future.get().getContent().get(MODEL_ID));
         assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
-
     }
 
     public void testRegisterLocalModelFailure() {
@@ -177,8 +201,7 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap()
         );
-        assertTrue(future.isDone());
-        assertTrue(future.isCompletedExceptionally());
+
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("test", ex.getCause().getMessage());
@@ -227,12 +250,10 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap()
         );
-        assertTrue(future.isDone());
-        assertTrue(future.isCompletedExceptionally());
+
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Local model registration failed with error : " + testErrorMessage, ex.getCause().getMessage());
-
     }
 
     public void testMissingInputs() {

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
@@ -109,6 +109,7 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
                 Map.entry("name", "xyz"),
                 Map.entry("version", "1.0.0"),
                 Map.entry("description", "description"),
+                Map.entry("function_name", "SPARSE_TOKENIZE"),
                 Map.entry("model_format", "TORCH_SCRIPT"),
                 Map.entry(MODEL_GROUP_ID, "abcdefg"),
                 Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),


### PR DESCRIPTION
### Description

Refactors the `RetryableWorkflowStep` class:
 - runs the `getTask()` code in a loop instead of using recursion
 - uses an abstract method to allow the subclass to provide the needed ID method

### Issues Resolved

Fixes #277 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
