### PR TITLE
Replace all CompletableFutures with PlainActionFutures

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,6 +61,7 @@ jobs:
   integTest:
     needs: [spotless, javadoc]
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Don't use 21.0.2 https://github.com/opensearch-project/flow-framework/issues/426

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,6 +81,6 @@ jobs:
         run: |
           ./gradlew integTest yamlRestTest
       - name: Multi Nodes Integration Testing
-        if: matrix.java == 21
+        if: matrix.java == '21.0.1'
         run: |
           ./gradlew integTest -PnumNodes=3

--- a/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
@@ -162,7 +162,7 @@ public class DeprovisionWorkflowTransportAction extends HandledTransportAction<W
                 String resourceNameAndId = getResourceNameAndId(resource);
                 PlainActionFuture<WorkflowData> deprovisionFuture = deprovisionNode.execute();
                 try {
-                    deprovisionFuture.actionGet();
+                    deprovisionFuture.get();
                     logger.info("Successful {} for {}", deprovisionNode.id(), resourceNameAndId);
                     // Remove from list so we don't try again
                     iter.remove();

--- a/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
@@ -14,6 +14,7 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.client.Client;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -160,9 +161,9 @@ public class DeprovisionWorkflowTransportAction extends HandledTransportAction<W
                 ProcessNode deprovisionNode = iter.next();
                 ResourceCreated resource = getResourceFromDeprovisionNode(deprovisionNode, resourcesCreated);
                 String resourceNameAndId = getResourceNameAndId(resource);
-                CompletableFuture<WorkflowData> deprovisionFuture = deprovisionNode.execute();
+                PlainActionFuture<WorkflowData> deprovisionFuture = deprovisionNode.execute();
                 try {
-                    deprovisionFuture.join();
+                    deprovisionFuture.actionGet();
                     logger.info("Successful {} for {}", deprovisionNode.id(), resourceNameAndId);
                     // Remove from list so we don't try again
                     iter.remove();

--- a/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static org.opensearch.flowframework.common.CommonValue.PROVISIONING_PROGRESS_FIELD;

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -14,6 +14,7 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.client.Client;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -183,7 +184,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
     private void executeWorkflow(List<ProcessNode> workflowSequence, String workflowId) {
         try {
 
-            List<CompletableFuture<?>> workflowFutureList = new ArrayList<>();
+            List<PlainActionFuture<?>> workflowFutureList = new ArrayList<>();
             for (ProcessNode processNode : workflowSequence) {
                 List<ProcessNode> predecessors = processNode.predecessors();
 
@@ -203,7 +204,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
             }
 
             // Attempt to join each workflow step future, may throw a CompletionException if any step completes exceptionally
-            workflowFutureList.forEach(CompletableFuture::join);
+            workflowFutureList.forEach(PlainActionFuture::actionGet);
 
             logger.info("Provisioning completed successfully for workflow {}", workflowId);
             flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static org.opensearch.flowframework.common.CommonValue.ERROR_FIELD;

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -202,7 +202,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                 workflowFutureList.add(processNode.execute());
             }
 
-            // Attempt to join each workflow step future, may throw a CompletionException if any step completes exceptionally
+            // Attempt to join each workflow step future, may throw a ExecutionException if any step completes exceptionally
             workflowFutureList.forEach(PlainActionFuture::actionGet);
 
             logger.info("Provisioning completed successfully for workflow {}", workflowId);

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.workflow;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
@@ -75,14 +76,14 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
     }
 
     @Override
-    public CompletableFuture<WorkflowData> execute(
+    public PlainActionFuture<WorkflowData> execute(
         String currentNodeId,
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
     ) {
 
-        CompletableFuture<WorkflowData> registerLocalModelFuture = new CompletableFuture<>();
+        PlainActionFuture<WorkflowData> registerLocalModelFuture = PlainActionFuture.newFuture();
 
         try {
             Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
@@ -180,7 +181,7 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
                                         "successfully updated resources created in state index: {}",
                                         deployUpdateResponse.getIndex()
                                     );
-                                    registerLocalModelFuture.complete(
+                                    registerLocalModelFuture.onResponse(
                                         new WorkflowData(
                                             Map.ofEntries(
                                                 Map.entry(resourceName, id),
@@ -192,7 +193,7 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
                                     );
                                 }, deployUpdateException -> {
                                     logger.error("Failed to update simulated deploy step resource", deployUpdateException);
-                                    registerLocalModelFuture.completeExceptionally(
+                                    registerLocalModelFuture.onFailure(
                                         new FlowFrameworkException(
                                             deployUpdateException.getMessage(),
                                             ExceptionsHelper.status(deployUpdateException)
@@ -201,7 +202,7 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
                                 })
                             );
                         } else {
-                            registerLocalModelFuture.complete(
+                            registerLocalModelFuture.onResponse(
                                 new WorkflowData(
                                     Map.ofEntries(Map.entry(resourceName, id), Map.entry(REGISTER_MODEL_STATUS, mlTask.getState().name())),
                                     currentNodeInputs.getWorkflowId(),
@@ -209,16 +210,16 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
                                 )
                             );
                         }
-                    }, exception -> { registerLocalModelFuture.completeExceptionally(exception); })
+                    }, exception -> { registerLocalModelFuture.onFailure(exception); })
                 );
             }, exception -> {
                 logger.error("Failed to register local model");
-                registerLocalModelFuture.completeExceptionally(
+                registerLocalModelFuture.onFailure(
                     new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception))
                 );
             }));
         } catch (FlowFrameworkException e) {
-            registerLocalModelFuture.completeExceptionally(e);
+            registerLocalModelFuture.onFailure(e);
         }
         return registerLocalModelFuture;
     }

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
@@ -29,7 +29,6 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import static org.opensearch.flowframework.common.CommonValue.ALL_CONFIG;
@@ -214,9 +213,7 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
                 );
             }, exception -> {
                 logger.error("Failed to register local model");
-                registerLocalModelFuture.onFailure(
-                    new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception))
-                );
+                registerLocalModelFuture.onFailure(new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception)));
             }));
         } catch (FlowFrameworkException e) {
             registerLocalModelFuture.onFailure(e);

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.workflow;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.FutureUtils;
 import org.opensearch.core.action.ActionListener;

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -68,7 +68,7 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
     protected void retryableGetMlTask(
         String workflowId,
         String nodeId,
-        CompletableFuture<WorkflowData> future,
+        PlainActionFuture<WorkflowData> future,
         String taskId,
         String workflowStep,
         ActionListener<MLTask> mlTaskListener

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.workflow;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
@@ -21,7 +22,6 @@ import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.ConnectorAction.ActionType;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
-import org.opensearch.action.support.PlainActionFuture;
 
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
@@ -34,7 +34,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.flowframework.common.CommonValue.ACTIONS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.CREDENTIAL_FIELD;

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStep.java
@@ -135,7 +135,9 @@ public class CreateIngestPipelineStep implements WorkflowStep {
 
         if (configuration == null) {
             // Required workflow data not found
-            createIngestPipelineFuture.onFailure(new Exception("Failed to create ingest pipeline, required inputs not found"));
+            createIngestPipelineFuture.onFailure(
+                new IllegalArgumentException("Failed to create ingest pipeline, required inputs not found")
+            );
         } else {
             // Create PutPipelineRequest and execute
             PutPipelineRequest putPipelineRequest = new PutPipelineRequest(pipelineId, configuration, XContentType.JSON);

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
@@ -12,16 +12,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
-import org.opensearch.action.support.PlainActionFuture;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.flowframework.common.WorkflowResources.AGENT_ID;
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
@@ -12,16 +12,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
-import org.opensearch.action.support.PlainActionFuture;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
@@ -12,16 +12,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
-import org.opensearch.action.support.PlainActionFuture;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.workflow;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
@@ -20,12 +21,10 @@ import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.transport.deploy.MLDeployModelResponse;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.action.support.PlainActionFuture;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
@@ -95,11 +94,7 @@ public class DeployModelStep extends AbstractRetryableWorkflowStep {
                                 currentNodeId
                             )
                         );
-                    },
-                        e -> {
-                            deployModelFuture.onFailure(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
-                        }
-                    )
+                    }, e -> { deployModelFuture.onFailure(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e))); })
                 );
             }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/NoOpStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/NoOpStep.java
