### PR TITLE
Clean up miscellaneous code smells, eliminate most Guava use

### DIFF
--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework;
 
-import com.google.common.collect.ImmutableList;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -127,7 +126,7 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
             settings
         );
 
-        return ImmutableList.of(workflowStepFactory, workflowProcessSorter, encryptorUtils, flowFrameworkIndicesHandler);
+        return List.of(workflowStepFactory, workflowProcessSorter, encryptorUtils, flowFrameworkIndicesHandler);
     }
 
     @Override
@@ -140,7 +139,7 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        return ImmutableList.of(
+        return List.of(
             new RestCreateWorkflowAction(flowFrameworkFeatureEnabledSetting, settings, clusterService),
             new RestDeleteWorkflowAction(flowFrameworkFeatureEnabledSetting),
             new RestProvisionWorkflowAction(flowFrameworkFeatureEnabledSetting),
@@ -154,7 +153,7 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return ImmutableList.of(
+        return List.of(
             new ActionHandler<>(CreateWorkflowAction.INSTANCE, CreateWorkflowTransportAction.class),
             new ActionHandler<>(DeleteWorkflowAction.INSTANCE, DeleteWorkflowTransportAction.class),
             new ActionHandler<>(ProvisionWorkflowAction.INSTANCE, ProvisionWorkflowTransportAction.class),
@@ -168,20 +167,13 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public List<Setting<?>> getSettings() {
-        List<Setting<?>> settings = ImmutableList.of(
-            FLOW_FRAMEWORK_ENABLED,
-            MAX_WORKFLOWS,
-            MAX_WORKFLOW_STEPS,
-            WORKFLOW_REQUEST_TIMEOUT,
-            MAX_GET_TASK_REQUEST_RETRY
-        );
-        return settings;
+        return List.of(FLOW_FRAMEWORK_ENABLED, MAX_WORKFLOWS, MAX_WORKFLOW_STEPS, WORKFLOW_REQUEST_TIMEOUT, MAX_GET_TASK_REQUEST_RETRY);
     }
 
     @Override
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
         // TODO : Determine final size/queueSize values for the provision thread pool
-        return ImmutableList.of(
+        return List.of(
             new FixedExecutorBuilder(
                 settings,
                 PROVISION_THREAD_POOL,

--- a/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
+++ b/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
@@ -91,7 +91,7 @@ public enum WorkflowResources {
                 }
             }
         }
-        logger.error("Unable to find resource type for step: " + workflowStep);
+        logger.error("Unable to find resource type for step: {}", workflowStep);
         throw new FlowFrameworkException("Unable to find resource type for step: " + workflowStep, RestStatus.BAD_REQUEST);
     }
 
@@ -109,7 +109,7 @@ public enum WorkflowResources {
                 }
             }
         }
-        logger.error("Unable to find deprovision step for step: " + workflowStep);
+        logger.error("Unable to find deprovision step for step: {}", workflowStep);
         throw new FlowFrameworkException("Unable to find deprovision step for step: " + workflowStep, RestStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowValidator.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowValidator.java
@@ -8,13 +8,13 @@
  */
 package org.opensearch.flowframework.model;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.util.ParseUtils;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -63,7 +63,7 @@ public class WorkflowValidator {
      */
     public static WorkflowValidator parse(String file) throws IOException {
         URL url = WorkflowValidator.class.getClassLoader().getResource(file);
-        String json = Resources.toString(url, Charsets.UTF_8);
+        String json = Resources.toString(url, StandardCharsets.UTF_8);
         return parse(ParseUtils.jsonToParser(json));
     }
 

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.rest;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.node.NodeClient;
@@ -70,7 +69,7 @@ public class RestCreateWorkflowAction extends AbstractWorkflowAction {
 
     @Override
     public List<Route> routes() {
-        return ImmutableList.of(
+        return List.of(
             // Create new workflow
             new Route(RestRequest.Method.POST, String.format(Locale.ROOT, "%s", WORKFLOW_URI)),
             // Update use case template

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.rest;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -57,7 +56,7 @@ public class RestDeleteWorkflowAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return ImmutableList.of(new Route(RestRequest.Method.DELETE, String.format(Locale.ROOT, "%s/{%s}", WORKFLOW_URI, WORKFLOW_ID)));
+        return List.of(new Route(RestRequest.Method.DELETE, String.format(Locale.ROOT, "%s/{%s}", WORKFLOW_URI, WORKFLOW_ID)));
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.rest;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -101,7 +100,7 @@ public class RestDeprovisionWorkflowAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return ImmutableList.of(
+        return List.of(
             new Route(RestRequest.Method.POST, String.format(Locale.ROOT, "%s/{%s}/%s", WORKFLOW_URI, WORKFLOW_ID, "_deprovision"))
         );
     }

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.rest;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -57,7 +56,7 @@ public class RestGetWorkflowAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return ImmutableList.of(new Route(RestRequest.Method.GET, String.format(Locale.ROOT, "%s/{%s}", WORKFLOW_URI, WORKFLOW_ID)));
+        return List.of(new Route(RestRequest.Method.GET, String.format(Locale.ROOT, "%s/{%s}", WORKFLOW_URI, WORKFLOW_ID)));
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.rest;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -104,8 +103,6 @@ public class RestGetWorkflowStateAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return ImmutableList.of(
-            new Route(RestRequest.Method.GET, String.format(Locale.ROOT, "%s/{%s}/%s", WORKFLOW_URI, WORKFLOW_ID, "_status"))
-        );
+        return List.of(new Route(RestRequest.Method.GET, String.format(Locale.ROOT, "%s/{%s}/%s", WORKFLOW_URI, WORKFLOW_ID, "_status")));
     }
 }

--- a/src/main/java/org/opensearch/flowframework/rest/RestProvisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestProvisionWorkflowAction.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.rest;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.node.NodeClient;
@@ -59,7 +58,7 @@ public class RestProvisionWorkflowAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return ImmutableList.of(
+        return List.of(
             // Provision workflow from indexed use case template
             new Route(RestRequest.Method.POST, String.format(Locale.ROOT, "%s/{%s}/%s", WORKFLOW_URI, WORKFLOW_ID, "_provision"))
         );

--- a/src/main/java/org/opensearch/flowframework/rest/RestSearchWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestSearchWorkflowAction.java
@@ -8,10 +8,11 @@
  */
 package org.opensearch.flowframework.rest;
 
-import com.google.common.collect.ImmutableList;
 import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.transport.SearchWorkflowAction;
+
+import java.util.List;
 
 import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
@@ -31,7 +32,7 @@ public class RestSearchWorkflowAction extends AbstractSearchWorkflowAction<Templ
      */
     public RestSearchWorkflowAction(FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting) {
         super(
-            ImmutableList.of(SEARCH_WORKFLOW_PATH),
+            List.of(SEARCH_WORKFLOW_PATH),
             GLOBAL_CONTEXT_INDEX,
             Template.class,
             SearchWorkflowAction.INSTANCE,

--- a/src/main/java/org/opensearch/flowframework/rest/RestSearchWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestSearchWorkflowStateAction.java
@@ -8,10 +8,11 @@
  */
 package org.opensearch.flowframework.rest;
 
-import com.google.common.collect.ImmutableList;
 import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.flowframework.model.WorkflowState;
 import org.opensearch.flowframework.transport.SearchWorkflowStateAction;
+
+import java.util.List;
 
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
@@ -31,7 +32,7 @@ public class RestSearchWorkflowStateAction extends AbstractSearchWorkflowAction<
      */
     public RestSearchWorkflowStateAction(FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting) {
         super(
-            ImmutableList.of(SEARCH_WORKFLOW_STATE_PATH),
+            List.of(SEARCH_WORKFLOW_STATE_PATH),
             WORKFLOW_STATE_INDEX,
             WorkflowState.class,
             SearchWorkflowStateAction.INSTANCE,

--- a/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
@@ -58,7 +58,7 @@ public class DeleteWorkflowTransportAction extends HandledTransportAction<Workfl
             DeleteRequest deleteRequest = new DeleteRequest(GLOBAL_CONTEXT_INDEX, workflowId);
 
             ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext();
-            client.delete(deleteRequest, ActionListener.runBefore(listener, () -> context.restore()));
+            client.delete(deleteRequest, ActionListener.runBefore(listener, context::restore));
         } else {
             listener.onFailure(new FlowFrameworkException("There are no templates in the global context.", RestStatus.NOT_FOUND));
         }

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportAction.java
@@ -92,7 +92,7 @@ public class GetWorkflowStateTransportAction extends HandledTransportAction<GetW
                     logger.error("Failed to get workflow status of: " + workflowId, e);
                     listener.onFailure(new FlowFrameworkException("Failed to get workflow status of: " + workflowId, RestStatus.NOT_FOUND));
                 }
-            }), () -> context.restore()));
+            }), context::restore));
         } catch (Exception e) {
             logger.error("Failed to get workflow: " + workflowId, e);
             listener.onFailure(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.transport;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -38,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -126,15 +126,11 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
 
                 flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(
                     workflowId,
-                    ImmutableMap.of(
-                        STATE_FIELD,
-                        State.PROVISIONING,
-                        PROVISIONING_PROGRESS_FIELD,
-                        ProvisioningProgress.IN_PROGRESS,
-                        PROVISION_START_TIME_FIELD,
-                        Instant.now().toEpochMilli(),
-                        RESOURCES_CREATED_FIELD,
-                        Collections.emptyList()
+                    Map.ofEntries(
+                        Map.entry(STATE_FIELD, State.PROVISIONING),
+                        Map.entry(PROVISIONING_PROGRESS_FIELD, ProvisioningProgress.IN_PROGRESS),
+                        Map.entry(PROVISION_START_TIME_FIELD, Instant.now().toEpochMilli()),
+                        Map.entry(RESOURCES_CREATED_FIELD, Collections.emptyList())
                     ),
                     ActionListener.wrap(updateResponse -> {
                         logger.info("updated workflow {} state to PROVISIONING", request.getWorkflowId());
@@ -206,13 +202,10 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
             logger.info("Provisioning completed successfully for workflow {}", workflowId);
             flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(
                 workflowId,
-                ImmutableMap.of(
-                    STATE_FIELD,
-                    State.COMPLETED,
-                    PROVISIONING_PROGRESS_FIELD,
-                    ProvisioningProgress.DONE,
-                    PROVISION_END_TIME_FIELD,
-                    Instant.now().toEpochMilli()
+                Map.ofEntries(
+                    Map.entry(STATE_FIELD, State.COMPLETED),
+                    Map.entry(PROVISIONING_PROGRESS_FIELD, ProvisioningProgress.DONE),
+                    Map.entry(PROVISION_END_TIME_FIELD, Instant.now().toEpochMilli())
                 ),
                 ActionListener.wrap(updateResponse -> {
                     logger.info("updated workflow {} state to {}", workflowId, State.COMPLETED);
@@ -222,15 +215,12 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
             logger.error("Provisioning failed for workflow: {}", workflowId, ex);
             flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(
                 workflowId,
-                ImmutableMap.of(
-                    STATE_FIELD,
-                    State.FAILED,
-                    ERROR_FIELD,
-                    ex.getMessage(), // TODO: potentially improve the error message here
-                    PROVISIONING_PROGRESS_FIELD,
-                    ProvisioningProgress.FAILED,
-                    PROVISION_END_TIME_FIELD,
-                    Instant.now().toEpochMilli()
+                Map.ofEntries(
+                    Map.entry(STATE_FIELD, State.FAILED),
+                    // TODO: potentially improve the error message here
+                    Map.entry(ERROR_FIELD, ex.getMessage()),
+                    Map.entry(PROVISIONING_PROGRESS_FIELD, ProvisioningProgress.FAILED),
+                    Map.entry(PROVISION_END_TIME_FIELD, Instant.now().toEpochMilli())
                 ),
                 ActionListener.wrap(updateResponse -> {
                     logger.info("updated workflow {} state to {}", workflowId, State.FAILED);

--- a/src/main/java/org/opensearch/flowframework/transport/SearchWorkflowStateTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/SearchWorkflowStateTransportAction.java
@@ -42,7 +42,7 @@ public class SearchWorkflowStateTransportAction extends HandledTransportAction<S
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> actionListener) {
         // TODO: AccessController should take care of letting the user with right permission to view the workflow
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            client.search(request, ActionListener.runBefore(actionListener, () -> context.restore()));
+            client.search(request, ActionListener.runBefore(actionListener, context::restore));
         } catch (Exception e) {
             actionListener.onFailure(e);
         }

--- a/src/main/java/org/opensearch/flowframework/transport/SearchWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/SearchWorkflowTransportAction.java
@@ -41,7 +41,7 @@ public class SearchWorkflowTransportAction extends HandledTransportAction<Search
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> actionListener) {
         // TODO: AccessController should take care of letting the user with right permission to view the workflow
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            client.search(request, ActionListener.runBefore(actionListener, () -> context.restore()));
+            client.search(request, ActionListener.runBefore(actionListener, context::restore));
         } catch (Exception e) {
             actionListener.onFailure(e);
         }

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -46,7 +46,7 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
      * @param mlClient machine learning client
      * @param flowFrameworkIndicesHandler FlowFrameworkIndicesHandler class to update system indices
      */
-    public AbstractRetryableWorkflowStep(
+    protected AbstractRetryableWorkflowStep(
         Settings settings,
         ClusterService clusterService,
         MachineLearningNodeClient mlClient,
@@ -67,7 +67,7 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
      * @param retries the current number of request retries
      * @param workflowStep the workflow step which requires a retry get ml task functionality
      */
-    void retryableGetMlTask(
+    protected void retryableGetMlTask(
         String workflowId,
         String nodeId,
         CompletableFuture<WorkflowData> future,

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -23,7 +23,6 @@ import org.opensearch.ml.common.connector.ConnectorAction.ActionType;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
 
-import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -75,7 +74,7 @@ public class CreateConnectorStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
-    ) throws IOException {
+    ) {
         CompletableFuture<WorkflowData> createConnectorFuture = new CompletableFuture<>();
 
         ActionListener<MLCreateConnectorResponse> actionListener = new ActionListener<>() {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
@@ -17,7 +17,6 @@ import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -50,7 +49,7 @@ public class DeleteAgentStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
-    ) throws IOException {
+    ) {
         CompletableFuture<WorkflowData> deleteAgentFuture = new CompletableFuture<>();
 
         ActionListener<DeleteResponse> actionListener = new ActionListener<>() {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
@@ -17,7 +17,6 @@ import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -50,7 +49,7 @@ public class DeleteConnectorStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
-    ) throws IOException {
+    ) {
         CompletableFuture<WorkflowData> deleteConnectorFuture = new CompletableFuture<>();
 
         ActionListener<DeleteResponse> actionListener = new ActionListener<>() {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
@@ -17,7 +17,6 @@ import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -50,7 +49,7 @@ public class DeleteModelStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
-    ) throws IOException {
+    ) {
         CompletableFuture<WorkflowData> deleteModelFuture = new CompletableFuture<>();
 
         ActionListener<DeleteResponse> actionListener = new ActionListener<>() {

--- a/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
@@ -23,7 +23,7 @@ import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput.MLRegisterModelGroupInputBuilder;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupResponse;
 
-import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,8 +65,7 @@ public class ModelGroupStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
-    ) throws IOException {
-
+    ) {
         CompletableFuture<WorkflowData> registerModelGroupFuture = new CompletableFuture<>();
 
         ActionListener<MLRegisterModelGroupResponse> actionListener = new ActionListener<>() {
@@ -164,6 +163,6 @@ public class ModelGroupStep implements WorkflowStep {
         if (content.containsKey(BACKEND_ROLES_FIELD)) {
             return (List<String>) content.get(BACKEND_ROLES_FIELD);
         }
-        return null;
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/org/opensearch/flowframework/workflow/NoOpStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/NoOpStep.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.workflow;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -29,7 +28,7 @@ public class NoOpStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
-    ) throws IOException {
+    ) {
         return CompletableFuture.completedFuture(WorkflowData.EMPTY);
     }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -26,7 +26,6 @@ import org.opensearch.ml.common.agent.MLMemorySpec;
 import org.opensearch.ml.common.agent.MLToolSpec;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentResponse;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,7 +81,7 @@ public class RegisterAgentStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
-    ) throws IOException {
+    ) {
 
         String workflowId = currentNodeInputs.getWorkflowId();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
@@ -14,7 +14,6 @@ import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.common.agent.MLToolSpec;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -44,8 +43,7 @@ public class ToolStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
-    ) throws IOException {
-
+    ) {
         Set<String> requiredKeys = Set.of(TYPE);
         Set<String> optionalKeys = Set.of(NAME_FIELD, DESCRIPTION_FIELD, PARAMETERS_FIELD, INCLUDE_OUTPUT_IN_AGENT_RESPONSE);
 

--- a/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
@@ -19,7 +19,6 @@ import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.transport.undeploy.MLUndeployModelsResponse;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +54,7 @@ public class UndeployModelStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
-    ) throws IOException {
+    ) {
         CompletableFuture<WorkflowData> undeployModelFuture = new CompletableFuture<>();
 
         ActionListener<MLUndeployModelsResponse> actionListener = new ActionListener<>() {

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.workflow;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -24,14 +23,13 @@ public interface WorkflowStep {
      * @param outputs WorkflowData content of previous steps.
      * @param previousNodeInputs Input params for this node that come from previous steps
      * @return A CompletableFuture of the building block. This block should return immediately, but not be completed until the step executes, containing either the step's output data or {@link WorkflowData#EMPTY} which may be passed to follow-on steps.
-     * @throws IOException on a failure.
      */
     CompletableFuture<WorkflowData> execute(
         String currentNodeId,
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
-    ) throws IOException;
+    );
 
     /**
      * Gets the name of the workflow step.

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -8,8 +8,6 @@
  */
 package org.opensearch.flowframework;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
@@ -95,7 +93,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
                 "_cluster/settings",
                 null,
                 "{\"transient\":{\"plugins.flow_framework.enabled\":true}}",
-                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+                List.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
             );
             assertEquals(200, response.getStatusLine().getStatusCode());
 
@@ -106,7 +104,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
                 "_cluster/settings",
                 null,
                 "{\"persistent\":{\"plugins.ml_commons.only_run_on_ml_node\":false}}",
-                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+                List.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
             );
             assertEquals(200, response.getStatusLine().getStatusCode());
 
@@ -117,7 +115,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
                 "_cluster/settings",
                 null,
                 "{\"persistent\":{\"plugins.ml_commons.allow_registering_model_via_url\":true}}",
-                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+                List.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
             );
             assertEquals(200, response.getStatusLine().getStatusCode());
 
@@ -316,11 +314,11 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
      * @return a rest response
      */
     protected Response createWorkflow(Template template) throws Exception {
-        return TestHelpers.makeRequest(client(), "POST", WORKFLOW_URI, ImmutableMap.of(), template.toJson(), null);
+        return TestHelpers.makeRequest(client(), "POST", WORKFLOW_URI, Collections.emptyMap(), template.toJson(), null);
     }
 
     protected Response createWorkflowWithProvision(Template template) throws Exception {
-        return TestHelpers.makeRequest(client(), "POST", WORKFLOW_URI + "?provision=true", ImmutableMap.of(), template.toJson(), null);
+        return TestHelpers.makeRequest(client(), "POST", WORKFLOW_URI + "?provision=true", Collections.emptyMap(), template.toJson(), null);
     }
 
     /**
@@ -330,7 +328,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
      * @return a rest response
      */
     protected Response createWorkflowValidation(Template template) throws Exception {
-        return TestHelpers.makeRequest(client(), "POST", WORKFLOW_URI, ImmutableMap.of(), template.toJson(), null);
+        return TestHelpers.makeRequest(client(), "POST", WORKFLOW_URI, Collections.emptyMap(), template.toJson(), null);
     }
 
     /**
@@ -345,7 +343,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
             client(),
             "PUT",
             String.format(Locale.ROOT, "%s/%s", WORKFLOW_URI, workflowId),
-            ImmutableMap.of(),
+            Collections.emptyMap(),
             template.toJson(),
             null
         );
@@ -362,7 +360,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
             client(),
             "POST",
             String.format(Locale.ROOT, "%s/%s/%s", WORKFLOW_URI, workflowId, "_provision"),
-            ImmutableMap.of(),
+            Collections.emptyMap(),
             "",
             null
         );
@@ -379,7 +377,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
             client(),
             "POST",
             String.format(Locale.ROOT, "%s/%s/%s", WORKFLOW_URI, workflowId, "_deprovision"),
-            ImmutableMap.of(),
+            Collections.emptyMap(),
             "",
             null
         );
@@ -396,7 +394,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
             client(),
             "DELETE",
             String.format(Locale.ROOT, "%s/%s", WORKFLOW_URI, workflowId),
-            ImmutableMap.of(),
+            Collections.emptyMap(),
             "",
             null
         );
@@ -414,7 +412,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
             client(),
             "GET",
             String.format(Locale.ROOT, "%s/%s/%s?all=%s", WORKFLOW_URI, workflowId, "_status", all),
-            ImmutableMap.of(),
+            Collections.emptyMap(),
             "",
             null
         );
@@ -434,7 +432,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
             client(),
             "GET",
             String.format(Locale.ROOT, "%s/_search", WORKFLOW_URI),
-            ImmutableMap.of(),
+            Collections.emptyMap(),
             query,
             null
         );
@@ -459,7 +457,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
             client(),
             "GET",
             String.format(Locale.ROOT, "%s/state/_search", WORKFLOW_URI),
-            ImmutableMap.of(),
+            Collections.emptyMap(),
             query,
             null
         );

--- a/src/test/java/org/opensearch/flowframework/TestHelpers.java
+++ b/src/test/java/org/opensearch/flowframework/TestHelpers.java
@@ -8,9 +8,6 @@
  */
 package org.opensearch.flowframework;
 
-import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 import com.google.common.io.Resources;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
@@ -40,6 +37,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +52,7 @@ public class TestHelpers {
 
     public static Template createTemplateFromFile(String fileName) throws IOException {
         URL url = TestHelpers.class.getClassLoader().getResource("template/" + fileName);
-        String json = Resources.toString(url, Charsets.UTF_8);
+        String json = Resources.toString(url, StandardCharsets.UTF_8);
         return Template.parse(json);
     }
 
@@ -140,19 +139,12 @@ public class TestHelpers {
     }
 
     public static User randomUser() {
-        return new User(
-            randomAlphaOfLength(8),
-            ImmutableList.of(randomAlphaOfLength(10)),
-            ImmutableList.of("all_access"),
-            ImmutableList.of("attribute=test")
-        );
+        return new User(randomAlphaOfLength(8), List.of(randomAlphaOfLength(10)), List.of("all_access"), List.of("attribute=test"));
     }
 
     public static ClusterSettings clusterSetting(Settings settings, Setting<?>... setting) {
-        final Set<Setting<?>> settingsSet = Stream.concat(
-            ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(),
-            Sets.newHashSet(setting).stream()
-        ).collect(Collectors.toSet());
+        final Set<Setting<?>> settingsSet = Stream.concat(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(), Arrays.stream(setting))
+            .collect(Collectors.toSet());
         ClusterSettings clusterSettings = new ClusterSettings(settings, settingsSet);
         return clusterSettings;
     }

--- a/src/test/java/org/opensearch/flowframework/model/TemplateTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/TemplateTests.java
@@ -12,6 +12,7 @@ import org.opensearch.Version;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -29,8 +30,8 @@ public class TemplateTests extends OpenSearchTestCase {
     public void testTemplate() throws IOException {
         Version templateVersion = Version.fromString("1.2.3");
         List<Version> compatibilityVersion = List.of(Version.fromString("4.5.6"), Version.fromString("7.8.9"));
-        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Map.of(), Map.of("foo", "bar"));
-        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Map.of(), Map.of("baz", "qux"));
+        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Collections.emptyMap(), Map.of("foo", "bar"));
+        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Collections.emptyMap(), Map.of("baz", "qux"));
         WorkflowEdge edgeAB = new WorkflowEdge("A", "B");
         List<WorkflowNode> nodes = List.of(nodeA, nodeB);
         List<WorkflowEdge> edges = List.of(edgeAB);

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowNodeTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowNodeTests.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.model;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 public class WorkflowNodeTests extends OpenSearchTestCase {
@@ -52,7 +53,7 @@ public class WorkflowNodeTests extends OpenSearchTestCase {
         assertArrayEquals(new String[] { "foo", "bar" }, (String[]) map.get("tools_order"));
 
         // node equality is based only on ID
-        WorkflowNode nodeA2 = new WorkflowNode("A", "a2-type", Map.of(), Map.of("bar", "baz"));
+        WorkflowNode nodeA2 = new WorkflowNode("A", "a2-type", Collections.emptyMap(), Map.of("bar", "baz"));
         assertEquals(nodeA, nodeA2);
 
         WorkflowNode nodeB = new WorkflowNode("B", "b-type", Map.of("A", "foo"), Map.of("baz", "qux"));

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowTests.java
@@ -12,6 +12,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +24,7 @@ public class WorkflowTests extends OpenSearchTestCase {
     }
 
     public void testWorkflow() throws IOException {
-        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Map.of(), Map.of("foo", "bar"));
+        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Collections.emptyMap(), Map.of("foo", "bar"));
         WorkflowNode nodeB = new WorkflowNode("B", "b-type", Map.of("A", "foo"), Map.of("baz", "qux"));
         WorkflowEdge edgeAB = new WorkflowEdge("A", "B");
         List<WorkflowNode> nodes = List.of(nodeA, nodeB);

--- a/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
@@ -29,6 +29,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.rest.FakeRestChannel;
 import org.opensearch.test.rest.FakeRestRequest;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -67,8 +68,8 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
 
         Version templateVersion = Version.fromString("1.0.0");
         List<Version> compatibilityVersions = List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0"));
-        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Map.of(), Map.of("foo", "bar"));
-        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Map.of(), Map.of("baz", "qux"));
+        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Collections.emptyMap(), Map.of("foo", "bar"));
+        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Collections.emptyMap(), Map.of("baz", "qux"));
         WorkflowEdge edgeAB = new WorkflowEdge("A", "B");
         List<WorkflowNode> nodes = List.of(nodeA, nodeB);
         List<WorkflowEdge> edges = List.of(edgeAB);
@@ -81,7 +82,7 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
             templateVersion,
             compatibilityVersions,
             Map.of("workflow", workflow),
-            Map.of(),
+            Collections.emptyMap(),
             TestHelpers.randomUser()
         );
 

--- a/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
@@ -34,6 +34,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -119,8 +120,8 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
 
         Version templateVersion = Version.fromString("1.0.0");
         List<Version> compatibilityVersions = List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0"));
-        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Map.of(), Map.of("foo", "bar"));
-        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Map.of(), Map.of("baz", "qux"));
+        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Collections.emptyMap(), Map.of("foo", "bar"));
+        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Collections.emptyMap(), Map.of("baz", "qux"));
         WorkflowEdge edgeAB = new WorkflowEdge("A", "B");
         List<WorkflowNode> nodes = List.of(nodeA, nodeB);
         List<WorkflowEdge> edges = List.of(edgeAB);
@@ -133,7 +134,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             templateVersion,
             compatibilityVersions,
             Map.of("workflow", workflow),
-            Map.of(),
+            Collections.emptyMap(),
             TestHelpers.randomUser()
         );
     }
@@ -152,7 +153,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         WorkflowNode createConnector = new WorkflowNode(
             "workflow_step_1",
             "create_connector",
-            Map.of(),
+            Collections.emptyMap(),
             Map.ofEntries(
                 Map.entry("name", ""),
                 Map.entry("description", ""),
@@ -175,7 +176,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             "workflow_step_3",
             "deploy_model",
             Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
-            Map.of()
+            Collections.emptyMap()
         );
 
         WorkflowEdge edge1 = new WorkflowEdge(createConnector.id(), registerModel.id());
@@ -183,7 +184,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         WorkflowEdge cyclicalEdge = new WorkflowEdge(deployModel.id(), createConnector.id());
 
         Workflow workflow = new Workflow(
-            Map.of(),
+            Collections.emptyMap(),
             List.of(createConnector, registerModel, deployModel),
             List.of(edge1, edge2, cyclicalEdge)
         );
@@ -195,7 +196,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             Version.fromString("1.0.0"),
             List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0")),
             Map.of("workflow", workflow),
-            Map.of(),
+            Collections.emptyMap(),
             TestHelpers.randomUser()
         );
 
@@ -497,7 +498,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         WorkflowNode createConnector = new WorkflowNode(
             "workflow_step_1",
             WorkflowResources.CREATE_CONNECTOR.getWorkflowStep(),
-            Map.of(),
+            Collections.emptyMap(),
             Map.ofEntries(
                 Map.entry("name", ""),
                 Map.entry("description", ""),
@@ -518,13 +519,17 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             "workflow_step_3",
             WorkflowResources.DEPLOY_MODEL.getWorkflowStep(),
             Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
-            Map.of()
+            Collections.emptyMap()
         );
 
         WorkflowEdge edge1 = new WorkflowEdge(createConnector.id(), registerModel.id());
         WorkflowEdge edge2 = new WorkflowEdge(registerModel.id(), deployModel.id());
 
-        Workflow workflow = new Workflow(Map.of(), List.of(createConnector, registerModel, deployModel), List.of(edge1, edge2));
+        Workflow workflow = new Workflow(
+            Collections.emptyMap(),
+            List.of(createConnector, registerModel, deployModel),
+            List.of(edge1, edge2)
+        );
 
         Template validTemplate = new Template(
             "test",
@@ -533,7 +538,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             Version.fromString("1.0.0"),
             List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0")),
             Map.of("workflow", workflow),
-            Map.of(),
+            Collections.emptyMap(),
             TestHelpers.randomUser()
         );
 

--- a/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
@@ -106,7 +106,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
             templateVersion,
             compatibilityVersions,
             Map.of(PROVISION_WORKFLOW, workflow),
-            Map.of(),
+            Collections.emptyMap(),
             TestHelpers.randomUser()
         );
         this.getResult = mock(GetResult.class);

--- a/src/test/java/org/opensearch/flowframework/transport/GetWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/GetWorkflowTransportActionTests.java
@@ -31,6 +31,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -68,8 +69,8 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
 
         Version templateVersion = Version.fromString("1.0.0");
         List<Version> compatibilityVersions = List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0"));
-        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Map.of(), Map.of("foo", "bar"));
-        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Map.of(), Map.of("baz", "qux"));
+        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Collections.emptyMap(), Map.of("foo", "bar"));
+        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Collections.emptyMap(), Map.of("baz", "qux"));
         WorkflowEdge edgeAB = new WorkflowEdge("A", "B");
         List<WorkflowNode> nodes = List.of(nodeA, nodeB);
         List<WorkflowEdge> edges = List.of(edgeAB);
@@ -82,7 +83,7 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
             templateVersion,
             compatibilityVersions,
             Map.of("provision", workflow),
-            Map.of(),
+            Collections.emptyMap(),
             TestHelpers.randomUser()
         );
 

--- a/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
@@ -34,6 +34,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -78,8 +79,8 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
 
         Version templateVersion = Version.fromString("1.0.0");
         List<Version> compatibilityVersions = List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0"));
-        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Map.of(), Map.of("foo", "bar"));
-        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Map.of(), Map.of("baz", "qux"));
+        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Collections.emptyMap(), Map.of("foo", "bar"));
+        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Collections.emptyMap(), Map.of("baz", "qux"));
         WorkflowEdge edgeAB = new WorkflowEdge("A", "B");
         List<WorkflowNode> nodes = List.of(nodeA, nodeB);
         List<WorkflowEdge> edges = List.of(edgeAB);
