### PR TITLE
Update GA worklows to use JDK 21.0.2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,8 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # Don't use 21.0.2 https://github.com/opensearch-project/flow-framework/issues/426
-        java: [11, 21.0.1]
+        java: [11, 21]
         include:
           - os: ubuntu-latest
             java: 17
@@ -64,8 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # Don't use 21.0.2 https://github.com/opensearch-project/flow-framework/issues/426
-        java: [11, 21.0.1]
+        java: [11, 21]
         include:
           - os: ubuntu-latest
             java: 17
@@ -82,6 +80,6 @@ jobs:
         run: |
           ./gradlew integTest yamlRestTest
       - name: Multi Nodes Integration Testing
-        if: matrix.java == '21.0.1'
+        if: matrix.java == '21'
         run: |
           ./gradlew integTest -PnumNodes=3

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -16,8 +16,7 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        # Don't use 21.0.2 https://github.com/opensearch-project/flow-framework/issues/426
-        java: [11, 17, 21.0.1]
+        java: [11, 17, 21]
 
     name: Run Security Integration Tests on Linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
We should be all set to use JDK 21.0.2 (with mitigation in place https://github.com/opensearch-project/OpenSearch/pull/11968)

### Issues Resolved
Follow up on https://github.com/opensearch-project/flow-framework/issues/426

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
