### PR TITLE
Added a noop workflow step to delete model group

### DIFF
--- a/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
+++ b/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
@@ -17,6 +17,7 @@ import org.opensearch.flowframework.workflow.CreateIndexStep;
 import org.opensearch.flowframework.workflow.CreateIngestPipelineStep;
 import org.opensearch.flowframework.workflow.DeleteAgentStep;
 import org.opensearch.flowframework.workflow.DeleteConnectorStep;
+import org.opensearch.flowframework.workflow.DeleteModelGroupStep;
 import org.opensearch.flowframework.workflow.DeleteModelStep;
 import org.opensearch.flowframework.workflow.DeployModelStep;
 import org.opensearch.flowframework.workflow.ModelGroupStep;
@@ -41,7 +42,7 @@ public enum WorkflowResources {
     /** Workflow steps for registering/deleting a local model and associated created resource */
     REGISTER_LOCAL_MODEL(RegisterLocalModelStep.NAME, WorkflowResources.MODEL_ID, DeleteModelStep.NAME),
     /** Workflow steps for registering a model group and associated created resource */
-    REGISTER_MODEL_GROUP(ModelGroupStep.NAME, WorkflowResources.MODEL_GROUP_ID, null), // TODO delete step
+    REGISTER_MODEL_GROUP(ModelGroupStep.NAME, WorkflowResources.MODEL_GROUP_ID, DeleteModelGroupStep.NAME),
     /** Workflow steps for deploying/undeploying a model and associated created resource */
     DEPLOY_MODEL(DeployModelStep.NAME, WorkflowResources.MODEL_ID, UndeployModelStep.NAME),
     /** Workflow steps for creating an ingest-pipeline and associated created resource */

--- a/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
+++ b/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
@@ -20,9 +20,9 @@ import org.opensearch.flowframework.workflow.DeleteConnectorStep;
 import org.opensearch.flowframework.workflow.DeleteModelGroupStep;
 import org.opensearch.flowframework.workflow.DeleteModelStep;
 import org.opensearch.flowframework.workflow.DeployModelStep;
-import org.opensearch.flowframework.workflow.ModelGroupStep;
 import org.opensearch.flowframework.workflow.RegisterAgentStep;
 import org.opensearch.flowframework.workflow.RegisterLocalModelStep;
+import org.opensearch.flowframework.workflow.RegisterModelGroupStep;
 import org.opensearch.flowframework.workflow.RegisterRemoteModelStep;
 import org.opensearch.flowframework.workflow.UndeployModelStep;
 
@@ -41,8 +41,8 @@ public enum WorkflowResources {
     REGISTER_REMOTE_MODEL(RegisterRemoteModelStep.NAME, WorkflowResources.MODEL_ID, DeleteModelStep.NAME),
     /** Workflow steps for registering/deleting a local model and associated created resource */
     REGISTER_LOCAL_MODEL(RegisterLocalModelStep.NAME, WorkflowResources.MODEL_ID, DeleteModelStep.NAME),
-    /** Workflow steps for registering a model group and associated created resource */
-    REGISTER_MODEL_GROUP(ModelGroupStep.NAME, WorkflowResources.MODEL_GROUP_ID, DeleteModelGroupStep.NAME),
+    /** Workflow steps for registering/deleting a model group and associated created resource */
+    REGISTER_MODEL_GROUP(RegisterModelGroupStep.NAME, WorkflowResources.MODEL_GROUP_ID, DeleteModelGroupStep.NAME),
     /** Workflow steps for deploying/undeploying a model and associated created resource */
     DEPLOY_MODEL(DeployModelStep.NAME, WorkflowResources.MODEL_ID, UndeployModelStep.NAME),
     /** Workflow steps for creating an ingest-pipeline and associated created resource */

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteModelGroupStep.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Step to delete a model group
+ */
+public class DeleteModelGroupStep implements WorkflowStep {
+
+    /** Instantiate this class */
+    public DeleteModelGroupStep() {}
+
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "delete_model_group";
+
+    @Override
+    public CompletableFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs
+    ) {
+        return CompletableFuture.completedFuture(WorkflowData.EMPTY);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+}

--- a/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ModelGroupStep.java
@@ -48,7 +48,7 @@ public class ModelGroupStep implements WorkflowStep {
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
     /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
-    public static final String NAME = "register_model_group";
+    public static final String NAME = "model_group";
 
     /**
      * Instantiate this class

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterModelGroupStep.java
@@ -39,23 +39,23 @@ import static org.opensearch.flowframework.common.WorkflowResources.getResourceB
 /**
  * Step to register a model group
  */
-public class ModelGroupStep implements WorkflowStep {
+public class RegisterModelGroupStep implements WorkflowStep {
 
-    private static final Logger logger = LogManager.getLogger(ModelGroupStep.class);
+    private static final Logger logger = LogManager.getLogger(RegisterModelGroupStep.class);
 
     private final MachineLearningNodeClient mlClient;
 
     private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
 
     /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
-    public static final String NAME = "model_group";
+    public static final String NAME = "register_model_group";
 
     /**
      * Instantiate this class
      * @param mlClient client to instantiate MLClient
      * @param flowFrameworkIndicesHandler FlowFrameworkIndicesHandler class to update system indices
      */
-    public ModelGroupStep(MachineLearningNodeClient mlClient, FlowFrameworkIndicesHandler flowFrameworkIndicesHandler) {
+    public RegisterModelGroupStep(MachineLearningNodeClient mlClient, FlowFrameworkIndicesHandler flowFrameworkIndicesHandler) {
         this.mlClient = mlClient;
         this.flowFrameworkIndicesHandler = flowFrameworkIndicesHandler;
     }

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -62,7 +62,7 @@ public class WorkflowStepFactory {
         stepMap.put(UndeployModelStep.NAME, () -> new UndeployModelStep(mlClient));
         stepMap.put(CreateConnectorStep.NAME, () -> new CreateConnectorStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(DeleteConnectorStep.NAME, () -> new DeleteConnectorStep(mlClient));
-        stepMap.put(ModelGroupStep.NAME, () -> new ModelGroupStep(mlClient, flowFrameworkIndicesHandler));
+        stepMap.put(RegisterModelGroupStep.NAME, () -> new RegisterModelGroupStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(DeleteModelGroupStep.NAME, DeleteModelGroupStep::new);
         stepMap.put(ToolStep.NAME, ToolStep::new);
         stepMap.put(RegisterAgentStep.NAME, () -> new RegisterAgentStep(mlClient, flowFrameworkIndicesHandler));

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -63,6 +63,7 @@ public class WorkflowStepFactory {
         stepMap.put(CreateConnectorStep.NAME, () -> new CreateConnectorStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(DeleteConnectorStep.NAME, () -> new DeleteConnectorStep(mlClient));
         stepMap.put(ModelGroupStep.NAME, () -> new ModelGroupStep(mlClient, flowFrameworkIndicesHandler));
+        stepMap.put(DeleteModelGroupStep.NAME, DeleteModelGroupStep::new);
         stepMap.put(ToolStep.NAME, ToolStep::new);
         stepMap.put(RegisterAgentStep.NAME, () -> new RegisterAgentStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(DeleteAgentStep.NAME, () -> new DeleteAgentStep(mlClient));

--- a/src/main/resources/mappings/workflow-steps.json
+++ b/src/main/resources/mappings/workflow-steps.json
@@ -123,7 +123,7 @@
             "opensearch-ml"
         ]
     },
-    "model_group": {
+    "register_model_group": {
         "inputs":[
             "name"
         ],

--- a/src/main/resources/mappings/workflow-steps.json
+++ b/src/main/resources/mappings/workflow-steps.json
@@ -123,7 +123,7 @@
             "opensearch-ml"
         ]
     },
-    "register_model_group": {
+    "model_group": {
         "inputs":[
             "name"
         ],
@@ -134,6 +134,11 @@
         "required_plugins":[
             "opensearch-ml"
         ]
+    },
+    "delete_model_group": {
+        "inputs":[],
+        "outputs":[],
+        "required_plugins":[]
     },
     "register_agent": {
         "inputs":[

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteModelGroupTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteModelGroupTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+public class DeleteModelGroupTests extends OpenSearchTestCase {
+
+    public void testDeleteModelGroup() throws IOException {
+        DeleteModelGroupStep deleteModelGroupStep = new DeleteModelGroupStep();
+        assertEquals(DeleteModelGroupStep.NAME, deleteModelGroupStep.getName());
+        CompletableFuture<WorkflowData> future = deleteModelGroupStep.execute(
+            "nodeId",
+            WorkflowData.EMPTY,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+        assertTrue(future.isDone());
+        assertFalse(future.isCompletedExceptionally());
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
@@ -73,7 +73,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
         String modelGroupId = MODEL_GROUP_ID;
         String status = MLTaskState.CREATED.name();
 
-        ModelGroupStep modelGroupStep = new ModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+        RegisterModelGroupStep modelGroupStep = new RegisterModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ActionListener<MLRegisterModelGroupResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
@@ -107,7 +107,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
     }
 
     public void testRegisterModelGroupFailure() throws IOException {
-        ModelGroupStep modelGroupStep = new ModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+        RegisterModelGroupStep modelGroupStep = new RegisterModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ActionListener<MLRegisterModelGroupResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
@@ -135,7 +135,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
     }
 
     public void testRegisterModelGroupWithNoName() throws IOException {
-        ModelGroupStep modelGroupStep = new ModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+        RegisterModelGroupStep modelGroupStep = new RegisterModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
         CompletableFuture<WorkflowData> future = modelGroupStep.execute(
             inputDataWithNoName.getNodeId(),


### PR DESCRIPTION
### Description
Added a noop workflow step to delete model group. The reason of the noop step is that the model group is deleted on its own when there are no model in it. To handle the null case in deprovisioning for register model group step, created this noop workflow step to avoid any conflict with the resources created.

### Issues Resolved
Fixes https://github.com/opensearch-project/flow-framework/issues/365

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
