### PR TITLE
Separate multi-node integ tests to their own job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,7 +79,22 @@ jobs:
       - name: Build and Run Tests
         run: |
           ./gradlew integTest yamlRestTest
-      - name: Multi Nodes Integration Testing
-        if: matrix.java == '21'
+  integMultiNodeTest:
+    needs: [spotless, javadoc]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        java: [21]
+    name: Multi-Node Integ Test JDK${{ matrix.java }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
+      - name: Build and Run Tests
         run: |
           ./gradlew integTest -PnumNodes=3


### PR DESCRIPTION
### Description

Multi-node integration tests were set to run on the same server as integration tests had just run on.  On cluster startup, the nodes were reading the previous cluster state from the (dropped) single node and uses the same stored indices.

Additionally ML Commons recently made the default `true` for a feature that auto-deploys ML models after a node drop and recovery, so these recoveries were occurring.

While no guarantee separating this out will fix the flaky macOS tests, I've seen enough hints in the logs to suggest that leftover bits from previous tests are slowing startup and potentially contributing to test failures. 

### Issues Resolved

Might resolve flaky tests. At least will cut down on the debugging noise.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
