### PR TITLE
Restrict verifier to run on main

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -1,10 +1,9 @@
 name: "Changelog Verifier"
 on:
-  push:
+  pull_request:
     branches-ignore:
       - 'whitesource-remediate/**'
       - 'backport/**'
-  pull_request:
     branches: main
     types: [opened, edited, review_requested, synchronize, reopened, ready_for_review, labeled, unlabeled]
 

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -1,9 +1,10 @@
 name: "Changelog Verifier"
 on:
-  pull_request:
+  push:
     branches-ignore:
       - 'whitesource-remediate/**'
       - 'backport/**'
+  pull_request:
     branches: main
     types: [opened, edited, review_requested, synchronize, reopened, ready_for_review, labeled, unlabeled]
 

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -5,6 +5,7 @@ on:
       - 'whitesource-remediate/**'
       - 'backport/**'
   pull_request:
+    branches: main
     types: [opened, edited, review_requested, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -414,7 +414,7 @@ subprojects {
         retry {
             failOnPassedAfterRetry = false
             maxRetries = 3
-            maxFailures = 5
+            maxFailures = 10
         }
     }
 }


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/flow-framework/pull/450#issuecomment-1909126642. Restrict verifier to run on main

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
