### PR TITLE
Fix Integ test retry configiration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,13 +408,15 @@ task integTestRemote(type: RestIntegTestTask) {
 
 
 // test retry configuration
-subprojects {
+allprojects {
     apply plugin: "org.gradle.test-retry"
     tasks.withType(RestIntegTestTask).configureEach {
         retry {
-            failOnPassedAfterRetry = false
-            maxRetries = 3
-            maxFailures = 10
+            if (System.getenv().containsKey("CI")) {
+                maxRetries = 1
+                maxFailures = 3
+                failOnPassedAfterRetry = false
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

The task retry configuration was only set on subprojects, but we were running the root project.

Also set it to only run on GitHub actions, so local tests will not retry.

### Issues Resolved

Fixes #461 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