@@ -92,7 +93,7 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
             templateVersion,
             compatibilityVersions,
             Map.of("provision", workflow),
-            Map.of(),
+            Collections.emptyMap(),
             TestHelpers.randomUser()
         );
 

--- a/src/test/java/org/opensearch/flowframework/transport/WorkflowRequestResponseTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/WorkflowRequestResponseTests.java
@@ -24,6 +24,7 @@ import org.opensearch.flowframework.model.WorkflowNode;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -36,8 +37,8 @@ public class WorkflowRequestResponseTests extends OpenSearchTestCase {
         super.setUp();
         Version templateVersion = Version.fromString("1.0.0");
         List<Version> compatibilityVersions = List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0"));
-        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Map.of(), Map.of("foo", "bar"));
-        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Map.of(), Map.of("baz", "qux"));
+        WorkflowNode nodeA = new WorkflowNode("A", "a-type", Collections.emptyMap(), Map.of("foo", "bar"));
+        WorkflowNode nodeB = new WorkflowNode("B", "b-type", Collections.emptyMap(), Map.of("baz", "qux"));
         WorkflowEdge edgeAB = new WorkflowEdge("A", "B");
         List<WorkflowNode> nodes = List.of(nodeA, nodeB);
         List<WorkflowEdge> edges = List.of(edgeAB);
