### PR TITLE
Retrieves installed plugins from the PlugisService instead of the ClusterState

### DIFF
--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -32,6 +32,7 @@ import org.opensearch.flowframework.workflow.ProcessNode;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.plugins.PluginsService;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -55,6 +56,7 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
     private final Client client;
     private final Settings settings;
+    private final PluginsService pluginsService;
 
     /**
      * Intantiates a new CreateWorkflowTransportAction
@@ -64,6 +66,7 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
      * @param flowFrameworkIndicesHandler The handler for the global context index
      * @param settings Environment settings
      * @param client The client used to make the request to OS
+     * @param pluginsService The plugin service
      */
     @Inject
     public CreateWorkflowTransportAction(
@@ -72,13 +75,15 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
         WorkflowProcessSorter workflowProcessSorter,
         FlowFrameworkIndicesHandler flowFrameworkIndicesHandler,
         Settings settings,
-        Client client
+        Client client,
+        PluginsService pluginsService
     ) {
         super(CreateWorkflowAction.NAME, transportService, actionFilters, WorkflowRequest::new);
         this.workflowProcessSorter = workflowProcessSorter;
         this.flowFrameworkIndicesHandler = flowFrameworkIndicesHandler;
         this.settings = settings;
         this.client = client;
+        this.pluginsService = pluginsService;
     }
 
     @Override
@@ -263,7 +268,7 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
     private void validateWorkflows(Template template) throws Exception {
         for (Workflow workflow : template.workflows().values()) {
             List<ProcessNode> sortedNodes = workflowProcessSorter.sortProcessNodes(workflow, null);
-            workflowProcessSorter.validate(sortedNodes);
+            workflowProcessSorter.validate(sortedNodes, pluginsService);
         }
     }
 }

--- a/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
@@ -28,6 +28,7 @@ import org.opensearch.flowframework.model.Workflow;
 import org.opensearch.flowframework.model.WorkflowEdge;
 import org.opensearch.flowframework.model.WorkflowNode;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
+import org.opensearch.plugins.PluginsService;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -80,6 +81,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
     private ClusterSettings clusterSettings;
     private ClusterService clusterService;
     private Settings settings;
+    private PluginsService pluginsService;
 
     @Override
     public void setUp() throws Exception {
@@ -102,6 +104,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
 
         // Validation functionality should not be invoked in these unit tests, mocking instead
         this.workflowProcessSorter = mock(WorkflowProcessSorter.class);
+        this.pluginsService = mock(PluginsService.class);
 
         // Spy this action to stub check max workflows
         this.createWorkflowTransportAction = spy(
@@ -111,7 +114,8 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
                 workflowProcessSorter,
                 flowFrameworkIndicesHandler,
                 settings,
-                client
+                client,
+                pluginsService
             )
         );
         // client = mock(Client.class);
@@ -207,7 +211,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
         // Stub validation failure
-        doThrow(Exception.class).when(workflowProcessSorter).validate(any());
+        doThrow(Exception.class).when(workflowProcessSorter).validate(any(), any());
         WorkflowRequest createNewWorkflow = new WorkflowRequest(null, cyclicalTemplate, new String[] { "all" }, false, null, null);
 
         createWorkflowTransportAction.doExecute(mock(Task.class), createNewWorkflow, listener);
@@ -386,7 +390,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
 
-        doNothing().when(workflowProcessSorter).validate(any());
+        doNothing().when(workflowProcessSorter).validate(any(), any());
         WorkflowRequest workflowRequest = new WorkflowRequest(
             null,
             validTemplate,
@@ -446,7 +450,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
 
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        doNothing().when(workflowProcessSorter).validate(any());
+        doNothing().when(workflowProcessSorter).validate(any(), any());
         WorkflowRequest workflowRequest = new WorkflowRequest(
             null,
             validTemplate,

--- a/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
@@ -29,6 +29,7 @@ import org.opensearch.flowframework.model.WorkflowNode;
 import org.opensearch.flowframework.util.EncryptorUtils;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
 import org.opensearch.index.get.GetResult;
+import org.opensearch.plugins.PluginsService;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -57,6 +58,7 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
     private Template template;
     private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
     private EncryptorUtils encryptorUtils;
+    private PluginsService pluginsService;
 
     @Override
     public void setUp() throws Exception {
@@ -66,6 +68,7 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
         this.workflowProcessSorter = mock(WorkflowProcessSorter.class);
         this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
         this.encryptorUtils = mock(EncryptorUtils.class);
+        this.pluginsService = mock(PluginsService.class);
 
         this.provisionWorkflowTransportAction = new ProvisionWorkflowTransportAction(
             mock(TransportService.class),
@@ -74,7 +77,8 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
             client,
             workflowProcessSorter,
             flowFrameworkIndicesHandler,
-            encryptorUtils
+            encryptorUtils,
+            pluginsService
         );
 
         Version templateVersion = Version.fromString("1.0.0");


### PR DESCRIPTION
### Description
Retrieves installed plugins list from the `PluginsService` instead of a transport request to the Cluster State

### Issues Resolved
https://github.com/opensearch-project/flow-framework/issues/369

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
