### PR TITLE
Prevent provisioning an already-provisioned workflow

### DIFF
--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -412,8 +412,8 @@ public class FlowFrameworkIndicesHandler {
         }
         doesTemplateExist(documentId, templateExists -> {
             if (templateExists) {
-                isWorkflowProvisioned(documentId, workflowIsProvisioned -> {
-                    if (workflowIsProvisioned) {
+                isWorkflowNotStarted(documentId, workflowIsNotStarted -> {
+                    if (workflowIsNotStarted) {
                         IndexRequest request = new IndexRequest(GLOBAL_CONTEXT_INDEX).id(documentId);
                         try (
                             XContentBuilder builder = XContentFactory.jsonBuilder();
@@ -474,7 +474,7 @@ public class FlowFrameworkIndicesHandler {
      * @param listener action listener
      * @param <T> action listener response type
      */
-    public <T> void isWorkflowProvisioned(String documentId, Consumer<Boolean> booleanResultConsumer, ActionListener<T> listener) {
+    public <T> void isWorkflowNotStarted(String documentId, Consumer<Boolean> booleanResultConsumer, ActionListener<T> listener) {
         GetRequest getRequest = new GetRequest(WORKFLOW_STATE_INDEX, documentId);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             client.get(getRequest, ActionListener.wrap(response -> {

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -60,7 +60,7 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
     private final PluginsService pluginsService;
 
     /**
-     * Intantiates a new CreateWorkflowTransportAction
+     * Instantiates a new CreateWorkflowTransportAction
      * @param transportService the TransportService
      * @param actionFilters action filters
      * @param workflowProcessSorter the workflow process sorter

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -141,12 +141,15 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                                 Map.entry(RESOURCES_CREATED_FIELD, Collections.emptyList())
                             ),
                             ActionListener.wrap(updateResponse -> {
-                                logger.info("updated workflow {} state to PROVISIONING", request.getWorkflowId());
+                                logger.info("updated workflow {} state to {}", request.getWorkflowId(), State.PROVISIONING);
+                                executeWorkflowAsync(workflowId, provisionProcessSequence, listener);
                                 listener.onResponse(new WorkflowResponse(workflowId));
-                            }, exception -> { logger.error("Failed to update workflow state : {}", exception.getMessage()); })
+                            }, exception -> {
+                                String errorMessage = "Failed to update wowrfow state: " + workflowId;
+                                logger.error(errorMessage, exception);
+                                listener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception)));
+                            })
                         );
-
-                        executeWorkflowAsync(workflowId, provisionProcessSequence, listener);
                     } else {
                         String errorMessage = "The template has already been provisioned: " + workflowId;
                         logger.error(errorMessage);

--- a/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
+++ b/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
@@ -274,7 +274,7 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
             responseListener.onResponse(new GetResponse(getResult));
             return null;
         }).when(client).get(any(GetRequest.class), any());
-        flowFrameworkIndicesHandler.isWorkflowProvisioned(documentId, function, listener);
+        flowFrameworkIndicesHandler.isWorkflowNotStarted(documentId, function, listener);
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener, times(1)).onFailure(exceptionCaptor.capture());
         assertTrue(exceptionCaptor.getValue().getMessage().contains("Failed to parse workflow state"));


### PR DESCRIPTION
### Description

Prevents provisioning a workflow whose state is anything other than NOT_STARTED.

Clarified some associated method/variable naming.

### Issues Resolved

Fixes #445 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