@@ -50,7 +51,7 @@ public class WorkflowRequestResponseTests extends OpenSearchTestCase {
             templateVersion,
             compatibilityVersions,
             Map.of("workflow", workflow),
-            Map.of(),
+            Collections.emptyMap(),
             TestHelpers.randomUser()
         );
     }

--- a/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.util;
 
-import com.google.common.collect.ImmutableMap;
 import org.opensearch.Version;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
@@ -27,6 +26,7 @@ import org.opensearch.flowframework.model.WorkflowNode;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -63,11 +63,11 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
         WorkflowNode nodeA = new WorkflowNode(
             "A",
             "a-type",
-            Map.of(),
+            Collections.emptyMap(),
             Map.of(CREDENTIAL_FIELD, Map.of(testCredentialKey, testCredentialValue))
         );
         List<WorkflowNode> nodes = List.of(nodeA);
-        Workflow workflow = new Workflow(Map.of("key", "value"), nodes, List.of());
+        Workflow workflow = new Workflow(Map.of("key", "value"), nodes, Collections.emptyList());
 
         this.testTemplate = new Template(
             "test",
@@ -76,7 +76,7 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
             templateVersion,
             compatibilityVersions,
             Map.of("provision", workflow),
-            Map.of(),
+            Collections.emptyMap(),
             TestHelpers.randomUser()
         );
 
