### PR TITLE
Infer edges from previous node inputs

### DIFF
--- a/src/test/java/org/opensearch/flowframework/model/TemplateTestJsonUtil.java
+++ b/src/test/java/org/opensearch/flowframework/model/TemplateTestJsonUtil.java
@@ -17,6 +17,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.workflow.NoOpStep;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -51,6 +52,22 @@ public class TemplateTestJsonUtil {
             + "\": \""
             + timeout
             + "\"}}";
+    }
+
+    public static String nodeWithTypeAndPreviousNodes(String id, String type, String... previousNodes) {
+        return "{\""
+            + WorkflowNode.ID_FIELD
+            + "\": \""
+            + id
+            + "\", \""
+            + WorkflowNode.TYPE_FIELD
+            + "\": \""
+            + type
+            + "\", \""
+            + WorkflowNode.PREVIOUS_NODE_INPUTS_FIELD
+            + "\": {"
+            + Arrays.stream(previousNodes).map(n -> "\"" + n + "\": \"output_value\"").collect(Collectors.joining(","))
+            + "}}";
     }
 
     public static String edge(String sourceId, String destId) {

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -140,7 +140,7 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         Workflow cyclicalWorkflow = new Workflow(
             originalWorkflow.userParams(),
             originalWorkflow.nodes(),
-            List.of(new WorkflowEdge("workflow_step_1", "workflow_step_2"), new WorkflowEdge("workflow_step_2", "workflow_step_1"))
+            List.of(new WorkflowEdge("workflow_step_2", "workflow_step_3"), new WorkflowEdge("workflow_step_3", "workflow_step_2"))
         );
 
         Template cyclicalTemplate = new Template.Builder().name(template.name())
@@ -155,7 +155,10 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
 
         // Hit dry run
         ResponseException exception = expectThrows(ResponseException.class, () -> createWorkflowValidation(cyclicalTemplate));
-        assertTrue(exception.getMessage().contains("Cycle detected: [workflow_step_2->workflow_step_1, workflow_step_1->workflow_step_2]"));
+        // output order not guaranteed
+        assertTrue(exception.getMessage().contains("Cycle detected"));
+        assertTrue(exception.getMessage().contains("workflow_step_2->workflow_step_3"));
+        assertTrue(exception.getMessage().contains("workflow_step_3->workflow_step_2"));
 
         // Hit Create Workflow API with original template
         Response response = createWorkflow(template);


### PR DESCRIPTION
### Description

If the `previous_node_inputs` section requires input from a previous node, infers that the edge exists even if it hasn't been explicitly defined.

### Issues Resolved

Fixes #333 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
