### PR TITLE
[2.x] Revert 2.x HttpClient to Apache HttpComponents / Core 4.x

### DIFF
--- a/src/test/java/org/opensearch/flowframework/TestHelpers.java
+++ b/src/test/java/org/opensearch/flowframework/TestHelpers.java
@@ -12,9 +12,9 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.google.common.io.Resources;
-import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.nio.entity.NStringEntity;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.opensearch.test.OpenSearchTestCase.randomAlphaOfLength;
-import static org.apache.hc.core5.http.ContentType.APPLICATION_JSON;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 
 public class TestHelpers {
 
@@ -74,7 +74,7 @@ public class TestHelpers {
         String jsonEntity,
         List<Header> headers
     ) throws IOException {
-        HttpEntity httpEntity = Strings.isBlank(jsonEntity) ? null : new StringEntity(jsonEntity, APPLICATION_JSON);
+        HttpEntity httpEntity = Strings.isBlank(jsonEntity) ? null : new NStringEntity(jsonEntity, APPLICATION_JSON);
         return makeRequest(client, method, endpoint, params, httpEntity, headers);
     }
 
@@ -117,11 +117,11 @@ public class TestHelpers {
     }
 
     public static HttpEntity toHttpEntity(ToXContentObject object) throws IOException {
-        return new StringEntity(toJsonString(object), APPLICATION_JSON);
+        return new NStringEntity(toJsonString(object), APPLICATION_JSON);
     }
 
     public static HttpEntity toHttpEntity(String jsonString) throws IOException {
-        return new StringEntity(jsonString, APPLICATION_JSON);
+        return new NStringEntity(jsonString, APPLICATION_JSON);
     }
 
     public static RestStatus restStatus(Response response) {


### PR DESCRIPTION
### Description

Fixes 2.x build following backport of integ tests #302 which relied on 3.x Http Client 5.

Most changes derived from reverse-diffing https://github.com/opensearch-project/opensearch-sdk-java/issues/345 or multiple other plugin PRs referencing https://github.com/opensearch-project/OpenSearch/issues/4256

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
