### PR TITLE
Wait for yellow cluster before integ tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,7 +253,9 @@ integTest {
         systemProperty 'cluster.number_of_nodes', "${_numNodes}"
         // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
         // not being written, the waitForAllConditions ensures it's written
+        // additionally adding condition of yellow cluster
         getClusters().forEach { cluster ->
+            cluster.addWaitForClusterHealth()
             cluster.waitForAllConditions()
         }
     }
@@ -424,7 +426,9 @@ run {
     doFirst {
         // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
         // not being written, the waitForAllConditions ensures it's written
+        // additionally adding condition of yellow cluster
         getClusters().forEach { cluster ->
+            cluster.addWaitForClusterHealth()
             cluster.waitForAllConditions()
         }
     }


### PR DESCRIPTION
### Description

Waits to execute integration tests until the cluster is yellow.

### Issues Resolved

Flaky integ tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