@@ -8,8 +8,9 @@
  */
 package org.opensearch.flowframework.workflow;
 
+import org.opensearch.action.support.PlainActionFuture;
+
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A workflow step that does nothing. May be used for synchronizing other actions.
@@ -23,13 +24,15 @@ public class NoOpStep implements WorkflowStep {
     public static final String NAME = "noop";
 
     @Override
-    public CompletableFuture<WorkflowData> execute(
+    public PlainActionFuture<WorkflowData> execute(
         String currentNodeId,
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
     ) {
-        return CompletableFuture.completedFuture(WorkflowData.EMPTY);
+        PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
+        future.onResponse(WorkflowData.EMPTY);
+        return future;
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
@@ -15,13 +15,11 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.threadpool.Scheduler.ScheduledCancellable;
 import org.opensearch.threadpool.ThreadPool;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_THREAD_POOL;
 
@@ -147,20 +145,12 @@ public class ProcessNode {
         }
 
         CompletableFuture.runAsync(() -> {
-            List<PlainActionFuture<WorkflowData>> predFutures = predecessors.stream().map(p -> p.future()).collect(Collectors.toList());
-            List<WorkflowData> waitForPredecessors = new ArrayList<>(predFutures.size());
             try {
-                if (!predecessors.isEmpty()) {
-                    for (PlainActionFuture<WorkflowData> future : predFutures) {
-                        waitForPredecessors.add(future.get());
-                    }
-
-                }
                 logger.info("Starting {}.", this.id);
                 // get the input data from predecessor(s)
                 Map<String, WorkflowData> inputMap = new HashMap<>();
-                for (PlainActionFuture<WorkflowData> cf : predFutures) {
-                    WorkflowData wd = cf.actionGet();
+                for (ProcessNode node : predecessors) {
+                    WorkflowData wd = node.future().actionGet();
                     inputMap.put(wd.getNodeId(), wd);
                 }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
@@ -146,13 +146,13 @@ public class ProcessNode {
 
         CompletableFuture.runAsync(() -> {
             try {
-                logger.info("Starting {}.", this.id);
                 // get the input data from predecessor(s)
                 Map<String, WorkflowData> inputMap = new HashMap<>();
                 for (ProcessNode node : predecessors) {
                     WorkflowData wd = node.future().actionGet();
                     inputMap.put(wd.getNodeId(), wd);
                 }
+                logger.info("Starting {}.", this.id);
 
                 ScheduledCancellable delayExec = null;
                 if (this.nodeTimeout.compareTo(TimeValue.ZERO) > 0) {

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.workflow;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.Nullable;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
@@ -23,7 +24,6 @@ import org.opensearch.ml.common.agent.MLAgent.MLAgentBuilder;
 import org.opensearch.ml.common.agent.MLMemorySpec;
 import org.opensearch.ml.common.agent.MLToolSpec;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentResponse;
-import org.opensearch.action.support.PlainActionFuture;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static org.opensearch.flowframework.common.CommonValue.APP_TYPE_FIELD;

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterModelGroupStep.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.flowframework.common.CommonValue.ADD_ALL_BACKEND_ROLES;
 import static org.opensearch.flowframework.common.CommonValue.BACKEND_ROLES_FIELD;

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterModelGroupStep.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.workflow;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
@@ -61,13 +62,13 @@ public class RegisterModelGroupStep implements WorkflowStep {
     }
 
     @Override
-    public CompletableFuture<WorkflowData> execute(
+    public PlainActionFuture<WorkflowData> execute(
         String currentNodeId,
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
     ) {
-        CompletableFuture<WorkflowData> registerModelGroupFuture = new CompletableFuture<>();
+        PlainActionFuture<WorkflowData> registerModelGroupFuture = PlainActionFuture.newFuture();
 
         ActionListener<MLRegisterModelGroupResponse> actionListener = new ActionListener<>() {
             @Override
@@ -82,7 +83,7 @@ public class RegisterModelGroupStep implements WorkflowStep {
                         mlRegisterModelGroupResponse.getModelGroupId(),
                         ActionListener.wrap(updateResponse -> {
                             logger.info("successfully updated resources created in state index: {}", updateResponse.getIndex());
-                            registerModelGroupFuture.complete(
+                            registerModelGroupFuture.onResponse(
                                 new WorkflowData(
                                     Map.ofEntries(
                                         Map.entry(resourceName, mlRegisterModelGroupResponse.getModelGroupId()),
@@ -94,7 +95,7 @@ public class RegisterModelGroupStep implements WorkflowStep {
                             );
                         }, exception -> {
                             logger.error("Failed to update new created resource", exception);
-                            registerModelGroupFuture.completeExceptionally(
+                            registerModelGroupFuture.onFailure(
                                 new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception))
                             );
                         })
@@ -102,14 +103,14 @@ public class RegisterModelGroupStep implements WorkflowStep {
 
                 } catch (Exception e) {
                     logger.error("Failed to parse and update new created resource", e);
-                    registerModelGroupFuture.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
+                    registerModelGroupFuture.onFailure(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
                 }
             }
 
             @Override
             public void onFailure(Exception e) {
                 logger.error("Failed to register model group");
-                registerModelGroupFuture.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
+                registerModelGroupFuture.onFailure(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
             }
         };
 
@@ -148,7 +149,7 @@ public class RegisterModelGroupStep implements WorkflowStep {
 
             mlClient.registerModelGroup(mlInput, actionListener);
         } catch (FlowFrameworkException e) {
-            registerModelGroupFuture.completeExceptionally(e);
+            registerModelGroupFuture.onFailure(e);
         }
 
         return registerModelGroupFuture;

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -25,7 +25,6 @@ import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
@@ -148,9 +147,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
 
                     } catch (Exception e) {
                         logger.error("Failed to parse and update new created resource", e);
-                        registerRemoteModelFuture.onFailure(
-                            new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e))
-                        );
+                        registerRemoteModelFuture.onFailure(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
                     }
                 }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.workflow;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
@@ -59,14 +60,14 @@ public class RegisterRemoteModelStep implements WorkflowStep {
     }
 
     @Override
-    public CompletableFuture<WorkflowData> execute(
+    public PlainActionFuture<WorkflowData> execute(
         String currentNodeId,
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs
     ) {
 
-        CompletableFuture<WorkflowData> registerRemoteModelFuture = new CompletableFuture<>();
+        PlainActionFuture<WorkflowData> registerRemoteModelFuture = PlainActionFuture.newFuture();
 
         Set<String> requiredKeys = Set.of(NAME_FIELD, CONNECTOR_ID);
         Set<String> optionalKeys = Set.of(MODEL_GROUP_ID, DESCRIPTION_FIELD, DEPLOY_FIELD);
@@ -126,7 +127,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
                                             completeRegisterFuture(deployUpdateResponse, resourceName, mlRegisterModelResponse);
                                         }, deployUpdateException -> {
                                             logger.error("Failed to update simulated deploy step resource", deployUpdateException);
-                                            registerRemoteModelFuture.completeExceptionally(
+                                            registerRemoteModelFuture.onFailure(
                                                 new FlowFrameworkException(
                                                     deployUpdateException.getMessage(),
                                                     ExceptionsHelper.status(deployUpdateException)
@@ -139,7 +140,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
                                 }
                             }, exception -> {
                                 logger.error("Failed to update new created resource", exception);
-                                registerRemoteModelFuture.completeExceptionally(
+                                registerRemoteModelFuture.onFailure(
                                     new FlowFrameworkException(exception.getMessage(), ExceptionsHelper.status(exception))
                                 );
                             })
@@ -147,7 +148,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
 
                     } catch (Exception e) {
                         logger.error("Failed to parse and update new created resource", e);
-                        registerRemoteModelFuture.completeExceptionally(
+                        registerRemoteModelFuture.onFailure(
                             new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e))
                         );
                     }
@@ -155,7 +156,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
 
                 void completeRegisterFuture(UpdateResponse response, String resourceName, MLRegisterModelResponse mlRegisterModelResponse) {
                     logger.info("successfully updated resources created in state index: {}", response.getIndex());
-                    registerRemoteModelFuture.complete(
+                    registerRemoteModelFuture.onResponse(
                         new WorkflowData(
                             Map.ofEntries(
                                 Map.entry(resourceName, mlRegisterModelResponse.getModelId()),
@@ -170,12 +171,12 @@ public class RegisterRemoteModelStep implements WorkflowStep {
                 @Override
                 public void onFailure(Exception e) {
                     logger.error("Failed to register remote model");
-                    registerRemoteModelFuture.completeExceptionally(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
+                    registerRemoteModelFuture.onFailure(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
                 }
             });
 
         } catch (FlowFrameworkException e) {
-            registerRemoteModelFuture.completeExceptionally(e);
+            registerRemoteModelFuture.onFailure(e);
         }
         return registerRemoteModelFuture;
     }

--- a/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
@@ -18,7 +18,6 @@ import org.opensearch.ml.common.agent.MLToolSpec;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.INCLUDE_OUTPUT_IN_AGENT_RESPONSE;

--- a/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.common.agent.MLToolSpec;
@@ -34,11 +35,11 @@ import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 public class ToolStep implements WorkflowStep {
 
     private static final Logger logger = LogManager.getLogger(ToolStep.class);
-    CompletableFuture<WorkflowData> toolFuture = new CompletableFuture<>();
+    PlainActionFuture<WorkflowData> toolFuture = PlainActionFuture.newFuture();
     static final String NAME = "create_tool";
 
     @Override
-    public CompletableFuture<WorkflowData> execute(
+    public PlainActionFuture<WorkflowData> execute(
         String currentNodeId,
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
@@ -80,7 +81,7 @@ public class ToolStep implements WorkflowStep {
 
             MLToolSpec mlToolSpec = builder.build();
 
-            toolFuture.complete(
+            toolFuture.onResponse(
                 new WorkflowData(
                     Map.ofEntries(Map.entry(TOOLS_FIELD, mlToolSpec)),
                     currentNodeInputs.getWorkflowId(),
@@ -91,7 +92,7 @@ public class ToolStep implements WorkflowStep {
             logger.info("Tool registered successfully {}", type);
 
         } catch (FlowFrameworkException e) {
-            toolFuture.completeExceptionally(e);
+            toolFuture.onFailure(e);
         }
         return toolFuture;
     }

--- a/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static org.opensearch.flowframework.common.CommonValue.SUCCESS;

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
@@ -8,8 +8,9 @@
  */
 package org.opensearch.flowframework.workflow;
 
+import org.opensearch.action.support.PlainActionFuture;
+
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Interface for the workflow setup of different building blocks.
@@ -24,7 +25,7 @@ public interface WorkflowStep {
      * @param previousNodeInputs Input params for this node that come from previous steps
      * @return A CompletableFuture of the building block. This block should return immediately, but not be completed until the step executes, containing either the step's output data or {@link WorkflowData#EMPTY} which may be passed to follow-on steps.
      */
-    CompletableFuture<WorkflowData> execute(
+    PlainActionFuture<WorkflowData> execute(
         String currentNodeId,
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,

--- a/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.transport;
 
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -32,7 +33,6 @@ import org.opensearch.transport.TransportService;
 import org.junit.AfterClass;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -122,9 +122,9 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
             return null;
         }).when(client).execute(any(GetWorkflowStateAction.class), any(GetWorkflowStateRequest.class), any());
 
-        when(this.deleteConnectorStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap())).thenReturn(
-            CompletableFuture.completedFuture(WorkflowData.EMPTY)
-        );
+        PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
+        future.onResponse(WorkflowData.EMPTY);
+        when(this.deleteConnectorStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap())).thenReturn(future);
 
         deprovisionWorkflowTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
         ArgumentCaptor<WorkflowResponse> responseCaptor = ArgumentCaptor.forClass(WorkflowResponse.class);
@@ -152,8 +152,8 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
             return null;
         }).when(client).execute(any(GetWorkflowStateAction.class), any(GetWorkflowStateRequest.class), any());
 
-        CompletableFuture<WorkflowData> future = new CompletableFuture<>();
-        future.completeExceptionally(new RuntimeException("rte"));
+        PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
+        future.onFailure(new RuntimeException("rte"));
         when(this.deleteConnectorStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap())).thenReturn(future);
 
         deprovisionWorkflowTransportAction.doExecute(mock(Task.class), workflowRequest, listener);

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
@@ -130,7 +130,7 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to create connector", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.flowframework.workflow;
 
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
@@ -24,7 +25,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.mockito.Mock;
@@ -99,7 +99,7 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
             return null;
         }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
 
-        CompletableFuture<WorkflowData> future = createConnectorStep.execute(
+        PlainActionFuture<WorkflowData> future = createConnectorStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -121,7 +121,7 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());
 
-        CompletableFuture<WorkflowData> future = createConnectorStep.execute(
+        PlainActionFuture<WorkflowData> future = createConnectorStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -130,7 +130,7 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to create connector", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.AdminClient;
 import org.opensearch.client.Client;
@@ -31,7 +32,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -109,7 +109,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
 
         @SuppressWarnings({ "unchecked" })
         ArgumentCaptor<ActionListener<CreateIndexResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
-        CompletableFuture<WorkflowData> future = createIndexStep.execute(
+        PlainActionFuture<WorkflowData> future = createIndexStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -119,7 +119,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
         verify(indicesAdminClient, times(1)).create(any(CreateIndexRequest.class), actionListenerCaptor.capture());
         actionListenerCaptor.getValue().onResponse(new CreateIndexResponse(true, true, "demo"));
 
-        assertTrue(future.isDone() && !future.isCompletedExceptionally());
+        assertTrue(future.isDone());
 
         Map<String, Object> outputData = Map.of(INDEX_NAME, "demo");
         assertEquals(outputData, future.get().getContent());
@@ -129,7 +129,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
     public void testCreateIndexStepFailure() throws ExecutionException, InterruptedException {
         @SuppressWarnings({ "unchecked" })
         ArgumentCaptor<ActionListener<CreateIndexResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
-        CompletableFuture<WorkflowData> future = createIndexStep.execute(
+        PlainActionFuture<WorkflowData> future = createIndexStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -140,7 +140,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
 
         actionListenerCaptor.getValue().onFailure(new Exception("Failed to create an index"));
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof Exception);
         assertEquals("Failed to create an index", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
@@ -140,7 +140,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
 
         actionListenerCaptor.getValue().onFailure(new Exception("Failed to create an index"));
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof Exception);
         assertEquals("Failed to create an index", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.flowframework.workflow;
 
 import org.opensearch.action.ingest.PutPipelineRequest;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.AdminClient;
@@ -22,7 +23,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.mockito.ArgumentCaptor;
@@ -90,7 +90,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ActionListener<AcknowledgedResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
-        CompletableFuture<WorkflowData> future = createIngestPipelineStep.execute(
+        PlainActionFuture<WorkflowData> future = createIngestPipelineStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -103,7 +103,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
         verify(clusterAdminClient, times(1)).putPipeline(any(PutPipelineRequest.class), actionListenerCaptor.capture());
         actionListenerCaptor.getValue().onResponse(new AcknowledgedResponse(true));
 
-        assertTrue(future.isDone() && !future.isCompletedExceptionally());
+        assertTrue(future.isDone());
         assertEquals(outpuData.getContent(), future.get().getContent());
     }
 
@@ -113,7 +113,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ActionListener<AcknowledgedResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
-        CompletableFuture<WorkflowData> future = createIngestPipelineStep.execute(
+        PlainActionFuture<WorkflowData> future = createIngestPipelineStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -126,7 +126,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
         verify(clusterAdminClient, times(1)).putPipeline(any(PutPipelineRequest.class), actionListenerCaptor.capture());
         actionListenerCaptor.getValue().onFailure(new Exception("Failed to create ingest pipeline"));
 
-        assertTrue(future.isDone() && future.isCompletedExceptionally());
+        assertTrue(future.isDone());
 
         ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get());
         assertTrue(exception.getCause() instanceof Exception);
@@ -148,13 +148,13 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
             "test-node-id"
         );
 
-        CompletableFuture<WorkflowData> future = createIngestPipelineStep.execute(
+        PlainActionFuture<WorkflowData> future = createIngestPipelineStep.execute(
             incorrectData.getNodeId(),
             incorrectData,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
-        assertTrue(future.isDone() && future.isCompletedExceptionally());
+        assertTrue(future.isDone());
 
         ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get());
         assertTrue(exception.getCause() instanceof Exception);

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteAgentStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteAgentStepTests.java
@@ -82,7 +82,7 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             Collections.emptyMap()
         );
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Missing required inputs [agent_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
@@ -106,7 +106,7 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).deleteAgent(any(String.class), any());
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to delete agent", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteAgentStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteAgentStepTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.flowframework.workflow;
 
 import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -20,7 +21,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.mockito.Mock;
@@ -60,7 +60,7 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).deleteAgent(any(String.class), any());
 
-        CompletableFuture<WorkflowData> future = deleteAgentStep.execute(
+        PlainActionFuture<WorkflowData> future = deleteAgentStep.execute(
             inputData.getNodeId(),
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(AGENT_ID, agentId), "workflowId", "nodeId")),
@@ -75,14 +75,14 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
     public void testNoAgentIdInOutput() throws IOException {
         DeleteAgentStep deleteAgentStep = new DeleteAgentStep(machineLearningNodeClient);
 
-        CompletableFuture<WorkflowData> future = deleteAgentStep.execute(
+        PlainActionFuture<WorkflowData> future = deleteAgentStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Missing required inputs [agent_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
@@ -97,7 +97,7 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).deleteAgent(any(String.class), any());
 
-        CompletableFuture<WorkflowData> future = deleteAgentStep.execute(
+        PlainActionFuture<WorkflowData> future = deleteAgentStep.execute(
             inputData.getNodeId(),
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(AGENT_ID, "test"), "workflowId", "nodeId")),
@@ -106,7 +106,7 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).deleteAgent(any(String.class), any());
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to delete agent", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
@@ -82,7 +82,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             Collections.emptyMap()
         );
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Missing required inputs [connector_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
@@ -106,7 +106,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).deleteConnector(any(String.class), any());
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to delete connector", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.flowframework.workflow;
 
 import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -20,7 +21,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.mockito.Mock;
@@ -60,7 +60,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).deleteConnector(any(String.class), any());
 
-        CompletableFuture<WorkflowData> future = deleteConnectorStep.execute(
+        PlainActionFuture<WorkflowData> future = deleteConnectorStep.execute(
             inputData.getNodeId(),
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(CONNECTOR_ID, connectorId), "workflowId", "nodeId")),
@@ -75,14 +75,14 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
     public void testNoConnectorIdInOutput() throws IOException {
         DeleteConnectorStep deleteConnectorStep = new DeleteConnectorStep(machineLearningNodeClient);
 
-        CompletableFuture<WorkflowData> future = deleteConnectorStep.execute(
+        PlainActionFuture<WorkflowData> future = deleteConnectorStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Missing required inputs [connector_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
@@ -97,7 +97,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).deleteConnector(any(String.class), any());
 
-        CompletableFuture<WorkflowData> future = deleteConnectorStep.execute(
+        PlainActionFuture<WorkflowData> future = deleteConnectorStep.execute(
             inputData.getNodeId(),
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(CONNECTOR_ID, "test"), "workflowId", "nodeId")),
@@ -106,7 +106,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).deleteConnector(any(String.class), any());
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to delete connector", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
@@ -82,7 +82,7 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap()
         );
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Missing required inputs [model_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
@@ -106,7 +106,7 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).deleteModel(any(String.class), any());
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to delete model", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.flowframework.workflow;
 
 import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -20,7 +21,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.mockito.Mock;
@@ -60,7 +60,7 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).deleteModel(any(String.class), any());
 
-        CompletableFuture<WorkflowData> future = deleteModelStep.execute(
+        PlainActionFuture<WorkflowData> future = deleteModelStep.execute(
             inputData.getNodeId(),
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, modelId), "workflowId", "nodeId")),
@@ -75,14 +75,14 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
     public void testNoModelIdInOutput() throws IOException {
         DeleteModelStep deleteModelStep = new DeleteModelStep(machineLearningNodeClient);
 
-        CompletableFuture<WorkflowData> future = deleteModelStep.execute(
+        PlainActionFuture<WorkflowData> future = deleteModelStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Missing required inputs [model_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
@@ -97,7 +97,7 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).deleteModel(any(String.class), any());
 
-        CompletableFuture<WorkflowData> future = deleteModelStep.execute(
+        PlainActionFuture<WorkflowData> future = deleteModelStep.execute(
             inputData.getNodeId(),
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, "test"), "workflowId", "nodeId")),
@@ -106,7 +106,7 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).deleteModel(any(String.class), any());
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to delete model", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -34,7 +35,6 @@ import org.junit.AfterClass;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -150,14 +150,14 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
 
-        CompletableFuture<WorkflowData> future = deployModel.execute(
+        PlainActionFuture<WorkflowData> future = deployModel.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
 
-        future.join();
+        future.actionGet();
 
         verify(machineLearningNodeClient, times(1)).deploy(any(String.class), any());
         verify(machineLearningNodeClient, times(1)).getTask(any(), any());
@@ -177,7 +177,7 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).deploy(eq("modelId"), actionListenerCaptor.capture());
 
-        CompletableFuture<WorkflowData> future = deployModel.execute(
+        PlainActionFuture<WorkflowData> future = deployModel.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -232,7 +232,7 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).getTask(any(), any());
 
-        CompletableFuture<WorkflowData> future = this.deployModel.execute(
+        PlainActionFuture<WorkflowData> future = this.deployModel.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),

--- a/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
@@ -127,7 +127,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to register model group", ex.getCause().getMessage());
@@ -144,7 +144,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
             Collections.emptyMap()
         );
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Missing required inputs [name] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ModelGroupStepTests.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.flowframework.workflow;
 
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
@@ -25,7 +26,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.mockito.ArgumentCaptor;
@@ -91,7 +91,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
             return null;
         }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
 
-        CompletableFuture<WorkflowData> future = modelGroupStep.execute(
+        PlainActionFuture<WorkflowData> future = modelGroupStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -118,7 +118,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
 
-        CompletableFuture<WorkflowData> future = modelGroupStep.execute(
+        PlainActionFuture<WorkflowData> future = modelGroupStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -127,7 +127,7 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to register model group", ex.getCause().getMessage());
@@ -137,14 +137,14 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
     public void testRegisterModelGroupWithNoName() throws IOException {
         RegisterModelGroupStep modelGroupStep = new RegisterModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
-        CompletableFuture<WorkflowData> future = modelGroupStep.execute(
+        PlainActionFuture<WorkflowData> future = modelGroupStep.execute(
             inputDataWithNoName.getNodeId(),
             inputDataWithNoName,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Missing required inputs [name] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/NoOpStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/NoOpStepTests.java
@@ -8,24 +8,23 @@
  */
 package org.opensearch.flowframework.workflow;
 
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
 
 public class NoOpStepTests extends OpenSearchTestCase {
 
     public void testNoOpStep() throws IOException {
         NoOpStep noopStep = new NoOpStep();
         assertEquals(NoOpStep.NAME, noopStep.getName());
-        CompletableFuture<WorkflowData> future = noopStep.execute(
+        PlainActionFuture<WorkflowData> future = noopStep.execute(
             "nodeId",
             WorkflowData.EMPTY,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
         assertTrue(future.isDone());
-        assertFalse(future.isCompletedExceptionally());
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
@@ -196,13 +196,8 @@ public class ProcessNodeTests extends OpenSearchTestCase {
         assertEquals("E", nodeE.toString());
 
         PlainActionFuture<WorkflowData> f = nodeE.execute();
-        UncategorizedExecutionException exception = assertThrows(UncategorizedExecutionException.class, () -> f.actionGet());
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> f.actionGet());
         assertTrue(f.isDone());
-        assertEquals(
-            "java.util.concurrent.ExecutionException: java.lang.RuntimeException: Test exception",
-            exception.getCause().getMessage()
-        );
-
         // Tests where we already called execute
         assertThrows(IllegalStateException.class, () -> nodeE.execute());
     }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -146,7 +146,7 @@ public class RegisterAgentTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to register the agent", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.flowframework.workflow;
 
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
@@ -25,7 +26,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.mockito.ArgumentCaptor;
@@ -105,7 +105,7 @@ public class RegisterAgentTests extends OpenSearchTestCase {
             return null;
         }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
 
-        CompletableFuture<WorkflowData> future = registerAgentStep.execute(
+        PlainActionFuture<WorkflowData> future = registerAgentStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -137,7 +137,7 @@ public class RegisterAgentTests extends OpenSearchTestCase {
             return null;
         }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
 
-        CompletableFuture<WorkflowData> future = registerAgentStep.execute(
+        PlainActionFuture<WorkflowData> future = registerAgentStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
@@ -146,7 +146,7 @@ public class RegisterAgentTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to register the agent", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -32,7 +33,6 @@ import org.junit.AfterClass;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -161,14 +161,14 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
 
-        CompletableFuture<WorkflowData> future = registerLocalModelStep.execute(
+        PlainActionFuture<WorkflowData> future = registerLocalModelStep.execute(
             workflowData.getNodeId(),
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
 
-        future.join();
+        future.actionGet();
 
         verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
         verify(machineLearningNodeClient, times(1)).getTask(any(), any());
@@ -185,7 +185,7 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
 
-        CompletableFuture<WorkflowData> future = this.registerLocalModelStep.execute(
+        PlainActionFuture<WorkflowData> future = this.registerLocalModelStep.execute(
             workflowData.getNodeId(),
             workflowData,
             Collections.emptyMap(),
@@ -234,7 +234,7 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).getTask(any(), any());
 
-        CompletableFuture<WorkflowData> future = this.registerLocalModelStep.execute(
+        PlainActionFuture<WorkflowData> future = this.registerLocalModelStep.execute(
             workflowData.getNodeId(),
             workflowData,
             Collections.emptyMap(),
@@ -247,14 +247,14 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
     }
 
     public void testMissingInputs() {
-        CompletableFuture<WorkflowData> future = registerLocalModelStep.execute(
+        PlainActionFuture<WorkflowData> future = registerLocalModelStep.execute(
             "nodeId",
             new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id"),
             Collections.emptyMap(),
             Collections.emptyMap()
         );
         assertTrue(future.isDone());
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertTrue(ex.getCause().getMessage().startsWith("Missing required inputs ["));

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -254,7 +254,6 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap()
         );
         assertTrue(future.isDone());
-        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertTrue(ex.getCause().getMessage().startsWith("Missing required inputs ["));

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -32,7 +33,6 @@ import org.junit.AfterClass;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -155,14 +155,14 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
 
-        CompletableFuture<WorkflowData> future = registerLocalPretrainedModelStep.execute(
+        PlainActionFuture<WorkflowData> future = registerLocalPretrainedModelStep.execute(
             workflowData.getNodeId(),
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
 
-        future.join();
+        future.actionGet();
 
         verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
         verify(machineLearningNodeClient, times(1)).getTask(any(), any());
@@ -179,7 +179,7 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
 
-        CompletableFuture<WorkflowData> future = this.registerLocalPretrainedModelStep.execute(
+        PlainActionFuture<WorkflowData> future = this.registerLocalPretrainedModelStep.execute(
             workflowData.getNodeId(),
             workflowData,
             Collections.emptyMap(),
@@ -228,7 +228,7 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).getTask(any(), any());
 
-        CompletableFuture<WorkflowData> future = this.registerLocalPretrainedModelStep.execute(
+        PlainActionFuture<WorkflowData> future = this.registerLocalPretrainedModelStep.execute(
             workflowData.getNodeId(),
             workflowData,
             Collections.emptyMap(),
@@ -241,14 +241,13 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
     }
 
     public void testMissingInputs() {
-        CompletableFuture<WorkflowData> future = registerLocalPretrainedModelStep.execute(
+        PlainActionFuture<WorkflowData> future = registerLocalPretrainedModelStep.execute(
             "nodeId",
             new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id"),
             Collections.emptyMap(),
             Collections.emptyMap()
         );
         assertTrue(future.isDone());
-        assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertTrue(ex.getCause().getMessage().startsWith("Missing required inputs ["));

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -32,7 +33,6 @@ import org.junit.AfterClass;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -158,14 +158,14 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             return null;
         }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
 
-        CompletableFuture<WorkflowData> future = registerLocalSparseEncodingModelStep.execute(
+        PlainActionFuture<WorkflowData> future = registerLocalSparseEncodingModelStep.execute(
             workflowData.getNodeId(),
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
 
-        future.join();
+        future.actionGet();
 
         verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
         verify(machineLearningNodeClient, times(1)).getTask(any(), any());
@@ -182,7 +182,7 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             return null;
         }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
 
-        CompletableFuture<WorkflowData> future = this.registerLocalSparseEncodingModelStep.execute(
+        PlainActionFuture<WorkflowData> future = this.registerLocalSparseEncodingModelStep.execute(
             workflowData.getNodeId(),
             workflowData,
             Collections.emptyMap(),
@@ -231,7 +231,7 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             return null;
         }).when(machineLearningNodeClient).getTask(any(), any());
 
-        CompletableFuture<WorkflowData> future = this.registerLocalSparseEncodingModelStep.execute(
+        PlainActionFuture<WorkflowData> future = this.registerLocalSparseEncodingModelStep.execute(
             workflowData.getNodeId(),
             workflowData,
             Collections.emptyMap(),
@@ -244,14 +244,13 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
     }
 
     public void testMissingInputs() {
-        CompletableFuture<WorkflowData> future = registerLocalSparseEncodingModelStep.execute(
+        PlainActionFuture<WorkflowData> future = registerLocalSparseEncodingModelStep.execute(
             "nodeId",
             new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id"),
             Collections.emptyMap(),
             Collections.emptyMap()
         );
         assertTrue(future.isDone());
-        assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertTrue(ex.getCause().getMessage().startsWith("Missing required inputs ["));

--- a/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
@@ -8,13 +8,13 @@
  */
 package org.opensearch.flowframework.workflow;
 
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.ml.common.agent.MLToolSpec;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 public class ToolStepTests extends OpenSearchTestCase {
@@ -40,7 +40,7 @@ public class ToolStepTests extends OpenSearchTestCase {
     public void testTool() throws IOException, ExecutionException, InterruptedException {
         ToolStep toolStep = new ToolStep();
 
-        CompletableFuture<WorkflowData> future = toolStep.execute(
+        PlainActionFuture<WorkflowData> future = toolStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),

--- a/src/test/java/org/opensearch/flowframework/workflow/UndeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UndeployModelStepTests.java
@@ -90,7 +90,7 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap()
         );
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Missing required inputs [model_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
@@ -123,7 +123,7 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).undeploy(any(String[].class), any(), any());
 
-        assertFalse(future.isDone());
+        assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof OpenSearchException);
         assertEquals("Failed to undeploy model on nodes [failed-node]", ex.getCause().getMessage());

--- a/src/test/java/org/opensearch/flowframework/workflow/UndeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UndeployModelStepTests.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -23,7 +24,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.mockito.Mock;
@@ -68,7 +68,7 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).undeploy(any(String[].class), any(), any());
 
-        CompletableFuture<WorkflowData> future = UndeployModelStep.execute(
+        PlainActionFuture<WorkflowData> future = UndeployModelStep.execute(
             inputData.getNodeId(),
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, modelId), "workflowId", "nodeId")),
@@ -83,14 +83,14 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
     public void testNoModelIdInOutput() throws IOException {
         UndeployModelStep UndeployModelStep = new UndeployModelStep(machineLearningNodeClient);
 
-        CompletableFuture<WorkflowData> future = UndeployModelStep.execute(
+        PlainActionFuture<WorkflowData> future = UndeployModelStep.execute(
             inputData.getNodeId(),
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap()
         );
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Missing required inputs [model_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
@@ -114,7 +114,7 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
             return null;
         }).when(machineLearningNodeClient).undeploy(any(String[].class), any(), any());
 
-        CompletableFuture<WorkflowData> future = UndeployModelStep.execute(
+        PlainActionFuture<WorkflowData> future = UndeployModelStep.execute(
             inputData.getNodeId(),
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, "test"), "workflowId", "nodeId")),
@@ -123,7 +123,7 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).undeploy(any(String[].class), any(), any());
 
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof OpenSearchException);
         assertEquals("Failed to undeploy model on nodes [failed-node]", ex.getCause().getMessage());


### PR DESCRIPTION
### Description
Replace all CompletableFutures with PlainActionFutures
Except 
- `CompletableFuture.runAsync`

### Issues Resolved
Fixes https://github.com/opensearch-project/flow-framework/issues/409

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
