### PR TITLE
Work around JDK 21.0.2 bug impacting scaling executors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 21]
+        # Don't use 21.0.2 https://github.com/opensearch-project/flow-framework/issues/426
+        java: [11, 21.0.1]
         include:
           - os: ubuntu-latest
             java: 17
@@ -62,7 +63,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 21]
+        # Don't use 21.0.2 https://github.com/opensearch-project/flow-framework/issues/426
+        java: [11, 21.0.1]
         include:
           - os: ubuntu-latest
             java: 17

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -16,7 +16,8 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        # Don't use 21.0.2 https://github.com/opensearch-project/flow-framework/issues/426
+        java: [11, 17, 21.0.1]
 
     name: Run Security Integration Tests on Linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Restricts CI GitHub Actions to run on JDK 21.0.1 until https://bugs.openjdk.org/browse/JDK-8323659 is released and deployed to runners.

### Issues Resolved

Fixes #426 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
