### PR TITLE
Refactor WorkflowResource Strings and other String reorganization

### DIFF
--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -15,8 +15,11 @@ public class CommonValue {
 
     private CommonValue() {}
 
+    /*
+     * Constants associated with Global Context
+     */
     /** Default value for no schema version */
-    public static Integer NO_SCHEMA_VERSION = 0;
+    public static final Integer NO_SCHEMA_VERSION = 0;
     /** Index mapping meta field name*/
     public static final String META = "_meta";
     /** Schema Version field name */
@@ -43,18 +46,12 @@ public class CommonValue {
     public static final String MASTER_KEY = "master_key";
     /** Create Time field  name */
     public static final String CREATE_TIME = "create_time";
-
-    /** The template field name for template use case */
-    public static final String USE_CASE_FIELD = "use_case";
-    /** The template field name for template version */
-    public static final String TEMPLATE_FIELD = "template";
-    /** The template field name for template compatibility with OpenSearch versions */
-    public static final String COMPATIBILITY_FIELD = "compatibility";
-    /** The template field name for template workflows */
-    public static final String WORKFLOWS_FIELD = "workflows";
     /** The template field name for the user who created the workflow **/
     public static final String USER_FIELD = "user";
 
+    /*
+     * Constants associated with Rest or Transport actions
+     */
     /** The transport action name prefix */
     public static final String TRANSPORT_ACTION_NAME_PREFIX = "cluster:admin/opensearch/flow_framework/";
     /** The base URI for this plugin's rest actions */
@@ -68,23 +65,25 @@ public class CommonValue {
     /** The field name for provision workflow within a use case template*/
     public static final String PROVISION_WORKFLOW = "provision";
 
+    /*
+     * Constants associated with plugin configuration
+     */
     /** Flow Framework plugin thread pool name prefix */
     public static final String FLOW_FRAMEWORK_THREAD_POOL_PREFIX = "thread_pool.flow_framework.";
     /** The provision workflow thread pool name */
     public static final String PROVISION_THREAD_POOL = "opensearch_workflow_provision";
 
+    /*
+     * Field names common to multiple classes
+     */
     /** Success name field */
     public static final String SUCCESS = "success";
-    /** Index name field */
-    public static final String INDEX_NAME = "index_name";
     /** Type field */
     public static final String TYPE = "type";
     /** default_mapping_option filed */
     public static final String DEFAULT_MAPPING_OPTION = "default_mapping_option";
     /** ID Field */
     public static final String ID = "id";
-    /** Pipeline Id field */
-    public static final String PIPELINE_ID = "pipeline_id";
     /** Processors field */
     public static final String PROCESSORS = "processors";
     /** Field map field */
@@ -93,8 +92,6 @@ public class CommonValue {
     public static final String INPUT_FIELD_NAME = "input_field_name";
     /** Output Field Name field */
     public static final String OUTPUT_FIELD_NAME = "output_field_name";
-    /** Model Id field */
-    public static final String MODEL_ID = "model_id";
     /** Task Id field */
     public static final String TASK_ID = "task_id";
     /** Register Model Status field */
@@ -106,13 +103,9 @@ public class CommonValue {
     /** Model Version field */
     public static final String MODEL_VERSION = "model_version";
     /** Model Group Id field */
-    public static final String MODEL_GROUP_ID = "model_group_id";
-    /** Model Group Id field */
     public static final String MODEL_GROUP_STATUS = "model_group_status";
     /** Description field */
     public static final String DESCRIPTION_FIELD = "description";
-    /** Connector Id field */
-    public static final String CONNECTOR_ID = "connector_id";
     /** Model format field */
     public static final String MODEL_FORMAT = "model_format";
     /** Model content hash value field */
@@ -145,7 +138,24 @@ public class CommonValue {
     public static final String MODEL_ACCESS_MODE = "access_mode";
     /** Add all backend roles */
     public static final String ADD_ALL_BACKEND_ROLES = "add_all_backend_roles";
+    /** The tools field for an agent */
+    public static final String TOOLS_FIELD = "tools";
+    /** The tools order field for an agent */
+    public static final String TOOLS_ORDER_FIELD = "tools_order";
+    /** The memory field for an agent */
+    public static final String MEMORY_FIELD = "memory";
+    /** The app type field for an agent */
+    public static final String APP_TYPE_FIELD = "app_type";
+    /** To include field for an agent response */
+    public static final String INCLUDE_OUTPUT_IN_AGENT_RESPONSE = "include_output_in_agent_response";
+    /** The created time field for an agent */
+    public static final String CREATED_TIME = "created_time";
+    /** The last updated time field for an agent */
+    public static final String LAST_UPDATED_TIME_FIELD = "last_updated_time";
 
+    /*
+     * Constants associated with resource provisioning / state
+     */
     /** The template field name for the associated workflowID **/
     public static final String WORKFLOW_ID_FIELD = "workflow_id";
     /** The template field name for the workflow error **/
@@ -172,20 +182,4 @@ public class CommonValue {
     public static final String RESOURCE_TYPE = "resource_type";
     /** The field name for the resource id */
     public static final String RESOURCE_ID = "resource_id";
-    /** The tools field for an agent */
-    public static final String TOOLS_FIELD = "tools";
-    /** The tools order field for an agent */
-    public static final String TOOLS_ORDER_FIELD = "tools_order";
-    /** The memory field for an agent */
-    public static final String MEMORY_FIELD = "memory";
-    /** The app type field for an agent */
-    public static final String APP_TYPE_FIELD = "app_type";
-    /** The agent id of an agent */
-    public static final String AGENT_ID = "agent_id";
-    /** To include field for an agent response */
-    public static final String INCLUDE_OUTPUT_IN_AGENT_RESPONSE = "include_output_in_agent_response";
-    /** The created time field for an agent */
-    public static final String CREATED_TIME = "created_time";
-    /** The last updated time field for an agent */
-    public static final String LAST_UPDATED_TIME_FIELD = "last_updated_time";
 }

--- a/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
+++ b/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
@@ -12,6 +12,18 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.workflow.CreateConnectorStep;
+import org.opensearch.flowframework.workflow.CreateIndexStep;
+import org.opensearch.flowframework.workflow.CreateIngestPipelineStep;
+import org.opensearch.flowframework.workflow.DeleteAgentStep;
+import org.opensearch.flowframework.workflow.DeleteConnectorStep;
+import org.opensearch.flowframework.workflow.DeleteModelStep;
+import org.opensearch.flowframework.workflow.DeployModelStep;
+import org.opensearch.flowframework.workflow.ModelGroupStep;
+import org.opensearch.flowframework.workflow.RegisterAgentStep;
+import org.opensearch.flowframework.workflow.RegisterLocalModelStep;
+import org.opensearch.flowframework.workflow.RegisterRemoteModelStep;
+import org.opensearch.flowframework.workflow.UndeployModelStep;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -22,22 +34,35 @@ import java.util.stream.Stream;
  */
 public enum WorkflowResources {
 
-    /** official workflow step name for creating a connector and associated created resource */
-    CREATE_CONNECTOR("create_connector", "connector_id", "delete_connector"),
-    /** official workflow step name for registering a remote model and associated created resource */
-    REGISTER_REMOTE_MODEL("register_remote_model", "model_id", "delete_model"),
-    /** official workflow step name for registering a local model and associated created resource */
-    REGISTER_LOCAL_MODEL("register_local_model", "model_id", "delete_model"),
-    /** official workflow step name for registering a model group and associated created resource */
-    REGISTER_MODEL_GROUP("register_model_group", "model_group_id", null), // TODO
-    /** official workflow step name for deploying a model and associated created resource */
-    DEPLOY_MODEL("deploy_model", "model_id", "undeploy_model"),
-    /** official workflow step name for creating an ingest-pipeline and associated created resource */
-    CREATE_INGEST_PIPELINE("create_ingest_pipeline", "pipeline_id", null), // TODO
-    /** official workflow step name for creating an index and associated created resource */
-    CREATE_INDEX("create_index", "index_name", null), // TODO
-    /** official workflow step name for register an agent and the associated created resource */
-    REGISTER_AGENT("register_agent", "agent_id", "delete_agent");
+    /** Workflow steps for creating/deleting a connector and associated created resource */
+    CREATE_CONNECTOR(CreateConnectorStep.NAME, WorkflowResources.CONNECTOR_ID, DeleteConnectorStep.NAME),
+    /** Workflow steps for registering/deleting a remote model and associated created resource */
+    REGISTER_REMOTE_MODEL(RegisterRemoteModelStep.NAME, WorkflowResources.MODEL_ID, DeleteModelStep.NAME),
+    /** Workflow steps for registering/deleting a local model and associated created resource */
+    REGISTER_LOCAL_MODEL(RegisterLocalModelStep.NAME, WorkflowResources.MODEL_ID, DeleteModelStep.NAME),
+    /** Workflow steps for registering a model group and associated created resource */
+    REGISTER_MODEL_GROUP(ModelGroupStep.NAME, WorkflowResources.MODEL_GROUP_ID, null), // TODO delete step
+    /** Workflow steps for deploying/undeploying a model and associated created resource */
+    DEPLOY_MODEL(DeployModelStep.NAME, WorkflowResources.MODEL_ID, UndeployModelStep.NAME),
+    /** Workflow steps for creating an ingest-pipeline and associated created resource */
+    CREATE_INGEST_PIPELINE(CreateIngestPipelineStep.NAME, WorkflowResources.PIPELINE_ID, null), // TODO delete step
+    /** Workflow steps for creating an index and associated created resource */
+    CREATE_INDEX(CreateIndexStep.NAME, WorkflowResources.INDEX_NAME, null), // TODO delete step
+    /** Workflow steps for registering/deleting an agent and the associated created resource */
+    REGISTER_AGENT(RegisterAgentStep.NAME, WorkflowResources.AGENT_ID, DeleteAgentStep.NAME);
+
+    /** Connector Id for a remote model connector */
+    public static final String CONNECTOR_ID = "connector_id";
+    /** Model Id for an ML model */
+    public static final String MODEL_ID = "model_id";
+    /** Model Group Id */
+    public static final String MODEL_GROUP_ID = "model_group_id";
+    /** Pipeline Id for Ingest Pipeline */
+    public static final String PIPELINE_ID = "pipeline_id";
+    /** Index name */
+    public static final String INDEX_NAME = "index_name";
+    /** Agent Id */
+    public static final String AGENT_ID = "agent_id";
 
     private final String workflowStep;
     private final String resourceCreated;

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -32,7 +32,6 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.model.ProvisioningProgress;
 import org.opensearch.flowframework.model.ResourceCreated;
@@ -60,6 +59,7 @@ import static org.opensearch.flowframework.common.CommonValue.NO_SCHEMA_VERSION;
 import static org.opensearch.flowframework.common.CommonValue.SCHEMA_VERSION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX_MAPPING;
+import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 
 /**
  * A handler for operations on system indices in the AI Flow Framework plugin
@@ -503,7 +503,7 @@ public class FlowFrameworkIndicesHandler {
         ResourceCreated newResource = new ResourceCreated(
             workflowStepName,
             nodeId,
-            WorkflowResources.getResourceByWorkflowStep(workflowStepName),
+            getResourceByWorkflowStep(workflowStepName),
             resourceId
         );
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());

--- a/src/main/java/org/opensearch/flowframework/model/ResourceCreated.java
+++ b/src/main/java/org/opensearch/flowframework/model/ResourceCreated.java
@@ -30,7 +30,6 @@ import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STEP_NAME
 /**
  * This represents an object in the WorkflowState {@link WorkflowState}.
  */
-// TODO: create an enum to add the resource name itself for each step example (create_connector_step -> connector)
 public class ResourceCreated implements ToXContentObject, Writeable {
 
     private static final Logger logger = LogManager.getLogger(ResourceCreated.class);

--- a/src/main/java/org/opensearch/flowframework/model/Template.java
+++ b/src/main/java/org/opensearch/flowframework/model/Template.java
@@ -28,20 +28,25 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.flowframework.common.CommonValue.COMPATIBILITY_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.TEMPLATE_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.UI_METADATA_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.USER_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.USE_CASE_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.WORKFLOWS_FIELD;
 
 /**
  * The Template is the central data structure which configures workflows. This object is used to parse JSON communicated via REST API.
  */
 public class Template implements ToXContentObject, Writeable {
+
+    /** The template field name for template workflows */
+    public static final String WORKFLOWS_FIELD = "workflows";
+    /** The template field name for template compatibility with OpenSearch versions */
+    public static final String COMPATIBILITY_FIELD = "compatibility";
+    /** The template field name for template version */
+    public static final String TEMPLATE_FIELD = "template";
+    /** The template field name for template use case */
+    public static final String USE_CASE_FIELD = "use_case";
 
     private String name;
     private String description;
@@ -351,13 +356,16 @@ public class Template implements ToXContentObject, Writeable {
      * @throws IOException on failure to parse
      */
     public static Template parse(String json) throws IOException {
-        XContentParser parser = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY,
-            LoggingDeprecationHandler.INSTANCE,
-            json
-        );
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-        return parse(parser);
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE,
+                json
+            )
+        ) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+            return parse(parser);
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
@@ -38,8 +38,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 
 /**
  * Utility methods for Template parsing

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -16,7 +16,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.FutureUtils;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -28,6 +27,8 @@ import java.util.stream.Stream;
 
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_GET_TASK_REQUEST_RETRY;
+import static org.opensearch.flowframework.common.WorkflowResources.DEPLOY_MODEL;
+import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 
 /**
  * Abstract retryable workflow step
@@ -90,9 +91,9 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
             } else {
                 try {
                     logger.info(workflowStep + " successful for {} and modelId {}", workflowId, response.getModelId());
-                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    String resourceName = getResourceByWorkflowStep(getName());
                     String id;
-                    if (getName().equals(WorkflowResources.DEPLOY_MODEL.getWorkflowStep())) {
+                    if (getName().equals(DEPLOY_MODEL.getWorkflowStep())) {
                         id = response.getModelId();
                     } else {
                         id = response.getTaskId();

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
@@ -43,6 +42,7 @@ import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PROTOCOL_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
+import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 import static org.opensearch.flowframework.util.ParseUtils.getStringToStringMap;
 
 /**
@@ -84,7 +84,7 @@ public class CreateConnectorStep implements WorkflowStep {
             public void onResponse(MLCreateConnectorResponse mlCreateConnectorResponse) {
 
                 try {
-                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    String resourceName = getResourceByWorkflowStep(getName());
                     logger.info("Created connector successfully");
                     flowFrameworkIndicesHandler.updateResourceInStateIndex(
                         currentNodeInputs.getWorkflowId(),

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -55,7 +55,8 @@ public class CreateConnectorStep implements WorkflowStep {
     private MachineLearningNodeClient mlClient;
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
-    static final String NAME = WorkflowResources.CREATE_CONNECTOR.getWorkflowStep();
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "create_connector";
 
     /**
      * Instantiate this class

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateIndexStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateIndexStep.java
@@ -18,7 +18,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 
@@ -30,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.opensearch.flowframework.common.CommonValue.DEFAULT_MAPPING_OPTION;
+import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 
 /**
  * Step to create an index
@@ -71,7 +71,7 @@ public class CreateIndexStep implements WorkflowStep {
             @Override
             public void onResponse(CreateIndexResponse createIndexResponse) {
                 try {
-                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    String resourceName = getResourceByWorkflowStep(getName());
                     logger.info("created index: {}", createIndexResponse.index());
                     flowFrameworkIndicesHandler.updateResourceInStateIndex(
                         currentNodeInputs.getWorkflowId(),
@@ -120,7 +120,7 @@ public class CreateIndexStep implements WorkflowStep {
         try {
             for (WorkflowData workflowData : data) {
                 Map<String, Object> content = workflowData.getContent();
-                index = (String) content.get(WorkflowResources.getResourceByWorkflowStep(getName()));
+                index = (String) content.get(getResourceByWorkflowStep(getName()));
                 defaultMappingOption = (String) content.get(DEFAULT_MAPPING_OPTION);
                 if (index != null && defaultMappingOption != null && settings != null) {
                     break;

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateIndexStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateIndexStep.java
@@ -42,7 +42,7 @@ public class CreateIndexStep implements WorkflowStep {
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
     /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
-    static final String NAME = WorkflowResources.CREATE_INDEX.getWorkflowStep();
+    public static final String NAME = "create_index";
     static Map<String, AtomicBoolean> indexMappingUpdated = new HashMap<>();
 
     /**

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStep.java
@@ -19,7 +19,6 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 
@@ -38,6 +37,8 @@ import static org.opensearch.flowframework.common.CommonValue.INPUT_FIELD_NAME;
 import static org.opensearch.flowframework.common.CommonValue.OUTPUT_FIELD_NAME;
 import static org.opensearch.flowframework.common.CommonValue.PROCESSORS;
 import static org.opensearch.flowframework.common.CommonValue.TYPE;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 
 /**
  * Workflow step to create an ingest pipeline
@@ -104,8 +105,8 @@ public class CreateIngestPipelineStep implements WorkflowStep {
                     case TYPE:
                         type = (String) content.get(TYPE);
                         break;
-                    case WorkflowResources.MODEL_ID:
-                        modelId = (String) content.get(WorkflowResources.MODEL_ID);
+                    case MODEL_ID:
+                        modelId = (String) content.get(MODEL_ID);
                         break;
                     case INPUT_FIELD_NAME:
                         inputFieldName = (String) content.get(INPUT_FIELD_NAME);
@@ -142,7 +143,7 @@ public class CreateIngestPipelineStep implements WorkflowStep {
                 logger.info("Created ingest pipeline : " + putPipelineRequest.getId());
 
                 try {
-                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    String resourceName = getResourceByWorkflowStep(getName());
                     flowFrameworkIndicesHandler.updateResourceInStateIndex(
                         currentNodeInputs.getWorkflowId(),
                         currentNodeId,
@@ -224,7 +225,7 @@ public class CreateIngestPipelineStep implements WorkflowStep {
             .startArray(PROCESSORS)
             .startObject()
             .startObject(type)
-            .field(WorkflowResources.MODEL_ID, modelId)
+            .field(MODEL_ID, modelId)
             .startObject(FIELD_MAP)
             .field(inputFieldName, outputFieldName)
             .endObject()

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStep.java
@@ -35,7 +35,6 @@ import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.FIELD_MAP;
 import static org.opensearch.flowframework.common.CommonValue.ID;
 import static org.opensearch.flowframework.common.CommonValue.INPUT_FIELD_NAME;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.OUTPUT_FIELD_NAME;
 import static org.opensearch.flowframework.common.CommonValue.PROCESSORS;
 import static org.opensearch.flowframework.common.CommonValue.TYPE;
@@ -48,7 +47,7 @@ public class CreateIngestPipelineStep implements WorkflowStep {
     private static final Logger logger = LogManager.getLogger(CreateIngestPipelineStep.class);
 
     /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
-    static final String NAME = WorkflowResources.CREATE_INGEST_PIPELINE.getWorkflowStep();
+    public static final String NAME = "create_ingest_pipeline";
 
     // Client to store a pipeline in the cluster state
     private final ClusterAdminClient clusterAdminClient;
@@ -105,8 +104,8 @@ public class CreateIngestPipelineStep implements WorkflowStep {
                     case TYPE:
                         type = (String) content.get(TYPE);
                         break;
-                    case MODEL_ID:
-                        modelId = (String) content.get(MODEL_ID);
+                    case WorkflowResources.MODEL_ID:
+                        modelId = (String) content.get(WorkflowResources.MODEL_ID);
                         break;
                     case INPUT_FIELD_NAME:
                         inputFieldName = (String) content.get(INPUT_FIELD_NAME);
@@ -225,7 +224,7 @@ public class CreateIngestPipelineStep implements WorkflowStep {
             .startArray(PROCESSORS)
             .startObject()
             .startObject(type)
-            .field(MODEL_ID, modelId)
+            .field(WorkflowResources.MODEL_ID, modelId)
             .startObject(FIELD_MAP)
             .field(inputFieldName, outputFieldName)
             .endObject()

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -21,8 +22,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-
-import static org.opensearch.flowframework.common.CommonValue.AGENT_ID;
 
 /**
  * Step to delete a agent for a remote model
@@ -33,7 +32,8 @@ public class DeleteAgentStep implements WorkflowStep {
 
     private MachineLearningNodeClient mlClient;
 
-    static final String NAME = "delete_agent";
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "delete_agent";
 
     /**
      * Instantiate this class
@@ -72,7 +72,7 @@ public class DeleteAgentStep implements WorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(AGENT_ID);
+        Set<String> requiredKeys = Set.of(WorkflowResources.AGENT_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
         try {
@@ -83,7 +83,7 @@ public class DeleteAgentStep implements WorkflowStep {
                 outputs,
                 previousNodeInputs
             );
-            String agentId = (String) inputs.get(AGENT_ID);
+            String agentId = (String) inputs.get(WorkflowResources.AGENT_ID);
 
             mlClient.deleteAgent(agentId, actionListener);
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -22,6 +21,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+
+import static org.opensearch.flowframework.common.WorkflowResources.AGENT_ID;
 
 /**
  * Step to delete a agent for a remote model
@@ -58,7 +59,7 @@ public class DeleteAgentStep implements WorkflowStep {
             public void onResponse(DeleteResponse deleteResponse) {
                 deleteAgentFuture.complete(
                     new WorkflowData(
-                        Map.ofEntries(Map.entry("agent_id", deleteResponse.getId())),
+                        Map.ofEntries(Map.entry(AGENT_ID, deleteResponse.getId())),
                         currentNodeInputs.getWorkflowId(),
                         currentNodeInputs.getNodeId()
                     )
@@ -72,7 +73,7 @@ public class DeleteAgentStep implements WorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(WorkflowResources.AGENT_ID);
+        Set<String> requiredKeys = Set.of(AGENT_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
         try {
@@ -83,7 +84,7 @@ public class DeleteAgentStep implements WorkflowStep {
                 outputs,
                 previousNodeInputs
             );
-            String agentId = (String) inputs.get(WorkflowResources.AGENT_ID);
+            String agentId = (String) inputs.get(AGENT_ID);
 
             mlClient.deleteAgent(agentId, actionListener);
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -21,8 +22,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-
-import static org.opensearch.flowframework.common.CommonValue.CONNECTOR_ID;
 
 /**
  * Step to delete a connector for a remote model
@@ -33,7 +32,8 @@ public class DeleteConnectorStep implements WorkflowStep {
 
     private MachineLearningNodeClient mlClient;
 
-    static final String NAME = "delete_connector";
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "delete_connector";
 
     /**
      * Instantiate this class
@@ -72,7 +72,7 @@ public class DeleteConnectorStep implements WorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(CONNECTOR_ID);
+        Set<String> requiredKeys = Set.of(WorkflowResources.CONNECTOR_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
         try {
@@ -83,7 +83,7 @@ public class DeleteConnectorStep implements WorkflowStep {
                 outputs,
                 previousNodeInputs
             );
-            String connectorId = (String) inputs.get(CONNECTOR_ID);
+            String connectorId = (String) inputs.get(WorkflowResources.CONNECTOR_ID);
 
             mlClient.deleteConnector(connectorId, actionListener);
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -22,6 +21,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+
+import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 
 /**
  * Step to delete a connector for a remote model
@@ -58,7 +59,7 @@ public class DeleteConnectorStep implements WorkflowStep {
             public void onResponse(DeleteResponse deleteResponse) {
                 deleteConnectorFuture.complete(
                     new WorkflowData(
-                        Map.ofEntries(Map.entry("connector_id", deleteResponse.getId())),
+                        Map.ofEntries(Map.entry(CONNECTOR_ID, deleteResponse.getId())),
                         currentNodeInputs.getWorkflowId(),
                         currentNodeInputs.getNodeId()
                     )
@@ -72,7 +73,7 @@ public class DeleteConnectorStep implements WorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(WorkflowResources.CONNECTOR_ID);
+        Set<String> requiredKeys = Set.of(CONNECTOR_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
         try {
@@ -83,7 +84,7 @@ public class DeleteConnectorStep implements WorkflowStep {
                 outputs,
                 previousNodeInputs
             );
-            String connectorId = (String) inputs.get(WorkflowResources.CONNECTOR_ID);
+            String connectorId = (String) inputs.get(CONNECTOR_ID);
 
             mlClient.deleteConnector(connectorId, actionListener);
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -21,8 +22,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 
 /**
  * Step to delete a model for a remote model
@@ -33,7 +32,8 @@ public class DeleteModelStep implements WorkflowStep {
 
     private MachineLearningNodeClient mlClient;
 
-    static final String NAME = "delete_model";
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "delete_model";
 
     /**
      * Instantiate this class
@@ -58,7 +58,7 @@ public class DeleteModelStep implements WorkflowStep {
             public void onResponse(DeleteResponse deleteResponse) {
                 deleteModelFuture.complete(
                     new WorkflowData(
-                        Map.ofEntries(Map.entry(MODEL_ID, deleteResponse.getId())),
+                        Map.ofEntries(Map.entry(WorkflowResources.MODEL_ID, deleteResponse.getId())),
                         currentNodeInputs.getWorkflowId(),
                         currentNodeInputs.getNodeId()
                     )
@@ -72,7 +72,7 @@ public class DeleteModelStep implements WorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(MODEL_ID);
+        Set<String> requiredKeys = Set.of(WorkflowResources.MODEL_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
         try {
@@ -84,7 +84,7 @@ public class DeleteModelStep implements WorkflowStep {
                 previousNodeInputs
             );
 
-            String modelId = inputs.get(MODEL_ID).toString();
+            String modelId = inputs.get(WorkflowResources.MODEL_ID).toString();
 
             mlClient.deleteModel(modelId, actionListener);
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -22,6 +21,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 
 /**
  * Step to delete a model for a remote model
@@ -58,7 +59,7 @@ public class DeleteModelStep implements WorkflowStep {
             public void onResponse(DeleteResponse deleteResponse) {
                 deleteModelFuture.complete(
                     new WorkflowData(
-                        Map.ofEntries(Map.entry(WorkflowResources.MODEL_ID, deleteResponse.getId())),
+                        Map.ofEntries(Map.entry(MODEL_ID, deleteResponse.getId())),
                         currentNodeInputs.getWorkflowId(),
                         currentNodeInputs.getNodeId()
                     )
@@ -72,7 +73,7 @@ public class DeleteModelStep implements WorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(WorkflowResources.MODEL_ID);
+        Set<String> requiredKeys = Set.of(MODEL_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
         try {
@@ -84,7 +85,7 @@ public class DeleteModelStep implements WorkflowStep {
                 previousNodeInputs
             );
 
-            String modelId = inputs.get(WorkflowResources.MODEL_ID).toString();
+            String modelId = inputs.get(MODEL_ID).toString();
 
             mlClient.deleteModel(modelId, actionListener);
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
@@ -14,6 +14,7 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
@@ -25,8 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
-
 /**
  * Step to deploy a model
  */
@@ -35,7 +34,9 @@ public class DeployModelStep extends AbstractRetryableWorkflowStep {
 
     private final MachineLearningNodeClient mlClient;
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
-    static final String NAME = "deploy_model";
+
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "deploy_model";
 
     /**
      * Instantiate this class
@@ -82,7 +83,7 @@ public class DeployModelStep extends AbstractRetryableWorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(MODEL_ID);
+        Set<String> requiredKeys = Set.of(WorkflowResources.MODEL_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
         try {
@@ -94,7 +95,7 @@ public class DeployModelStep extends AbstractRetryableWorkflowStep {
                 previousNodeInputs
             );
 
-            String modelId = (String) inputs.get(MODEL_ID);
+            String modelId = (String) inputs.get(WorkflowResources.MODEL_ID);
 
             mlClient.deploy(modelId, actionListener);
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
@@ -14,7 +14,6 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
@@ -25,6 +24,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 
 /**
  * Step to deploy a model
@@ -83,7 +84,7 @@ public class DeployModelStep extends AbstractRetryableWorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(WorkflowResources.MODEL_ID);
+        Set<String> requiredKeys = Set.of(MODEL_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
         try {
@@ -95,7 +96,7 @@ public class DeployModelStep extends AbstractRetryableWorkflowStep {
                 previousNodeInputs
             );
 
-            String modelId = (String) inputs.get(WorkflowResources.MODEL_ID);
+            String modelId = (String) inputs.get(MODEL_ID);
 
             mlClient.deploy(modelId, actionListener);
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.util.CollectionUtils;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
@@ -35,6 +34,7 @@ import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_ACCESS_MODE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
+import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 
 /**
  * Step to register a model group
@@ -74,7 +74,7 @@ public class ModelGroupStep implements WorkflowStep {
             public void onResponse(MLRegisterModelGroupResponse mlRegisterModelGroupResponse) {
                 try {
                     logger.info("Model group registration successful");
-                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    String resourceName = getResourceByWorkflowStep(getName());
                     flowFrameworkIndicesHandler.updateResourceInStateIndex(
                         currentNodeInputs.getWorkflowId(),
                         currentNodeId,

--- a/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
@@ -47,7 +47,8 @@ public class ModelGroupStep implements WorkflowStep {
 
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
-    static final String NAME = WorkflowResources.REGISTER_MODEL_GROUP.getWorkflowStep();
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "register_model_group";
 
     /**
      * Instantiate this class

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -14,7 +14,6 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.common.Nullable;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
@@ -47,6 +46,8 @@ import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_ORDER_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TYPE;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 import static org.opensearch.flowframework.util.ParseUtils.getStringToStringMap;
 
 /**
@@ -93,7 +94,7 @@ public class RegisterAgentStep implements WorkflowStep {
             @Override
             public void onResponse(MLRegisterAgentResponse mlRegisterAgentResponse) {
                 try {
-                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    String resourceName = getResourceByWorkflowStep(getName());
                     logger.info("Agent registration successful for the agent {}", mlRegisterAgentResponse.getAgentId());
                     flowFrameworkIndicesHandler.updateResourceInStateIndex(
                         workflowId,
@@ -244,7 +245,7 @@ public class RegisterAgentStep implements WorkflowStep {
         // Case when modelId is passed through previousSteps
         Optional<String> previousNode = previousNodeInputs.entrySet()
             .stream()
-            .filter(e -> WorkflowResources.MODEL_ID.equals(e.getValue()))
+            .filter(e -> MODEL_ID.equals(e.getValue()))
             .map(Map.Entry::getKey)
             .findFirst();
 
@@ -252,8 +253,7 @@ public class RegisterAgentStep implements WorkflowStep {
             WorkflowData previousNodeOutput = outputs.get(previousNode.get());
             if (previousNodeOutput != null) {
                 // Use either llm.model_id (if present) or model_id (backup)
-                Object modelId = previousNodeOutput.getContent()
-                    .getOrDefault(LLM_MODEL_ID, previousNodeOutput.getContent().get(WorkflowResources.MODEL_ID));
+                Object modelId = previousNodeOutput.getContent().getOrDefault(LLM_MODEL_ID, previousNodeOutput.getContent().get(MODEL_ID));
                 if (modelId != null) {
                     return modelId.toString();
                 }

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -42,7 +42,6 @@ import static org.opensearch.flowframework.common.CommonValue.CREATED_TIME;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.LAST_UPDATED_TIME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.MEMORY_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_FIELD;
@@ -60,10 +59,13 @@ public class RegisterAgentStep implements WorkflowStep {
     private MachineLearningNodeClient mlClient;
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
-    static final String NAME = WorkflowResources.REGISTER_AGENT.getWorkflowStep();
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "register_agent";
 
-    private static final String LLM_MODEL_ID = "llm.model_id";
-    private static final String LLM_PARAMETERS = "llm.parameters";
+    /** The model ID for the LLM */
+    public static final String LLM_MODEL_ID = "llm.model_id";
+    /** The parameters for the LLM */
+    public static final String LLM_PARAMETERS = "llm.parameters";
 
     /**
      * Instantiate this class
@@ -242,7 +244,7 @@ public class RegisterAgentStep implements WorkflowStep {
         // Case when modelId is passed through previousSteps
         Optional<String> previousNode = previousNodeInputs.entrySet()
             .stream()
-            .filter(e -> MODEL_ID.equals(e.getValue()))
+            .filter(e -> WorkflowResources.MODEL_ID.equals(e.getValue()))
             .map(Map.Entry::getKey)
             .findFirst();
 
@@ -250,7 +252,8 @@ public class RegisterAgentStep implements WorkflowStep {
             WorkflowData previousNodeOutput = outputs.get(previousNode.get());
             if (previousNodeOutput != null) {
                 // Use either llm.model_id (if present) or model_id (backup)
-                Object modelId = previousNodeOutput.getContent().getOrDefault(LLM_MODEL_ID, previousNodeOutput.getContent().get(MODEL_ID));
+                Object modelId = previousNodeOutput.getContent()
+                    .getOrDefault(LLM_MODEL_ID, previousNodeOutput.getContent().get(WorkflowResources.MODEL_ID));
                 if (modelId != null) {
                     return modelId.toString();
                 }

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalModelStep.java
@@ -38,7 +38,6 @@ import static org.opensearch.flowframework.common.CommonValue.EMBEDDING_DIMENSIO
 import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_ID;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.URL;
@@ -55,7 +54,8 @@ public class RegisterLocalModelStep extends AbstractRetryableWorkflowStep {
 
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
-    static final String NAME = WorkflowResources.REGISTER_LOCAL_MODEL.getWorkflowStep();
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "register_local_model";
 
     /**
      * Instantiate this class
@@ -120,7 +120,7 @@ public class RegisterLocalModelStep extends AbstractRetryableWorkflowStep {
             MODEL_CONTENT_HASH_VALUE,
             URL
         );
-        Set<String> optionalKeys = Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, ALL_CONFIG);
+        Set<String> optionalKeys = Set.of(DESCRIPTION_FIELD, WorkflowResources.MODEL_GROUP_ID, ALL_CONFIG);
 
         try {
             Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
@@ -135,7 +135,7 @@ public class RegisterLocalModelStep extends AbstractRetryableWorkflowStep {
             String modelVersion = (String) inputs.get(VERSION_FIELD);
             String description = (String) inputs.get(DESCRIPTION_FIELD);
             MLModelFormat modelFormat = MLModelFormat.from((String) inputs.get(MODEL_FORMAT));
-            String modelGroupId = (String) inputs.get(MODEL_GROUP_ID);
+            String modelGroupId = (String) inputs.get(WorkflowResources.MODEL_GROUP_ID);
             String modelContentHashValue = (String) inputs.get(MODEL_CONTENT_HASH_VALUE);
             String modelType = (String) inputs.get(MODEL_TYPE);
             String embeddingDimension = (String) inputs.get(EMBEDDING_DIMENSION);

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalModelStep.java
@@ -14,7 +14,6 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
@@ -42,6 +41,7 @@ import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.URL;
 import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 
 /**
  * Step to register a local model
@@ -120,7 +120,7 @@ public class RegisterLocalModelStep extends AbstractRetryableWorkflowStep {
             MODEL_CONTENT_HASH_VALUE,
             URL
         );
-        Set<String> optionalKeys = Set.of(DESCRIPTION_FIELD, WorkflowResources.MODEL_GROUP_ID, ALL_CONFIG);
+        Set<String> optionalKeys = Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, ALL_CONFIG);
 
         try {
             Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
@@ -135,7 +135,7 @@ public class RegisterLocalModelStep extends AbstractRetryableWorkflowStep {
             String modelVersion = (String) inputs.get(VERSION_FIELD);
             String description = (String) inputs.get(DESCRIPTION_FIELD);
             MLModelFormat modelFormat = MLModelFormat.from((String) inputs.get(MODEL_FORMAT));
-            String modelGroupId = (String) inputs.get(WorkflowResources.MODEL_GROUP_ID);
+            String modelGroupId = (String) inputs.get(MODEL_GROUP_ID);
             String modelContentHashValue = (String) inputs.get(MODEL_CONTENT_HASH_VALUE);
             String modelType = (String) inputs.get(MODEL_TYPE);
             String embeddingDimension = (String) inputs.get(EMBEDDING_DIMENSION);

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
@@ -31,6 +30,9 @@ import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
+import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 
 /**
  * Step to register a remote model
@@ -72,7 +74,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
 
                 try {
                     logger.info("Remote Model registration successful");
-                    String resourceName = WorkflowResources.getResourceByWorkflowStep(getName());
+                    String resourceName = getResourceByWorkflowStep(getName());
                     flowFrameworkIndicesHandler.updateResourceInStateIndex(
                         currentNodeInputs.getWorkflowId(),
                         currentNodeId,
@@ -111,8 +113,8 @@ public class RegisterRemoteModelStep implements WorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(NAME_FIELD, FUNCTION_NAME, WorkflowResources.CONNECTOR_ID);
-        Set<String> optionalKeys = Set.of(WorkflowResources.MODEL_GROUP_ID, DESCRIPTION_FIELD);
+        Set<String> requiredKeys = Set.of(NAME_FIELD, FUNCTION_NAME, CONNECTOR_ID);
+        Set<String> optionalKeys = Set.of(MODEL_GROUP_ID, DESCRIPTION_FIELD);
 
         try {
             Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
@@ -125,9 +127,9 @@ public class RegisterRemoteModelStep implements WorkflowStep {
 
             String modelName = (String) inputs.get(NAME_FIELD);
             FunctionName functionName = FunctionName.from(((String) inputs.get(FUNCTION_NAME)).toUpperCase(Locale.ROOT));
-            String modelGroupId = (String) inputs.get(WorkflowResources.MODEL_GROUP_ID);
+            String modelGroupId = (String) inputs.get(MODEL_GROUP_ID);
             String description = (String) inputs.get(DESCRIPTION_FIELD);
-            String connectorId = (String) inputs.get(WorkflowResources.CONNECTOR_ID);
+            String connectorId = (String) inputs.get(CONNECTOR_ID);
 
             MLRegisterModelInputBuilder builder = MLRegisterModelInput.builder()
                 .functionName(functionName)

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -27,10 +27,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import static org.opensearch.flowframework.common.CommonValue.CONNECTOR_ID;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_ID;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 
@@ -45,7 +43,8 @@ public class RegisterRemoteModelStep implements WorkflowStep {
 
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
-    static final String NAME = WorkflowResources.REGISTER_REMOTE_MODEL.getWorkflowStep();
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "register_remote_model";
 
     /**
      * Instantiate this class
@@ -112,8 +111,8 @@ public class RegisterRemoteModelStep implements WorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(NAME_FIELD, FUNCTION_NAME, CONNECTOR_ID);
-        Set<String> optionalKeys = Set.of(MODEL_GROUP_ID, DESCRIPTION_FIELD);
+        Set<String> requiredKeys = Set.of(NAME_FIELD, FUNCTION_NAME, WorkflowResources.CONNECTOR_ID);
+        Set<String> optionalKeys = Set.of(WorkflowResources.MODEL_GROUP_ID, DESCRIPTION_FIELD);
 
         try {
             Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
@@ -126,9 +125,9 @@ public class RegisterRemoteModelStep implements WorkflowStep {
 
             String modelName = (String) inputs.get(NAME_FIELD);
             FunctionName functionName = FunctionName.from(((String) inputs.get(FUNCTION_NAME)).toUpperCase(Locale.ROOT));
-            String modelGroupId = (String) inputs.get(MODEL_GROUP_ID);
+            String modelGroupId = (String) inputs.get(WorkflowResources.MODEL_GROUP_ID);
             String description = (String) inputs.get(DESCRIPTION_FIELD);
-            String connectorId = (String) inputs.get(CONNECTOR_ID);
+            String connectorId = (String) inputs.get(WorkflowResources.CONNECTOR_ID);
 
             MLRegisterModelInputBuilder builder = MLRegisterModelInput.builder()
                 .functionName(functionName)

--- a/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
@@ -10,7 +10,6 @@ package org.opensearch.flowframework.workflow;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.common.agent.MLToolSpec;
@@ -26,6 +25,8 @@ import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TYPE;
+import static org.opensearch.flowframework.common.WorkflowResources.AGENT_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 
 /**
  * Step to register a tool for an agent
@@ -108,29 +109,29 @@ public class ToolStep implements WorkflowStep {
         Map<String, String> parametersMap = (Map<String, String>) parameters;
         Optional<String> previousNodeModel = previousNodeInputs.entrySet()
             .stream()
-            .filter(e -> WorkflowResources.MODEL_ID.equals(e.getValue()))
+            .filter(e -> MODEL_ID.equals(e.getValue()))
             .map(Map.Entry::getKey)
             .findFirst();
 
         Optional<String> previousNodeAgent = previousNodeInputs.entrySet()
             .stream()
-            .filter(e -> WorkflowResources.AGENT_ID.equals(e.getValue()))
+            .filter(e -> AGENT_ID.equals(e.getValue()))
             .map(Map.Entry::getKey)
             .findFirst();
 
         // Case when modelId is passed through previousSteps and not present already in parameters
-        if (previousNodeModel.isPresent() && !parametersMap.containsKey(WorkflowResources.MODEL_ID)) {
+        if (previousNodeModel.isPresent() && !parametersMap.containsKey(MODEL_ID)) {
             WorkflowData previousNodeOutput = outputs.get(previousNodeModel.get());
-            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(WorkflowResources.MODEL_ID)) {
-                parametersMap.put(WorkflowResources.MODEL_ID, previousNodeOutput.getContent().get(WorkflowResources.MODEL_ID).toString());
+            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(MODEL_ID)) {
+                parametersMap.put(MODEL_ID, previousNodeOutput.getContent().get(MODEL_ID).toString());
             }
         }
 
         // Case when agentId is passed through previousSteps and not present already in parameters
-        if (previousNodeAgent.isPresent() && !parametersMap.containsKey(WorkflowResources.AGENT_ID)) {
+        if (previousNodeAgent.isPresent() && !parametersMap.containsKey(AGENT_ID)) {
             WorkflowData previousNodeOutput = outputs.get(previousNodeAgent.get());
-            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(WorkflowResources.AGENT_ID)) {
-                parametersMap.put(WorkflowResources.AGENT_ID, previousNodeOutput.getContent().get(WorkflowResources.AGENT_ID).toString());
+            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(AGENT_ID)) {
+                parametersMap.put(AGENT_ID, previousNodeOutput.getContent().get(AGENT_ID).toString());
             }
         }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.common.agent.MLToolSpec;
@@ -19,10 +20,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import static org.opensearch.flowframework.common.CommonValue.AGENT_ID;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.INCLUDE_OUTPUT_IN_AGENT_RESPONSE;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_FIELD;
@@ -109,29 +108,29 @@ public class ToolStep implements WorkflowStep {
         Map<String, String> parametersMap = (Map<String, String>) parameters;
         Optional<String> previousNodeModel = previousNodeInputs.entrySet()
             .stream()
-            .filter(e -> MODEL_ID.equals(e.getValue()))
+            .filter(e -> WorkflowResources.MODEL_ID.equals(e.getValue()))
             .map(Map.Entry::getKey)
             .findFirst();
 
         Optional<String> previousNodeAgent = previousNodeInputs.entrySet()
             .stream()
-            .filter(e -> AGENT_ID.equals(e.getValue()))
+            .filter(e -> WorkflowResources.AGENT_ID.equals(e.getValue()))
             .map(Map.Entry::getKey)
             .findFirst();
 
         // Case when modelId is passed through previousSteps and not present already in parameters
-        if (previousNodeModel.isPresent() && !parametersMap.containsKey(MODEL_ID)) {
+        if (previousNodeModel.isPresent() && !parametersMap.containsKey(WorkflowResources.MODEL_ID)) {
             WorkflowData previousNodeOutput = outputs.get(previousNodeModel.get());
-            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(MODEL_ID)) {
-                parametersMap.put(MODEL_ID, previousNodeOutput.getContent().get(MODEL_ID).toString());
+            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(WorkflowResources.MODEL_ID)) {
+                parametersMap.put(WorkflowResources.MODEL_ID, previousNodeOutput.getContent().get(WorkflowResources.MODEL_ID).toString());
             }
         }
 
         // Case when agentId is passed through previousSteps and not present already in parameters
-        if (previousNodeAgent.isPresent() && !parametersMap.containsKey(AGENT_ID)) {
+        if (previousNodeAgent.isPresent() && !parametersMap.containsKey(WorkflowResources.AGENT_ID)) {
             WorkflowData previousNodeOutput = outputs.get(previousNodeAgent.get());
-            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(AGENT_ID)) {
-                parametersMap.put(AGENT_ID, previousNodeOutput.getContent().get(AGENT_ID).toString());
+            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(WorkflowResources.AGENT_ID)) {
+                parametersMap.put(WorkflowResources.AGENT_ID, previousNodeOutput.getContent().get(WorkflowResources.AGENT_ID).toString());
             }
         }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
@@ -14,7 +14,6 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -28,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static org.opensearch.flowframework.common.CommonValue.SUCCESS;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 
 /**
  * Step to undeploy model
@@ -86,7 +86,7 @@ public class UndeployModelStep implements WorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(WorkflowResources.MODEL_ID);
+        Set<String> requiredKeys = Set.of(MODEL_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
         try {
@@ -98,7 +98,7 @@ public class UndeployModelStep implements WorkflowStep {
                 previousNodeInputs
             );
 
-            String modelId = inputs.get(WorkflowResources.MODEL_ID).toString();
+            String modelId = inputs.get(MODEL_ID).toString();
 
             mlClient.undeploy(new String[] { modelId }, null, actionListener);
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
@@ -14,6 +14,7 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -26,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.SUCCESS;
 
 /**
@@ -38,7 +38,8 @@ public class UndeployModelStep implements WorkflowStep {
 
     private MachineLearningNodeClient mlClient;
 
-    static final String NAME = "undeploy_model";
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "undeploy_model";
 
     /**
      * Instantiate this class
@@ -85,7 +86,7 @@ public class UndeployModelStep implements WorkflowStep {
             }
         };
 
-        Set<String> requiredKeys = Set.of(MODEL_ID);
+        Set<String> requiredKeys = Set.of(WorkflowResources.MODEL_ID);
         Set<String> optionalKeys = Collections.emptySet();
 
         try {
@@ -97,7 +98,7 @@ public class UndeployModelStep implements WorkflowStep {
                 previousNodeInputs
             );
 
-            String modelId = inputs.get(MODEL_ID).toString();
+            String modelId = inputs.get(WorkflowResources.MODEL_ID).toString();
 
             mlClient.undeploy(new String[] { modelId }, null, actionListener);
         } catch (FlowFrameworkException e) {

--- a/src/test/java/org/opensearch/flowframework/model/ResourceCreatedTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/ResourceCreatedTests.java
@@ -8,11 +8,14 @@
  */
 package org.opensearch.flowframework.model;
 
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+
+import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.CREATE_CONNECTOR;
+import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 
 public class ResourceCreatedTests extends OpenSearchTestCase {
 
@@ -22,12 +25,12 @@ public class ResourceCreatedTests extends OpenSearchTestCase {
     }
 
     public void testParseFeature() throws IOException {
-        String workflowStepName = WorkflowResources.CREATE_CONNECTOR.getWorkflowStep();
-        String resourceType = WorkflowResources.getResourceByWorkflowStep(workflowStepName);
+        String workflowStepName = CREATE_CONNECTOR.getWorkflowStep();
+        String resourceType = getResourceByWorkflowStep(workflowStepName);
         ResourceCreated resourceCreated = new ResourceCreated(workflowStepName, "workflow_step_1", resourceType, "L85p1IsBbfF");
         assertEquals(workflowStepName, resourceCreated.workflowStepName());
         assertEquals("workflow_step_1", resourceCreated.workflowStepId());
-        assertEquals("connector_id", resourceCreated.resourceType());
+        assertEquals(CONNECTOR_ID, resourceCreated.resourceType());
         assertEquals("L85p1IsBbfF", resourceCreated.resourceId());
 
         String expectedJson =

--- a/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
@@ -22,7 +22,6 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.flowframework.TestHelpers;
-import org.opensearch.flowframework.common.WorkflowResources;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.model.Workflow;
@@ -52,10 +51,15 @@ import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_GET_
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOWS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOW_STEPS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.WORKFLOW_REQUEST_TIMEOUT;
+import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.CREATE_CONNECTOR;
+import static org.opensearch.flowframework.common.WorkflowResources.DEPLOY_MODEL;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.REGISTER_REMOTE_MODEL;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -168,14 +172,14 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         WorkflowNode registerModel = new WorkflowNode(
             "workflow_step_2",
             "register_model",
-            Map.ofEntries(Map.entry("workflow_step_1", "connector_id")),
+            Map.ofEntries(Map.entry("workflow_step_1", CONNECTOR_ID)),
             Map.ofEntries(Map.entry("name", "name"), Map.entry("function_name", "remote"), Map.entry("description", "description"))
         );
 
         WorkflowNode deployModel = new WorkflowNode(
             "workflow_step_3",
             "deploy_model",
-            Map.ofEntries(Map.entry("workflow_step_2", WorkflowResources.MODEL_ID)),
+            Map.ofEntries(Map.entry("workflow_step_2", MODEL_ID)),
             Collections.emptyMap()
         );
 
@@ -497,7 +501,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
     private Template generateValidTemplate() {
         WorkflowNode createConnector = new WorkflowNode(
             "workflow_step_1",
-            WorkflowResources.CREATE_CONNECTOR.getWorkflowStep(),
+            CREATE_CONNECTOR.getWorkflowStep(),
             Collections.emptyMap(),
             Map.ofEntries(
                 Map.entry("name", ""),
@@ -511,14 +515,14 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         );
         WorkflowNode registerModel = new WorkflowNode(
             "workflow_step_2",
-            WorkflowResources.REGISTER_REMOTE_MODEL.getWorkflowStep(),
-            Map.ofEntries(Map.entry("workflow_step_1", "connector_id")),
+            REGISTER_REMOTE_MODEL.getWorkflowStep(),
+            Map.ofEntries(Map.entry("workflow_step_1", CONNECTOR_ID)),
             Map.ofEntries(Map.entry("name", "name"), Map.entry("function_name", "remote"), Map.entry("description", "description"))
         );
         WorkflowNode deployModel = new WorkflowNode(
             "workflow_step_3",
-            WorkflowResources.DEPLOY_MODEL.getWorkflowStep(),
-            Map.ofEntries(Map.entry("workflow_step_2", WorkflowResources.MODEL_ID)),
+            DEPLOY_MODEL.getWorkflowStep(),
+            Map.ofEntries(Map.entry("workflow_step_2", MODEL_ID)),
             Collections.emptyMap()
         );
 

--- a/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
@@ -175,7 +175,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         WorkflowNode deployModel = new WorkflowNode(
             "workflow_step_3",
             "deploy_model",
-            Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
+            Map.ofEntries(Map.entry("workflow_step_2", WorkflowResources.MODEL_ID)),
             Collections.emptyMap()
         );
 
@@ -518,7 +518,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         WorkflowNode deployModel = new WorkflowNode(
             "workflow_step_3",
             WorkflowResources.DEPLOY_MODEL.getWorkflowStep(),
-            Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
+            Map.ofEntries(Map.entry("workflow_step_2", WorkflowResources.MODEL_ID)),
             Collections.emptyMap()
         );
 

--- a/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
@@ -51,6 +51,8 @@ import java.util.concurrent.TimeUnit;
 import org.mockito.ArgumentCaptor;
 
 import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW;
+import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -155,7 +157,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
             ActionListener<GetWorkflowStateResponse> responseListener = invocation.getArgument(2);
 
             WorkflowState state = WorkflowState.builder()
-                .resourcesCreated(List.of(new ResourceCreated("create_connector", "step_1", "connector_id", "connectorId")))
+                .resourcesCreated(List.of(new ResourceCreated("create_connector", "step_1", CONNECTOR_ID, "connectorId")))
                 .build();
             responseListener.onResponse(new GetWorkflowStateResponse(state, true));
             return null;
@@ -215,7 +217,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
             ActionListener<GetWorkflowStateResponse> responseListener = invocation.getArgument(2);
 
             WorkflowState state = WorkflowState.builder()
-                .resourcesCreated(List.of(new ResourceCreated("deploy_model", "step_1", "model_id", "modelId")))
+                .resourcesCreated(List.of(new ResourceCreated("deploy_model", "step_1", MODEL_ID, "modelId")))
                 .build();
             responseListener.onResponse(new GetWorkflowStateResponse(state, true));
             return null;

--- a/src/test/java/org/opensearch/flowframework/transport/SearchWorkflowStateTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/SearchWorkflowStateTransportActionTests.java
@@ -20,7 +20,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
@@ -32,6 +32,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
+import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -107,7 +108,7 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());
         assertTrue(future.isDone());
-        assertEquals(connectorId, future.get().getContent().get("connector_id"));
+        assertEquals(connectorId, future.get().getContent().get(CONNECTOR_ID));
 
     }
 

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
@@ -42,6 +42,7 @@ import org.mockito.MockitoAnnotations;
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
 import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
+import static org.opensearch.flowframework.common.WorkflowResources.INDEX_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -76,7 +77,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
         this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
         MockitoAnnotations.openMocks(this);
         inputData = new WorkflowData(
-            Map.ofEntries(Map.entry("index_name", "demo"), Map.entry("default_mapping_option", "knn")),
+            Map.ofEntries(Map.entry(INDEX_NAME, "demo"), Map.entry("default_mapping_option", "knn")),
             "test-id",
             "test-node-id"
         );
@@ -120,7 +121,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
 
         assertTrue(future.isDone() && !future.isCompletedExceptionally());
 
-        Map<String, Object> outputData = Map.of("index_name", "demo");
+        Map<String, Object> outputData = Map.of(INDEX_NAME, "demo");
         assertEquals(outputData, future.get().getContent());
 
     }

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
@@ -29,6 +29,8 @@ import org.mockito.ArgumentCaptor;
 
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.PIPELINE_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -57,7 +59,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
                 Map.entry("id", "pipelineId"),
                 Map.entry("description", "some description"),
                 Map.entry("type", "text_embedding"),
-                Map.entry("model_id", "model_id"),
+                Map.entry(MODEL_ID, MODEL_ID),
                 Map.entry("input_field_name", "inputField"),
                 Map.entry("output_field_name", "outputField")
             ),
@@ -66,7 +68,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
         );
 
         // Set output data to returned pipelineId
-        outpuData = new WorkflowData(Map.ofEntries(Map.entry("pipeline_id", "pipelineId")), "test-id", "test-node-id");
+        outpuData = new WorkflowData(Map.ofEntries(Map.entry(PIPELINE_ID, "pipelineId")), "test-id", "test-node-id");
 
         client = mock(Client.class);
         adminClient = mock(AdminClient.class);
@@ -137,10 +139,10 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
         // Data with missing input and output fields
         WorkflowData incorrectData = new WorkflowData(
             Map.ofEntries(
-                Map.entry("id", "pipeline_id"),
+                Map.entry("id", PIPELINE_ID),
                 Map.entry("description", "some description"),
                 Map.entry("type", "text_embedding"),
-                Map.entry("model_id", "model_id")
+                Map.entry(MODEL_ID, MODEL_ID)
             ),
             "test-id",
             "test-node-id"

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteAgentStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteAgentStepTests.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.opensearch.flowframework.common.WorkflowResources.AGENT_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
@@ -62,13 +63,13 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
         CompletableFuture<WorkflowData> future = deleteAgentStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of("step_1", new WorkflowData(Map.of("agent_id", agentId), "workflowId", "nodeId")),
-            Map.of("step_1", "agent_id")
+            Map.of("step_1", new WorkflowData(Map.of(AGENT_ID, agentId), "workflowId", "nodeId")),
+            Map.of("step_1", AGENT_ID)
         );
         verify(machineLearningNodeClient).deleteAgent(any(String.class), any());
 
         assertTrue(future.isDone());
-        assertEquals(agentId, future.get().getContent().get("agent_id"));
+        assertEquals(agentId, future.get().getContent().get(AGENT_ID));
     }
 
     public void testNoAgentIdInOutput() throws IOException {
@@ -99,8 +100,8 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
         CompletableFuture<WorkflowData> future = deleteAgentStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of("step_1", new WorkflowData(Map.of("agent_id", "test"), "workflowId", "nodeId")),
-            Map.of("step_1", "agent_id")
+            Map.of("step_1", new WorkflowData(Map.of(AGENT_ID, "test"), "workflowId", "nodeId")),
+            Map.of("step_1", AGENT_ID)
         );
 
         verify(machineLearningNodeClient).deleteAgent(any(String.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
@@ -62,13 +63,13 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
         CompletableFuture<WorkflowData> future = deleteConnectorStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of("step_1", new WorkflowData(Map.of("connector_id", connectorId), "workflowId", "nodeId")),
-            Map.of("step_1", "connector_id")
+            Map.of("step_1", new WorkflowData(Map.of(CONNECTOR_ID, connectorId), "workflowId", "nodeId")),
+            Map.of("step_1", CONNECTOR_ID)
         );
         verify(machineLearningNodeClient).deleteConnector(any(String.class), any());
 
         assertTrue(future.isDone());
-        assertEquals(connectorId, future.get().getContent().get("connector_id"));
+        assertEquals(connectorId, future.get().getContent().get(CONNECTOR_ID));
     }
 
     public void testNoConnectorIdInOutput() throws IOException {
@@ -99,8 +100,8 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
         CompletableFuture<WorkflowData> future = deleteConnectorStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of("step_1", new WorkflowData(Map.of("connector_id", "test"), "workflowId", "nodeId")),
-            Map.of("step_1", "connector_id")
+            Map.of("step_1", new WorkflowData(Map.of(CONNECTOR_ID, "test"), "workflowId", "nodeId")),
+            Map.of("step_1", CONNECTOR_ID)
         );
 
         verify(machineLearningNodeClient).deleteConnector(any(String.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
@@ -62,13 +63,13 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
         CompletableFuture<WorkflowData> future = deleteModelStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of("step_1", new WorkflowData(Map.of("model_id", modelId), "workflowId", "nodeId")),
-            Map.of("step_1", "model_id")
+            Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, modelId), "workflowId", "nodeId")),
+            Map.of("step_1", MODEL_ID)
         );
         verify(machineLearningNodeClient).deleteModel(any(String.class), any());
 
         assertTrue(future.isDone());
-        assertEquals(modelId, future.get().getContent().get("model_id"));
+        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
     }
 
     public void testNoModelIdInOutput() throws IOException {
@@ -99,8 +100,8 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
         CompletableFuture<WorkflowData> future = deleteModelStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of("step_1", new WorkflowData(Map.of("model_id", "test"), "workflowId", "nodeId")),
-            Map.of("step_1", "model_id")
+            Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, "test"), "workflowId", "nodeId")),
+            Map.of("step_1", MODEL_ID)
         );
 
         verify(machineLearningNodeClient).deleteModel(any(String.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
@@ -46,9 +46,9 @@ import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_IND
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_GET_TASK_REQUEST_RETRY;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -83,7 +83,7 @@ public class DeployModelStepTests extends OpenSearchTestCase {
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         this.deployModel = new DeployModelStep(testMaxRetrySetting, clusterService, machineLearningNodeClient, flowFrameworkIndicesHandler);
-        this.inputData = new WorkflowData(Map.ofEntries(Map.entry("model_id", "modelId")), "test-id", "test-node-id");
+        this.inputData = new WorkflowData(Map.ofEntries(Map.entry(MODEL_ID, "modelId")), "test-id", "test-node-id");
 
     }
 

--- a/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
@@ -41,10 +41,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_GET_TASK_REQUEST_RETRY;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;

--- a/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
@@ -34,6 +34,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -69,7 +70,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
     }
 
     public void testRegisterModelGroup() throws ExecutionException, InterruptedException, IOException {
-        String modelGroupId = "model_group_id";
+        String modelGroupId = MODEL_GROUP_ID;
         String status = MLTaskState.CREATED.name();
 
         ModelGroupStep modelGroupStep = new ModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
@@ -100,7 +101,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
         verify(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
 
         assertTrue(future.isDone());
-        assertEquals(modelGroupId, future.get().getContent().get("model_group_id"));
+        assertEquals(modelGroupId, future.get().getContent().get(MODEL_GROUP_ID));
         assertEquals(status, future.get().getContent().get("model_group_status"));
 
     }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -34,6 +34,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
+import static org.opensearch.flowframework.common.WorkflowResources.AGENT_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -85,7 +86,7 @@ public class RegisterAgentTests extends OpenSearchTestCase {
     }
 
     public void testRegisterAgent() throws IOException, ExecutionException, InterruptedException {
-        String agentId = "agent_id";
+        String agentId = AGENT_ID;
         RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
         @SuppressWarnings("unchecked")
@@ -114,11 +115,11 @@ public class RegisterAgentTests extends OpenSearchTestCase {
         verify(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());
 
         assertTrue(future.isDone());
-        assertEquals(agentId, future.get().getContent().get("agent_id"));
+        assertEquals(agentId, future.get().getContent().get(AGENT_ID));
     }
 
     public void testRegisterAgentFailure() throws IOException {
-        String agentId = "agent_id";
+        String agentId = AGENT_ID;
         RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
         @SuppressWarnings("unchecked")

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
@@ -41,6 +41,7 @@ import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_GET_TASK_REQUEST_RETRY;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -89,7 +90,7 @@ public class RegisterLocalModelStepTests extends OpenSearchTestCase {
                 Map.entry("version", "1.0.0"),
                 Map.entry("description", "description"),
                 Map.entry("model_format", "TORCH_SCRIPT"),
-                Map.entry("model_group_id", "abcdefg"),
+                Map.entry(MODEL_GROUP_ID, "abcdefg"),
                 Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
                 Map.entry("model_type", "bert"),
                 Map.entry("embedding_dimension", "384"),

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalModelStepTests.java
@@ -38,10 +38,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_GET_TASK_REQUEST_RETRY;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -30,9 +30,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -32,6 +32,7 @@ import org.mockito.MockitoAnnotations;
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
+import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -61,7 +62,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
                 Map.entry("function_name", "remote"),
                 Map.entry("name", "xyz"),
                 Map.entry("description", "description"),
-                Map.entry("connector_id", "abcdefg")
+                Map.entry(CONNECTOR_ID, "abcdefg")
             ),
             "test-id",
             "test-node-id"
@@ -136,7 +137,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertTrue(ex.getCause().getMessage().startsWith("Missing required inputs ["));
-        for (String s : new String[] { "name", "function_name", "connector_id" }) {
+        for (String s : new String[] { "name", "function_name", CONNECTOR_ID }) {
             assertTrue(ex.getCause().getMessage().contains(s));
         }
         assertTrue(ex.getCause().getMessage().endsWith("] in workflow [test-id] node [test-node-id]"));

--- a/src/test/java/org/opensearch/flowframework/workflow/UndeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UndeployModelStepTests.java
@@ -29,8 +29,8 @@ import java.util.concurrent.ExecutionException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.opensearch.flowframework.common.CommonValue.MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.SUCCESS;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -55,6 +55,8 @@ import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_GET_
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOWS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOW_STEPS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.WORKFLOW_REQUEST_TIMEOUT;
+import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.opensearch.flowframework.model.TemplateTestJsonUtil.edge;
 import static org.opensearch.flowframework.model.TemplateTestJsonUtil.node;
 import static org.opensearch.flowframework.model.TemplateTestJsonUtil.nodeWithType;
@@ -352,13 +354,13 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         WorkflowNode registerModel = new WorkflowNode(
             "workflow_step_2",
             RegisterRemoteModelStep.NAME,
-            Map.ofEntries(Map.entry("workflow_step_1", "connector_id")),
+            Map.ofEntries(Map.entry("workflow_step_1", CONNECTOR_ID)),
             Map.ofEntries(Map.entry("name", "name"), Map.entry("function_name", "remote"), Map.entry("description", "description"))
         );
         WorkflowNode deployModel = new WorkflowNode(
             "workflow_step_3",
             DeployModelStep.NAME,
-            Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
+            Map.ofEntries(Map.entry("workflow_step_2", MODEL_ID)),
             Collections.emptyMap()
         );
 
@@ -387,7 +389,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         WorkflowNode deployModel = new WorkflowNode(
             "workflow_step_2",
             DeployModelStep.NAME,
-            Map.ofEntries(Map.entry("workflow_step_1", "model_id")),
+            Map.ofEntries(Map.entry("workflow_step_1", MODEL_ID)),
             Collections.emptyMap()
         );
         WorkflowEdge edge = new WorkflowEdge(registerModel.id(), deployModel.id());
@@ -463,13 +465,13 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         WorkflowNode registerModel = new WorkflowNode(
             "workflow_step_2",
             RegisterRemoteModelStep.NAME,
-            Map.ofEntries(Map.entry("workflow_step_1", "connector_id")),
+            Map.ofEntries(Map.entry("workflow_step_1", CONNECTOR_ID)),
             Map.ofEntries(Map.entry("name", "name"), Map.entry("function_name", "remote"), Map.entry("description", "description"))
         );
         WorkflowNode deployModel = new WorkflowNode(
             "workflow_step_3",
             DeployModelStep.NAME,
-            Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
+            Map.ofEntries(Map.entry("workflow_step_2", MODEL_ID)),
             Collections.emptyMap()
         );
 
@@ -545,13 +547,13 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         WorkflowNode registerModel = new WorkflowNode(
             "workflow_step_2",
             RegisterRemoteModelStep.NAME,
-            Map.ofEntries(Map.entry("workflow_step_1", "connector_id")),
+            Map.ofEntries(Map.entry("workflow_step_1", CONNECTOR_ID)),
             Map.ofEntries(Map.entry("name", "name"), Map.entry("function_name", "remote"), Map.entry("description", "description"))
         );
         WorkflowNode deployModel = new WorkflowNode(
             "workflow_step_3",
             DeployModelStep.NAME,
-            Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
+            Map.ofEntries(Map.entry("workflow_step_2", MODEL_ID)),
             Collections.emptyMap()
         );
 
@@ -594,27 +596,27 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             )
         );
         TimeValue createConnectorTimeout = workflowProcessSorter.parseTimeout(createConnector);
-        assertEquals(createConnectorTimeout.getSeconds(), 50);
+        assertEquals(50, createConnectorTimeout.getSeconds());
 
         // read timeout from workflow-step.json overwrite value
         WorkflowNode deployModel = new WorkflowNode(
             "workflow_step_3",
             DeployModelStep.NAME,
-            Map.ofEntries(Map.entry("workflow_step_2", "model_id")),
+            Map.ofEntries(Map.entry("workflow_step_2", MODEL_ID)),
             Map.of()
         );
         TimeValue deployModelTimeout = workflowProcessSorter.parseTimeout(deployModel);
-        assertEquals(deployModelTimeout.getSeconds(), 15);
+        assertEquals(15, deployModelTimeout.getSeconds());
 
         // read timeout from NODE_TIMEOUT_DEFAULT_VALUE when there's no node NODE_TIMEOUT_FIELD
         // and no overwrite timeout value in workflow-step.json
         WorkflowNode registerModel = new WorkflowNode(
             "workflow_step_2",
             RegisterRemoteModelStep.NAME,
-            Map.ofEntries(Map.entry("workflow_step_1", "connector_id")),
+            Map.ofEntries(Map.entry("workflow_step_1", CONNECTOR_ID)),
             Map.ofEntries(Map.entry("name", "name"), Map.entry("function_name", "remote"), Map.entry("description", "description"))
         );
         TimeValue registerRemoteModelTimeout = workflowProcessSorter.parseTimeout(registerModel);
-        assertEquals(registerRemoteModelTimeout.getSeconds(), 10);
+        assertEquals(10, registerRemoteModelTimeout.getSeconds());
     }
 }


### PR DESCRIPTION
### Description

Adds a bit more organization to the Strings throughout the project:
 - Moves Template-related strings to the Template as they are rarely used outside of that context
 - Separates CommonValue Strings into sections 
 - Moves WorkflowResources String constants to that enum
 - Makes WorkflowStep `NAME` fields public constants for more logical reference in the Workflow Resources
 - Replaces use of the resource id strings throughout the codebase with the constants

### Issues Resolved

Fixes #257 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
