### PR TITLE
Only pull security plugin zip if security enabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,11 @@ dependencies {
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
+
+    // Only pull security plugin dependency if security is enabled
+    if(System.getProperty('security.enabled') == 'true'){
+        zipArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
+    }
 
     configurations.all {
         resolutionStrategy {


### PR DESCRIPTION
### Description
Conditionally pulls in security plugin zip if security is enabled. Security is only enabled when running security enabled integration tests. `./gradlew assemble` now passes if security is unavailable. 

More context can be found [here](https://github.com/opensearch-project/flow-framework/issues/410#issuecomment-1900918784)

### Issues Resolved
https://github.com/opensearch-project/flow-framework/issues/410

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
