### PR TITLE
Get installed plugins from local node and add a timeout

### DIFF
--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -12,6 +12,8 @@ import org.opensearch.action.admin.cluster.node.info.NodeInfo;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.client.AdminClient;
 import org.opensearch.client.Client;
 import org.opensearch.client.ClusterAdminClient;
@@ -426,12 +428,19 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         when(client.admin()).thenReturn(adminClient);
         when(adminClient.cluster()).thenReturn(clusterAdminClient);
 
-        // Mock and stub the clusterservice to get the local node
-        ClusterState clusterState = mock(ClusterState.class);
-        DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
-        when(clusterService.state()).thenReturn(clusterState);
-        when(clusterState.getNodes()).thenReturn(discoveryNodes);
-        when(discoveryNodes.getLocalNodeId()).thenReturn("123");
+        // Stub cluster state request
+        doAnswer(invocation -> {
+            ActionListener<ClusterStateResponse> listener = invocation.getArgument(1);
+
+            ClusterStateResponse response = mock(ClusterStateResponse.class);
+            ClusterState clusterState = mock(ClusterState.class);
+            DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
+            when(response.getState()).thenReturn(clusterState);
+            when(clusterState.nodes()).thenReturn(discoveryNodes);
+            when(discoveryNodes.getLocalNodeId()).thenReturn("123");
+            listener.onResponse(response);
+            return null;
+        }).when(clusterAdminClient).state(any(ClusterStateRequest.class), any());
 
         // Stub cluster admin client's node info request
         doAnswer(invocation -> {
@@ -510,12 +519,19 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         when(client.admin()).thenReturn(adminClient);
         when(adminClient.cluster()).thenReturn(clusterAdminClient);
 
-        // Mock and stub the clusterservice to get the local node
-        ClusterState clusterState = mock(ClusterState.class);
-        DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
-        when(clusterService.state()).thenReturn(clusterState);
-        when(clusterState.getNodes()).thenReturn(discoveryNodes);
-        when(discoveryNodes.getLocalNodeId()).thenReturn("123");
+        // Stub cluster state request
+        doAnswer(invocation -> {
+            ActionListener<ClusterStateResponse> listener = invocation.getArgument(1);
+
+            ClusterStateResponse response = mock(ClusterStateResponse.class);
+            ClusterState clusterState = mock(ClusterState.class);
+            DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
+            when(response.getState()).thenReturn(clusterState);
+            when(clusterState.nodes()).thenReturn(discoveryNodes);
+            when(discoveryNodes.getLocalNodeId()).thenReturn("123");
+            listener.onResponse(response);
+            return null;
+        }).when(clusterAdminClient).state(any(ClusterStateRequest.class), any());
 
         // Stub cluster admin client's node info request
         doAnswer(invocation -> {


### PR DESCRIPTION
### Description

Refactors the installed plugin validation check to more closely match `_cat/plugins`:
 - Only queries the local node state to get the localNodeId
 - Adds a timeout to prevent blocking synchronously

### Issues Resolved

Fixes #352 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