@@ -132,7 +132,7 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
             // Stub get response for success case
             GetResponse getResponse = mock(GetResponse.class);
             when(getResponse.isExists()).thenReturn(true);
-            when(getResponse.getSourceAsMap()).thenReturn(ImmutableMap.of(MASTER_KEY, masterKey));
+            when(getResponse.getSourceAsMap()).thenReturn(Map.of(MASTER_KEY, masterKey));
 
             getRequestActionListener.onResponse(getResponse);
             return null;

--- a/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.workflow;
 
-import com.google.common.collect.ImmutableList;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
@@ -24,6 +23,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -58,7 +58,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
             Map.ofEntries(
                 Map.entry("name", "test"),
                 Map.entry("description", "description"),
-                Map.entry("backend_roles", ImmutableList.of("role-1")),
+                Map.entry("backend_roles", List.of("role-1")),
                 Map.entry("access_mode", AccessMode.PUBLIC),
                 Map.entry("add_all_backend_roles", false)
             ),

--- a/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
@@ -72,7 +72,7 @@ public class ProcessNodeTests extends OpenSearchTestCase {
                 return "test";
             }
         },
-            Map.of(),
+            Collections.emptyMap(),
             new WorkflowData(Map.of("test", "input"), Map.of("foo", "bar"), "test-id", "test-node-id"),
             List.of(successfulNode),
             testThreadPool,
