### PR TITLE
Retry flaky tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 ### Added
 - Github workflow for changelog verification ([#440](https://github.com/opensearch-project/flow-framework/pull/440))
+- Retry flaky tests ([#449](https://github.com/opensearch-project/flow-framework/pull/449))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 ### Added
 - Github workflow for changelog verification ([#440](https://github.com/opensearch-project/flow-framework/pull/440))
-- Retry flaky tests ([#449](https://github.com/opensearch-project/flow-framework/pull/449))
 
 ### Changed
 

--- a/build.gradle
+++ b/build.gradle
@@ -410,11 +410,11 @@ task integTestRemote(type: RestIntegTestTask) {
 // test retry configuration
 subprojects {
     apply plugin: "org.gradle.test-retry"
-    tasks.withType(Test).configureEach {
+    tasks.withType(RestIntegTestTask).configureEach {
         retry {
             failOnPassedAfterRetry = false
             maxRetries = 3
-            maxFailures = 10
+            maxFailures = 5
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ buildscript {
 
 plugins {
     id "de.undercouch.download" version "5.5.0"
+    id "org.gradle.test-retry" version "1.5.4" apply false
 }
 
 apply plugin: 'java'
@@ -401,6 +402,19 @@ task integTestRemote(type: RestIntegTestTask) {
         filter {
             includeTestsMatching "org.opensearch.flowframework.rest.FlowFrameworkSecureRestApiIT"
             excludeTestsMatching "org.opensearch.flowframework.rest.FlowFrameworkRestApiIT"
+        }
+    }
+}
+
+
+// test retry configuration
+subprojects {
+    apply plugin: "org.gradle.test-retry"
+    tasks.withType(Test).configureEach {
+        retry {
+            failOnPassedAfterRetry = false
+            maxRetries = 3
+            maxFailures = 10
         }
     }
 }


### PR DESCRIPTION
### Description
Retry flaky tests using `org.gradle.test-retry` plugin.

### Issues Resolved
Closes https://github.com/opensearch-project/flow-framework/issues/442

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
