### PR TITLE
Add timeout for each workflow steps

### DIFF
--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -9,6 +9,8 @@
 package org.opensearch.flowframework;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -27,6 +29,7 @@ import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.model.WorkflowValidator;
 import org.opensearch.flowframework.rest.RestCreateWorkflowAction;
 import org.opensearch.flowframework.rest.RestDeleteWorkflowAction;
 import org.opensearch.flowframework.rest.RestDeprovisionWorkflowAction;
@@ -52,6 +55,7 @@ import org.opensearch.flowframework.transport.SearchWorkflowStateAction;
 import org.opensearch.flowframework.transport.SearchWorkflowStateTransportAction;
 import org.opensearch.flowframework.transport.SearchWorkflowTransportAction;
 import org.opensearch.flowframework.util.EncryptorUtils;
+import org.opensearch.flowframework.workflow.CreateIndexStep;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -66,6 +70,7 @@ import org.opensearch.threadpool.FixedExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;

--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -9,8 +9,6 @@
 package org.opensearch.flowframework;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -29,7 +27,6 @@ import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
-import org.opensearch.flowframework.model.WorkflowValidator;
 import org.opensearch.flowframework.rest.RestCreateWorkflowAction;
 import org.opensearch.flowframework.rest.RestDeleteWorkflowAction;
 import org.opensearch.flowframework.rest.RestDeprovisionWorkflowAction;
@@ -55,7 +52,6 @@ import org.opensearch.flowframework.transport.SearchWorkflowStateAction;
 import org.opensearch.flowframework.transport.SearchWorkflowStateTransportAction;
 import org.opensearch.flowframework.transport.SearchWorkflowTransportAction;
 import org.opensearch.flowframework.util.EncryptorUtils;
