### PR TITLE
Change thread pool to a ScalingExecutorBuilder

### DIFF
--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -18,6 +18,7 @@ import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
@@ -64,7 +65,7 @@ import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ExecutorBuilder;
-import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -176,11 +177,11 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin {
     @Override
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
         return List.of(
-            new FixedExecutorBuilder(
-                settings,
+            new ScalingExecutorBuilder(
                 WORKFLOW_THREAD_POOL,
+                1,
                 OpenSearchExecutors.allocatedProcessors(settings),
-                100,
+                TimeValue.timeValueMinutes(5),
                 FLOW_FRAMEWORK_THREAD_POOL_PREFIX + WORKFLOW_THREAD_POOL
             )
         );

--- a/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
@@ -25,7 +25,7 @@ import org.opensearch.flowframework.workflow.WorkflowData;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -56,11 +56,11 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
     private static ThreadPool threadPool = new TestThreadPool(
         DeprovisionWorkflowTransportActionTests.class.getName(),
-        new FixedExecutorBuilder(
-            Settings.EMPTY,
+        new ScalingExecutorBuilder(
             WORKFLOW_THREAD_POOL,
+            1,
             OpenSearchExecutors.allocatedProcessors(Settings.EMPTY),
-            100,
+            TimeValue.timeValueMinutes(5),
             FLOW_FRAMEWORK_THREAD_POOL_PREFIX + WORKFLOW_THREAD_POOL
         )
     );

--- a/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
@@ -26,7 +26,7 @@ import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.MLTaskType;
 import org.opensearch.ml.common.transport.deploy.MLDeployModelResponse;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.AfterClass;
@@ -82,11 +82,11 @@ public class DeployModelStepTests extends OpenSearchTestCase {
 
         testThreadPool = new TestThreadPool(
             DeployModelStepTests.class.getName(),
-            new FixedExecutorBuilder(
-                Settings.EMPTY,
+            new ScalingExecutorBuilder(
                 WORKFLOW_THREAD_POOL,
+                1,
                 OpenSearchExecutors.allocatedProcessors(Settings.EMPTY),
-                100,
+                TimeValue.timeValueMinutes(5),
                 FLOW_FRAMEWORK_THREAD_POOL_PREFIX + WORKFLOW_THREAD_POOL
             )
         );

--- a/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
@@ -12,7 +12,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.AfterClass;
@@ -42,11 +42,11 @@ public class ProcessNodeTests extends OpenSearchTestCase {
     public static void setup() {
         testThreadPool = new TestThreadPool(
             ProcessNodeTests.class.getName(),
-            new FixedExecutorBuilder(
-                Settings.EMPTY,
+            new ScalingExecutorBuilder(
                 WORKFLOW_THREAD_POOL,
+                1,
                 OpenSearchExecutors.allocatedProcessors(Settings.EMPTY),
-                100,
+                TimeValue.timeValueMinutes(5),
                 FLOW_FRAMEWORK_THREAD_POOL_PREFIX + WORKFLOW_THREAD_POOL
             )
         );

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -25,7 +25,7 @@ import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.AfterClass;
@@ -78,11 +78,11 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
 
         testThreadPool = new TestThreadPool(
             RegisterLocalCustomModelStepTests.class.getName(),
-            new FixedExecutorBuilder(
-                Settings.EMPTY,
+            new ScalingExecutorBuilder(
                 WORKFLOW_THREAD_POOL,
+                1,
                 OpenSearchExecutors.allocatedProcessors(Settings.EMPTY),
-                100,
+                TimeValue.timeValueMinutes(5),
                 FLOW_FRAMEWORK_THREAD_POOL_PREFIX + WORKFLOW_THREAD_POOL
             )
         );

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
@@ -25,7 +25,7 @@ import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.AfterClass;
@@ -78,11 +78,11 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
 
         testThreadPool = new TestThreadPool(
             RegisterLocalCustomModelStepTests.class.getName(),
-            new FixedExecutorBuilder(
-                Settings.EMPTY,
+            new ScalingExecutorBuilder(
                 WORKFLOW_THREAD_POOL,
+                1,
                 OpenSearchExecutors.allocatedProcessors(Settings.EMPTY),
-                100,
+                TimeValue.timeValueMinutes(5),
                 FLOW_FRAMEWORK_THREAD_POOL_PREFIX + WORKFLOW_THREAD_POOL
             )
         );

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
@@ -25,7 +25,7 @@ import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.AfterClass;
@@ -78,11 +78,11 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
 
         testThreadPool = new TestThreadPool(
             RegisterLocalCustomModelStepTests.class.getName(),
-            new FixedExecutorBuilder(
-                Settings.EMPTY,
+            new ScalingExecutorBuilder(
                 WORKFLOW_THREAD_POOL,
+                1,
                 OpenSearchExecutors.allocatedProcessors(Settings.EMPTY),
-                100,
+                TimeValue.timeValueMinutes(5),
                 FLOW_FRAMEWORK_THREAD_POOL_PREFIX + WORKFLOW_THREAD_POOL
             )
         );

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -27,7 +27,7 @@ import org.opensearch.flowframework.model.WorkflowNode;
 import org.opensearch.flowframework.model.WorkflowValidator;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.AfterClass;
@@ -111,11 +111,11 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
 
         testThreadPool = new TestThreadPool(
             WorkflowProcessSorterTests.class.getName(),
-            new FixedExecutorBuilder(
-                Settings.EMPTY,
+            new ScalingExecutorBuilder(
                 WORKFLOW_THREAD_POOL,
+                1,
                 OpenSearchExecutors.allocatedProcessors(Settings.EMPTY),
-                100,
+                TimeValue.timeValueMinutes(5),
                 FLOW_FRAMEWORK_THREAD_POOL_PREFIX + WORKFLOW_THREAD_POOL
             )
         );


### PR DESCRIPTION
### Description

Changes Flow Framework thread pool to use a ScalingExecutorBuilder
 - the `FixedExecutorBuilder` establishes a maximum queue size which is arbitrary and not scalable
 - the `ResizableExecutorBuilder` allowing users to manually change this isn't used much
 - the `ScalingExecutorBuilder` is widely used across OpenSearch and plugins and is clearly the preferred option here unless we know better. (Which we don't.)

Matches ["generic" thread pool type](https://github.com/opensearch-project/OpenSearch/blob/e265355e8cf8399443b84104032af075953f1245/server/src/main/java/org/opensearch/threadpool/ThreadPool.java#L238), with different number of processors since it's more narrowly focused.

Uses [similar threadpool to AD](https://github.com/opensearch-project/anomaly-detection/blob/7c0ce4cb554a05230ecf5365b903219f357997bf/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java#L845-L853) except with shorter keepalive to correspond to [most OpenSearch thread pool times](https://github.com/opensearch-project/OpenSearch/blob/e265355e8cf8399443b84104032af075953f1245/server/src/main/java/org/opensearch/threadpool/ThreadPool.java#L251-L254), and uses full number of allocated processors (smaller # than generic).

Allows user to change # of processors per node via settings.

### Issues Resolved

Fixes #420 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