@@ -116,7 +116,7 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             public String getName() {
                 return "test";
             }
-        }, Map.of(), WorkflowData.EMPTY, Collections.emptyList(), testThreadPool, TimeValue.timeValueMillis(250));
+        }, Collections.emptyMap(), WorkflowData.EMPTY, Collections.emptyList(), testThreadPool, TimeValue.timeValueMillis(250));
         assertEquals("B", nodeB.id());
         assertEquals("test", nodeB.workflowStep().getName());
         assertEquals(WorkflowData.EMPTY, nodeB.input());
@@ -147,7 +147,7 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             public String getName() {
                 return "sleepy";
             }
-        }, Map.of(), WorkflowData.EMPTY, Collections.emptyList(), testThreadPool, TimeValue.timeValueMillis(100));
+        }, Collections.emptyMap(), WorkflowData.EMPTY, Collections.emptyList(), testThreadPool, TimeValue.timeValueMillis(100));
         assertEquals("Zzz", nodeZ.id());
         assertEquals("sleepy", nodeZ.workflowStep().getName());
         assertEquals(WorkflowData.EMPTY, nodeZ.input());
@@ -179,7 +179,7 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             public String getName() {
                 return "test";
             }
-        }, Map.of(), WorkflowData.EMPTY, List.of(successfulNode, failedNode), testThreadPool, TimeValue.timeValueSeconds(15));
+        }, Collections.emptyMap(), WorkflowData.EMPTY, List.of(successfulNode, failedNode), testThreadPool, TimeValue.timeValueSeconds(15));
         assertEquals("E", nodeE.id());
         assertEquals("test", nodeE.workflowStep().getName());
         assertEquals(WorkflowData.EMPTY, nodeE.input());

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -284,7 +284,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         WorkflowNode createConnector = new WorkflowNode(
             "workflow_step_1",
             CreateConnectorStep.NAME,
-            Map.of(),
+            Collections.emptyMap(),
             Map.ofEntries(
                 Map.entry("name", ""),
                 Map.entry("description", ""),
@@ -305,13 +305,17 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             "workflow_step_3",
             DeployModelStep.NAME,
             Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
-            Map.of()
+            Collections.emptyMap()
         );
 
         WorkflowEdge edge1 = new WorkflowEdge(createConnector.id(), registerModel.id());
         WorkflowEdge edge2 = new WorkflowEdge(registerModel.id(), deployModel.id());
 
-        Workflow workflow = new Workflow(Map.of(), List.of(createConnector, registerModel, deployModel), List.of(edge1, edge2));
+        Workflow workflow = new Workflow(
+            Collections.emptyMap(),
+            List.of(createConnector, registerModel, deployModel),
+            List.of(edge1, edge2)
+        );
 
         List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123");
         workflowProcessSorter.validateGraph(sortedProcessNodes, validator);
@@ -323,17 +327,17 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         WorkflowNode registerModel = new WorkflowNode(
             "workflow_step_1",
             RegisterRemoteModelStep.NAME,
-            Map.of(),
+            Collections.emptyMap(),
             Map.ofEntries(Map.entry("name", "name"), Map.entry("function_name", "remote"), Map.entry("description", "description"))
         );
         WorkflowNode deployModel = new WorkflowNode(
             "workflow_step_2",
             DeployModelStep.NAME,
             Map.ofEntries(Map.entry("workflow_step_1", "model_id")),
-            Map.of()
+            Collections.emptyMap()
         );
         WorkflowEdge edge = new WorkflowEdge(registerModel.id(), deployModel.id());
-        Workflow workflow = new Workflow(Map.of(), List.of(registerModel, deployModel), List.of(edge));
+        Workflow workflow = new Workflow(Collections.emptyMap(), List.of(registerModel, deployModel), List.of(edge));
 
         List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123");
         FlowFrameworkException ex = expectThrows(
@@ -391,7 +395,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         WorkflowNode createConnector = new WorkflowNode(
             "workflow_step_1",
             CreateConnectorStep.NAME,
-            Map.of(),
+            Collections.emptyMap(),
             Map.ofEntries(
                 Map.entry("name", ""),
                 Map.entry("description", ""),
@@ -412,13 +416,17 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             "workflow_step_3",
             DeployModelStep.NAME,
             Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
-            Map.of()
+            Collections.emptyMap()
         );
 
         WorkflowEdge edge1 = new WorkflowEdge(createConnector.id(), registerModel.id());
         WorkflowEdge edge2 = new WorkflowEdge(registerModel.id(), deployModel.id());
 
-        Workflow workflow = new Workflow(Map.of(), List.of(createConnector, registerModel, deployModel), List.of(edge1, edge2));
+        Workflow workflow = new Workflow(
+            Collections.emptyMap(),
+            List.of(createConnector, registerModel, deployModel),
+            List.of(edge1, edge2)
+        );
         List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123");
 
         workflowProcessSorter.validatePluginsInstalled(sortedProcessNodes, validator);
@@ -469,7 +477,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         WorkflowNode createConnector = new WorkflowNode(
             "workflow_step_1",
             CreateConnectorStep.NAME,
-            Map.of(),
+            Collections.emptyMap(),
             Map.ofEntries(
                 Map.entry("name", ""),
                 Map.entry("description", ""),
@@ -490,13 +498,17 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             "workflow_step_3",
             DeployModelStep.NAME,
             Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
-            Map.of()
+            Collections.emptyMap()
         );
 
         WorkflowEdge edge1 = new WorkflowEdge(createConnector.id(), registerModel.id());
         WorkflowEdge edge2 = new WorkflowEdge(registerModel.id(), deployModel.id());
 
-        Workflow workflow = new Workflow(Map.of(), List.of(createConnector, registerModel, deployModel), List.of(edge1, edge2));
+        Workflow workflow = new Workflow(
+            Collections.emptyMap(),
+            List.of(createConnector, registerModel, deployModel),
+            List.of(edge1, edge2)
+        );
         List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123");
 
         FlowFrameworkException exception = expectThrows(


### PR DESCRIPTION
### Description

Eliminated unnecessary throwing of `IOException` on workflow steps execution, left over from when we did more parsing in the steps.

Used a linter based on SonarQube analysis and fixed up lots of little things.
 - Used inline replacements for the logger rather than concatenation
 - Better handling of conditionals
 - Avoiding variable name collisions
 - Replacing functional interfaces with shorter syntax (mostly `() -> context.restore()` to `context::restore`)

Eliminated most use of Google Guava, which have been mostly useless since Java 9, specifically:
 - `ImmutableList.of` replaced by Java's `List.of` or `Collections.emptyList()` when empty
 - `ImmutableMap.of` replaced by Java's `Map.of` for 2 elements and `Map.ofEntries` for more than one pair, or `Collections.emptyMap()` if empty.
 - `Charset` replaced by Java's `StandardCharsets`
 - Did not remove the `Resource.toString()` yet as it's a bit more complex and should be handled in a separate PR. See issue #328

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