-import org.opensearch.flowframework.workflow.CreateIndexStep;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -70,7 +66,6 @@ import org.opensearch.threadpool.FixedExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -22,13 +22,13 @@ public class CommonValue {
     /** Schema Version field name */
     public static final String SCHEMA_VERSION_FIELD = "schema_version";
     /** Global Context Index Name */
-    public static final String GLOBAL_CONTEXT_INDEX = ".plugins-ai-global-context";
+    public static final String GLOBAL_CONTEXT_INDEX = ".plugins-flow-framework-templates";
     /** Global Context index mapping file path */
     public static final String GLOBAL_CONTEXT_INDEX_MAPPING = "mappings/global-context.json";
     /** Global Context index mapping version */
     public static final Integer GLOBAL_CONTEXT_INDEX_VERSION = 1;
     /** Workflow State Index Name */
-    public static final String WORKFLOW_STATE_INDEX = ".plugins-workflow-state";
+    public static final String WORKFLOW_STATE_INDEX = ".plugins-flow-framework-state";
     /** Workflow State index mapping file path */
     public static final String WORKFLOW_STATE_INDEX_MAPPING = "mappings/workflow-state.json";
     /** Workflow State index mapping version */

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.flowframework.model;
 
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_ORDER_FIELD;
 import static org.opensearch.flowframework.util.ParseUtils.buildStringToObjectMap;
@@ -50,7 +52,7 @@ public class WorkflowNode implements ToXContentObject {
     /** The field defining the timeout value for this node */
     public static final String NODE_TIMEOUT_FIELD = "node_timeout";
     /** The default timeout value if the template doesn't override it */
-    public static final String NODE_TIMEOUT_DEFAULT_VALUE = "10s";
+    public static final TimeValue NODE_TIMEOUT_DEFAULT_VALUE = new TimeValue(10, SECONDS);
 
     private final String id; // unique id
     private final String type; // maps to a WorkflowStep

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
@@ -50,7 +50,7 @@ public class WorkflowNode implements ToXContentObject {
     /** The field defining the timeout value for this node */
     public static final String NODE_TIMEOUT_FIELD = "node_timeout";
     /** The default timeout value if the template doesn't override it */
-    public static final String NODE_TIMEOUT_DEFAULT_VALUE = "15s";
+    public static final String NODE_TIMEOUT_DEFAULT_VALUE = "10s";
 
     private final String id; // unique id
     private final String type; // maps to a WorkflowStep

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowStepValidator.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowStepValidator.java
@@ -95,7 +95,7 @@ public class WorkflowStepValidator {
                     try {
                         timeout = TimeValue.parseTimeValue(parser.text(), TIMEOUT);
                     } catch (IllegalArgumentException e) {
-                        logger.error("Failed to parse TIMEOUT value for field [" + fieldName + "]", e);
+                        logger.error("Failed to parse TIMEOUT value for field [{}]", fieldName, e);
                         throw new FlowFrameworkException(
                             "Failed to parse workflow-step.json file for field [" + fieldName + "]",
                             RestStatus.INTERNAL_SERVER_ERROR

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowStepValidator.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowStepValidator.java
@@ -40,6 +40,7 @@ public class WorkflowStepValidator {
      * @param inputs the workflow step inputs
      * @param outputs the workflow step outputs
      * @param requiredPlugins the required plugins for this workflow step
+     * @param timeout the timeout for this workflow step
      */
     public WorkflowStepValidator(List<String> inputs, List<String> outputs, List<String> requiredPlugins, String timeout) {
         this.inputs = inputs;

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowStepValidator.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowStepValidator.java
@@ -27,21 +27,25 @@ public class WorkflowStepValidator {
     private static final String OUTPUTS_FIELD = "outputs";
     /** Required Plugins field name */
     private static final String REQUIRED_PLUGINS = "required_plugins";
+    /** Timeout field name */
+    private static final String TIMEOUT = "timeout";
 
     private List<String> inputs;
     private List<String> outputs;
     private List<String> requiredPlugins;
+    private String timeout;
 
     /**
-     * Intantiate the object representing a Workflow Step validator
+     * Instantiate the object representing a Workflow Step validator
      * @param inputs the workflow step inputs
      * @param outputs the workflow step outputs
      * @param requiredPlugins the required plugins for this workflow step
      */
-    public WorkflowStepValidator(List<String> inputs, List<String> outputs, List<String> requiredPlugins) {
+    public WorkflowStepValidator(List<String> inputs, List<String> outputs, List<String> requiredPlugins, String timeout) {
         this.inputs = inputs;
         this.outputs = outputs;
         this.requiredPlugins = requiredPlugins;
+        this.timeout = timeout;
     }
 
     /**
@@ -54,6 +58,7 @@ public class WorkflowStepValidator {
         List<String> parsedInputs = new ArrayList<>();
         List<String> parsedOutputs = new ArrayList<>();
         List<String> requiredPlugins = new ArrayList<>();
+        String timeout = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -78,11 +83,14 @@ public class WorkflowStepValidator {
                         requiredPlugins.add(parser.text());
                     }
                     break;
+                case TIMEOUT:
+                    timeout = parser.text();
+                    break;
                 default:
                     throw new IOException("Unable to parse field [" + fieldName + "] in a WorkflowStepValidator object.");
             }
         }
-        return new WorkflowStepValidator(parsedInputs, parsedOutputs, requiredPlugins);
+        return new WorkflowStepValidator(parsedInputs, parsedOutputs, requiredPlugins, timeout);
     }
 
     /**
@@ -103,9 +111,17 @@ public class WorkflowStepValidator {
 
     /**
      * Get the required plugins
-     * @return the outputs
+     * @return the required plugins
      */
     public List<String> getRequiredPlugins() {
         return List.copyOf(requiredPlugins);
+    }
+
+    /**
+     * Get the timeout
+     * @return the timeout
+     */
+    public String getTimeout() {
+        return timeout;
     }
 }

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -141,7 +141,7 @@ public class WorkflowProcessSorter {
      * @throws Exception if validation fails
      */
     public void validate(List<ProcessNode> processNodes) throws Exception {
-        WorkflowValidator validator = readWorkflowValidator(processNodes.get(0).id());
+        WorkflowValidator validator = readWorkflowValidator();
         validatePluginsInstalled(processNodes, validator);
         validateGraph(processNodes, validator);
     }
@@ -246,13 +246,13 @@ public class WorkflowProcessSorter {
         }
     }
 
-    private WorkflowValidator readWorkflowValidator(String workflowId) {
+    private WorkflowValidator readWorkflowValidator() {
         try {
             return WorkflowValidator.parse("mappings/workflow-steps.json");
         } catch (Exception e) {
-            logger.error("Failed to read workflow-steps mapping file", e);
+            logger.error("Failed at reading workflow-steps mapping file", e);
             throw new FlowFrameworkException(
-                "Workflow " + workflowId + " failed at reading workflow-steps mapping file",
+                "Failed at reading workflow-steps.json mapping file for a new workflow.",
                 RestStatus.INTERNAL_SERVER_ERROR
             );
         }
@@ -262,11 +262,11 @@ public class WorkflowProcessSorter {
      * A method for parsing workflow timeout value.
      * The value could be parsed from node NODE_TIMEOUT_FIELD, the timeout field in workflow-step.json,
      * or the default NODE_TIMEOUT_DEFAULT_VALUE
-     * @param node the workflow nde
+     * @param node the workflow node
      * @return the timeout value
      */
     protected TimeValue parseTimeout(WorkflowNode node) {
-        WorkflowValidator validator = readWorkflowValidator(node.id());
+        WorkflowValidator validator = readWorkflowValidator();
         TimeValue nodeTimeoutValue = Optional.ofNullable(validator.getWorkflowStepValidators().get(node.type()).getTimeout())
             .orElse(NODE_TIMEOUT_DEFAULT_VALUE);
         String nodeTimeoutAsString = nodeTimeoutValue.getSeconds() + "s";

--- a/src/main/resources/mappings/workflow-steps.json
+++ b/src/main/resources/mappings/workflow-steps.json
@@ -12,8 +12,7 @@
         "outputs":[
             "index_name"
         ],
-        "required_plugins":[],
-        "timeout": "10s"
+        "required_plugins":[]
     },
     "create_ingest_pipeline": {
         "inputs":[
@@ -27,8 +26,7 @@
         "outputs":[
             "pipeline_id"
         ],
-        "required_plugins":[],
-        "timeout": "10s"
+        "required_plugins":[]
     },
     "create_connector": {
         "inputs":[
@@ -45,8 +43,7 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ],
-        "timeout": "10s"
+        ]
     },
     "delete_connector": {
         "inputs": [
@@ -57,8 +54,7 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ],
-        "timeout": "10s"
+        ]
     },
     "register_local_model": {
         "inputs":[
@@ -78,7 +74,7 @@
         "required_plugins":[
             "opensearch-ml"
         ],
-        "timeout": "10s"
+        "timeout": "60s"
     },
     "register_remote_model": {
         "inputs": [
@@ -92,8 +88,7 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ],
-        "timeout": "10s"
+        ]
     },
     "delete_model": {
         "inputs": [
@@ -104,8 +99,7 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ],
-        "timeout": "10s"
+        ]
     },
     "deploy_model": {
         "inputs":[
@@ -128,8 +122,7 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ],
-        "timeout": "10s"
+        ]
     },
     "register_model_group": {
         "inputs":[
@@ -141,8 +134,7 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ],
-        "timeout": "10s"
+        ]
     },
     "register_agent": {
         "inputs":[
@@ -160,8 +152,7 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ],
-        "timeout": "10s"
+        ]
     },
     "delete_agent": {
         "inputs": [
@@ -172,8 +163,7 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ],
-        "timeout": "10s"
+        ]
     },
     "create_tool": {
         "inputs": [
@@ -184,7 +174,6 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ],
-        "timeout": "10s"
+        ]
     }
 }

--- a/src/main/resources/mappings/workflow-steps.json
+++ b/src/main/resources/mappings/workflow-steps.json
@@ -12,7 +12,8 @@
         "outputs":[
             "index_name"
         ],
-        "required_plugins":[]
+        "required_plugins":[],
+        "timeout": "10s"
     },
     "create_ingest_pipeline": {
         "inputs":[
@@ -26,7 +27,8 @@
         "outputs":[
             "pipeline_id"
         ],
-        "required_plugins":[]
+        "required_plugins":[],
+        "timeout": "10s"
     },
     "create_connector": {
         "inputs":[
@@ -43,7 +45,8 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "10s"
     },
     "delete_connector": {
         "inputs": [
@@ -54,7 +57,8 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "10s"
     },
     "register_local_model": {
         "inputs":[
@@ -73,7 +77,8 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "10s"
     },
     "register_remote_model": {
         "inputs": [
@@ -87,7 +92,8 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "10s"
     },
     "delete_model": {
         "inputs": [
@@ -98,7 +104,8 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "10s"
     },
     "deploy_model": {
         "inputs":[
@@ -109,7 +116,8 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "15s"
     },
     "undeploy_model": {
         "inputs":[
@@ -120,7 +128,8 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "10s"
     },
     "register_model_group": {
         "inputs":[
@@ -132,7 +141,8 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "10s"
     },
     "register_agent": {
         "inputs":[
@@ -150,7 +160,8 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "10s"
     },
     "delete_agent": {
         "inputs": [
@@ -161,7 +172,8 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "10s"
     },
     "create_tool": {
         "inputs": [
@@ -172,6 +184,7 @@
         ],
         "required_plugins":[
             "opensearch-ml"
-        ]
+        ],
+        "timeout": "10s"
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -21,6 +21,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
@@ -508,5 +509,47 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             "The workflowStep create_connector requires the following plugins to be installed : [opensearch-ml]",
             exception.getMessage()
         );
+    }
+
+    public void testReadWorkflowStepFile_withDefaultTimeout() throws IOException {
+        // read timeout from node NODE_TIMEOUT_FIELD
+        WorkflowNode createConnector = new WorkflowNode(
+            "workflow_step_1",
+            CreateConnectorStep.NAME,
+            Map.of(),
+            Map.ofEntries(
+                Map.entry("name", ""),
+                Map.entry("description", ""),
+                Map.entry("version", ""),
+                Map.entry("protocol", ""),
+                Map.entry("parameters", ""),
+                Map.entry("credential", ""),
+                Map.entry("actions", ""),
+                Map.entry("node_timeout", "50s")
+            )
+        );
+        TimeValue createConnectorTimeout = workflowProcessSorter.parseTimeout(createConnector);
+        assertEquals(createConnectorTimeout.getSeconds(), 50);
+
+        // read timeout from workflow-step.json overwrite value
+        WorkflowNode deployModel = new WorkflowNode(
+            "workflow_step_3",
+            DeployModelStep.NAME,
+            Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
+            Map.of()
+        );
+        TimeValue deployModelTimeout = workflowProcessSorter.parseTimeout(deployModel);
+        assertEquals(deployModelTimeout.getSeconds(), 15);
+
+        // read timeout from NODE_TIMEOUT_DEFAULT_VALUE when there's no node NODE_TIMEOUT_FIELD
+        // and no overwrite timeout value in workflow-step.json
+        WorkflowNode registerModel = new WorkflowNode(
+            "workflow_step_2",
+            RegisterRemoteModelStep.NAME,
+            Map.ofEntries(Map.entry("workflow_step_1", "connector_id")),
+            Map.ofEntries(Map.entry("name", "name"), Map.entry("function_name", "remote"), Map.entry("description", "description"))
+        );
+        TimeValue registerRemoteModelTimeout = workflowProcessSorter.parseTimeout(registerModel);
+        assertEquals(registerRemoteModelTimeout.getSeconds(), 10);
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -136,7 +136,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         ProcessNode node = workflow.get(0);
         assertEquals("default_timeout", node.id());
         assertEquals(CreateIngestPipelineStep.class, node.workflowStep().getClass());
-        assertEquals(15, node.nodeTimeout().seconds());
+        assertEquals(10, node.nodeTimeout().seconds());
         node = workflow.get(1);
         assertEquals("custom_timeout", node.id());
         assertEquals(CreateIndexStep.class, node.workflowStep().getClass());
@@ -317,7 +317,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         workflowProcessSorter.validateGraph(sortedProcessNodes, validator);
     }
 
-    public void testFailedGraphValidation() {
+    public void testFailedGraphValidation() throws IOException {
 
         // Create Register Model workflow node with missing connector_id field
         WorkflowNode registerModel = new WorkflowNode(


### PR DESCRIPTION
### 12/26 revision:
- Change the system default `NODE_TIMEOUT_DEFAULT_VALUE` to `10s`
- Removed all `10s` timeout values in the workflow-step.json file, only leaving the timeout field for those workflow steps that require an overwrite timeout value other than `10s`.
For example, `register_local_model` has default timeout value as 60s, and `deploy_model` has default timeout value as 15s

- Do try catch at where we read `workflow-step.json` file instead of passing it up. 
- Add a new unit test case to cover all possible ways of how we parse `timeout` value

--------

### Description
This pr does two things:
- Having a specific timeout for all the workflow steps in workflow-steps.json
- rename indices:
 `.plugins-ai-global-context` -> `.plugins-flow-framework-templates`
 `.plugins-workflow-state` -> `.plugins-flow-framework-state`

### Issues Resolved
https://github.com/opensearch-project/flow-framework/issues/249

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
