### PR TITLE
Iterate collection for unregistered Writeable in streams

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,10 +151,12 @@ dependencies {
     implementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     implementation "com.google.guava:guava:33.0.0-jre"
     api group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
+    api group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${opensearch_version}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
+    api "org.apache.httpcomponents.core5:httpcore5:5.2.2"
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -506,8 +506,6 @@ public class FlowFrameworkIndicesHandler {
             getResourceByWorkflowStep(workflowStepName),
             resourceId
         );
-        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
-        newResource.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
         // The script to append a new object to the resources_created array
         Script script = new Script(

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -512,7 +512,7 @@ public class FlowFrameworkIndicesHandler {
             ScriptType.INLINE,
             "painless",
             "ctx._source.resources_created.add(params.newResource)",
-            Collections.singletonMap("newResource", newResource)
+            Collections.singletonMap("newResource", newResource.resourceMap())
         );
 
         updateFlowFrameworkSystemIndexDocWithScript(WORKFLOW_STATE_INDEX, workflowId, script, ActionListener.wrap(updateResponse -> {

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowState.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowState.java
@@ -97,7 +97,7 @@ public class WorkflowState implements ToXContentObject, Writeable {
     private WorkflowState() {}
 
     /**
-     * Instatiates a new WorkflowState from an input stream
+     * Instantiates a new WorkflowState from an input stream
      * @param input the input stream to read from
      * @throws IOException if the workflowId cannot be read from the input stream
      */
@@ -108,8 +108,7 @@ public class WorkflowState implements ToXContentObject, Writeable {
         this.provisioningProgress = input.readOptionalString();
         this.provisionStartTime = input.readOptionalInstant();
         this.provisionEndTime = input.readOptionalInstant();
-        // TODO: fix error: cannot access Response issue when integrating with access control
-        // this.user = input.readBoolean() ? new User(input) : null;
+        this.user = input.readBoolean() ? new User(input) : null;
         this.userOutputs = input.readBoolean() ? input.readMap() : null;
 
         int resourceCount = input.readVInt();
@@ -297,14 +296,12 @@ public class WorkflowState implements ToXContentObject, Writeable {
         output.writeOptionalInstant(provisionStartTime);
         output.writeOptionalInstant(provisionEndTime);
 
-        /*- TODO: fix error: cannot access Response issue when integrating with access control
         if (user != null) {
             output.writeBoolean(true);
             user.writeTo(output);
         } else {
             output.writeBoolean(false);
         }
-        */
 
         if (userOutputs != null) {
             output.writeBoolean(true);

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowState.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowState.java
@@ -111,7 +111,12 @@ public class WorkflowState implements ToXContentObject, Writeable {
         // TODO: fix error: cannot access Response issue when integrating with access control
         // this.user = input.readBoolean() ? new User(input) : null;
         this.userOutputs = input.readBoolean() ? input.readMap() : null;
-        this.resourcesCreated = input.readList(ResourceCreated::new);
+
+        int resourceCount = input.readVInt();
+        this.resourcesCreated = new ArrayList<>(resourceCount);
+        for (int r = 0; r < resourceCount; r++) {
+            resourcesCreated.add(new ResourceCreated(input));
+        }
     }
 
     /**
@@ -292,11 +297,14 @@ public class WorkflowState implements ToXContentObject, Writeable {
         output.writeOptionalInstant(provisionStartTime);
         output.writeOptionalInstant(provisionEndTime);
 
+        /*- TODO: fix error: cannot access Response issue when integrating with access control
         if (user != null) {
+            output.writeBoolean(true);
             user.writeTo(output);
         } else {
             output.writeBoolean(false);
         }
+        */
 
         if (userOutputs != null) {
             output.writeBoolean(true);
@@ -304,7 +312,11 @@ public class WorkflowState implements ToXContentObject, Writeable {
         } else {
             output.writeBoolean(false);
         }
-        output.writeList(resourcesCreated);
+
+        output.writeVInt(resourcesCreated.size());
+        for (ResourceCreated resource : resourcesCreated) {
+            resource.writeTo(output);
+        }
     }
 
     /**

--- a/src/test/java/org/opensearch/flowframework/model/ResourceCreatedTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/ResourceCreatedTests.java
@@ -8,12 +8,10 @@
  */
 package org.opensearch.flowframework.model;
 
-import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 
-import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.CREATE_CONNECTOR;
 import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
 
@@ -30,34 +28,18 @@ public class ResourceCreatedTests extends OpenSearchTestCase {
         ResourceCreated resourceCreated = new ResourceCreated(workflowStepName, "workflow_step_1", resourceType, "L85p1IsBbfF");
         assertEquals(workflowStepName, resourceCreated.workflowStepName());
         assertEquals("workflow_step_1", resourceCreated.workflowStepId());
-        assertEquals(CONNECTOR_ID, resourceCreated.resourceType());
+        assertEquals("connector_id", resourceCreated.resourceType());
         assertEquals("L85p1IsBbfF", resourceCreated.resourceId());
 
-        String expectedJson =
-            "{\"workflow_step_name\":\"create_connector\",\"workflow_step_id\":\"workflow_step_1\",\"resource_type\":\"connector_id\",\"resource_id\":\"L85p1IsBbfF\"}";
         String json = TemplateTestJsonUtil.parseToJson(resourceCreated);
-        assertEquals(expectedJson, json);
+        assertTrue(json.contains("\"workflow_step_name\":\"create_connector\""));
+        assertTrue(json.contains("\"workflow_step_id\":\"workflow_step_1\""));
+        assertTrue(json.contains("\"resource_type\":\"connector_id\""));
+        assertTrue(json.contains("\"resource_id\":\"L85p1IsBbfF\""));
 
         ResourceCreated resourceCreatedTwo = ResourceCreated.parse(TemplateTestJsonUtil.jsonToParser(json));
         assertEquals(workflowStepName, resourceCreatedTwo.workflowStepName());
         assertEquals("workflow_step_1", resourceCreatedTwo.workflowStepId());
         assertEquals("L85p1IsBbfF", resourceCreatedTwo.resourceId());
     }
-
-    public void testExceptions() throws IOException {
-        String badJson = "{\"wrong\":\"A\",\"resource_id\":\"B\"}";
-        IOException badJsonException = assertThrows(
-            IOException.class,
-            () -> ResourceCreated.parse(TemplateTestJsonUtil.jsonToParser(badJson))
-        );
-        assertEquals("Unable to parse field [wrong] in a resources_created object.", badJsonException.getMessage());
-
-        String missingJson = "{\"resource_id\":\"B\"}";
-        FlowFrameworkException missingJsonException = assertThrows(
-            FlowFrameworkException.class,
-            () -> ResourceCreated.parse(TemplateTestJsonUtil.jsonToParser(missingJson))
-        );
-        assertEquals("A ResourceCreated object requires workflowStepName", missingJsonException.getMessage());
-    }
-
 }

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowStateTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowStateTests.java
@@ -9,12 +9,14 @@
 package org.opensearch.flowframework.model;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.commons.authuser.User;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.BytesStreamInput;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -32,6 +34,7 @@ public class WorkflowStateTests extends OpenSearchTestCase {
         String provisioningProgress = "progress";
         Instant provisionStartTime = Instant.now().minusSeconds(2);
         Instant provisionEndTime = Instant.now();
+        User user = new User("user", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         Map<String, Object> userOutputs = Map.of("foo", Map.of("bar", "baz"));
         List<ResourceCreated> resourcesCreated = List.of(new ResourceCreated("name", "stepId", "type", "id"));
 
@@ -42,8 +45,7 @@ public class WorkflowStateTests extends OpenSearchTestCase {
             .provisioningProgress(provisioningProgress)
             .provisionStartTime(provisionStartTime)
             .provisionEndTime(provisionEndTime)
-            // TODO test this
-            // .user(user)
+            .user(user)
             .userOutputs(userOutputs)
             .resourcesCreated(resourcesCreated)
             .build();
@@ -54,6 +56,7 @@ public class WorkflowStateTests extends OpenSearchTestCase {
         assertEquals(provisioningProgress, wfs.getProvisioningProgress());
         assertEquals(provisionStartTime, wfs.getProvisionStartTime());
         assertEquals(provisionEndTime, wfs.getProvisionEndTime());
+        assertEquals("user", wfs.getUser().getName());
         assertEquals(1, wfs.userOutputs().size());
         assertEquals("baz", ((Map<?, ?>) wfs.userOutputs().get("foo")).get("bar"));
         assertEquals(1, wfs.resourcesCreated().size());
@@ -74,6 +77,7 @@ public class WorkflowStateTests extends OpenSearchTestCase {
                 assertEquals(provisioningProgress, wfs.getProvisioningProgress());
                 assertEquals(provisionStartTime, wfs.getProvisionStartTime());
                 assertEquals(provisionEndTime, wfs.getProvisionEndTime());
+                assertEquals("user", wfs.getUser().getName());
                 assertEquals(1, wfs.userOutputs().size());
                 assertEquals("baz", ((Map<?, ?>) wfs.userOutputs().get("foo")).get("bar"));
                 assertEquals(1, wfs.resourcesCreated().size());

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowStateTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowStateTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.model;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.BytesStreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public class WorkflowStateTests extends OpenSearchTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testWorkflowState() throws IOException {
+        String workflowId = "id";
+        String error = "error";
+        String state = "state";
+        String provisioningProgress = "progress";
+        Instant provisionStartTime = Instant.now().minusSeconds(2);
+        Instant provisionEndTime = Instant.now();
+        Map<String, Object> userOutputs = Map.of("foo", Map.of("bar", "baz"));
+        List<ResourceCreated> resourcesCreated = List.of(new ResourceCreated("name", "stepId", "type", "id"));
+
+        WorkflowState wfs = WorkflowState.builder()
+            .workflowId(workflowId)
+            .error(error)
+            .state(state)
+            .provisioningProgress(provisioningProgress)
+            .provisionStartTime(provisionStartTime)
+            .provisionEndTime(provisionEndTime)
+            // TODO test this
+            // .user(user)
+            .userOutputs(userOutputs)
+            .resourcesCreated(resourcesCreated)
+            .build();
+
+        assertEquals(workflowId, wfs.getWorkflowId());
+        assertEquals(error, wfs.getError());
+        assertEquals(state, wfs.getState());
+        assertEquals(provisioningProgress, wfs.getProvisioningProgress());
+        assertEquals(provisionStartTime, wfs.getProvisionStartTime());
+        assertEquals(provisionEndTime, wfs.getProvisionEndTime());
+        assertEquals(1, wfs.userOutputs().size());
+        assertEquals("baz", ((Map<?, ?>) wfs.userOutputs().get("foo")).get("bar"));
+        assertEquals(1, wfs.resourcesCreated().size());
+        ResourceCreated rc = wfs.resourcesCreated().get(0);
+        assertEquals("name", rc.workflowStepName());
+        assertEquals("stepId", rc.workflowStepId());
+        assertEquals("type", rc.resourceType());
+        assertEquals("id", rc.resourceId());
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            wfs.writeTo(out);
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                wfs = new WorkflowState(in);
+
+                assertEquals(workflowId, wfs.getWorkflowId());
+                assertEquals(error, wfs.getError());
+                assertEquals(state, wfs.getState());
+                assertEquals(provisioningProgress, wfs.getProvisioningProgress());
+                assertEquals(provisionStartTime, wfs.getProvisionStartTime());
+                assertEquals(provisionEndTime, wfs.getProvisionEndTime());
+                assertEquals(1, wfs.userOutputs().size());
+                assertEquals("baz", ((Map<?, ?>) wfs.userOutputs().get("foo")).get("bar"));
+                assertEquals(1, wfs.resourcesCreated().size());
+                rc = wfs.resourcesCreated().get(0);
+                assertEquals("name", rc.workflowStepName());
+                assertEquals("stepId", rc.workflowStepId());
+                assertEquals("type", rc.resourceType());
+                assertEquals("id", rc.resourceId());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### Description

Updates the `WorkflowState` class writeable methods to iterate the `ResourceCreated` objects, as the collection streaming objects only understand well-defined types.

### Issues Resolved

Fixes #358 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
