### PR TITLE
[Backport 2.x] Work around JDK 21.0.2 bug impacting scaling executors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11]
+        # Don't use 21.0.2 https://github.com/opensearch-project/flow-framework/issues/426
+        java: [11, 21.0.1]
         include:
           - os: ubuntu-latest
             java: 17
@@ -62,7 +63,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11]
+        # Don't use 21.0.2 https://github.com/opensearch-project/flow-framework/issues/426
+        java: [11, 21.0.1]
         include:
           - os: ubuntu-latest
             java: 17

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -16,7 +16,8 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        java: [11, 17]
+      # Don't use 21.0.2 https://github.com/opensearch-project/flow-framework/issues/426
+        java: [11, 17, 21.0.1]
 
     name: Run Security Integration Tests on Linux
     runs-on: ubuntu-latest

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -16,7 +16,7 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [11, 17]
 
     name: Run Security Integration Tests on Linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
Manual backport of https://github.com/opensearch-project/flow-framework/pull/429

### Issues Resolved
Coming from https://github.com/opensearch-project/flow-framework/pull/429#issuecomment-1902458777

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
