### PR TITLE
Fixing security tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,6 +216,9 @@ integTest {
         is_https = is_https == null ? 'true' : is_https
         user = user == null ? 'admin' : user
         password = password == null ? 'admin' : password
+        System.setProperty("https", is_https)
+        System.setProperty("user", user)
+        System.setProperty("password", password)
     }
     systemProperty('https', is_https)
     systemProperty('user', user)
@@ -229,14 +232,14 @@ integTest {
     }
 
     // Exclude integration tests that require security plugin
-    if (System.getProperty("security.enabled") == null || System.getProperty("security.enabled") == "false") {
+    if (System.getProperty("https") == null || System.getProperty("https") == "false") {
         filter {
             excludeTestsMatching "org.opensearch.flowframework.rest.FlowFrameworkSecureRestApiIT"
         }
     }
 
     // Include only secure integration tests in security enabled clusters
-    if (System.getProperty("security.enabled") != null && System.getProperty("security.enabled") == "true") {
+    if (System.getProperty("https") != null && System.getProperty("https") == "true") {
         filter {
             includeTestsMatching "org.opensearch.flowframework.rest.FlowFrameworkSecureRestApiIT"
             excludeTestsMatching "org.opensearch.flowframework.rest.FlowFrameworkRestApiIT"
@@ -269,7 +272,7 @@ testClusters.integTest {
     testDistribution = "ARCHIVE"
 
     // Optionally install security
-    if (System.getProperty("security.enabled") != null && System.getProperty("security.enabled") == "true") {
+    if (System.getProperty("https") != null && System.getProperty("https") == "true") {
         // Retrieve Security Plugin Zip from zipArchive
         configurations.secureIntegTestPluginArchive.asFileTree.each {
             if(it.name.contains("opensearch-security")) {
@@ -376,6 +379,9 @@ task integTestRemote(type: RestIntegTestTask) {
         is_https = is_https == null ? 'true' : is_https
         user = user == null ? 'admin' : user
         password = password == null ? 'admin' : password
+        System.setProperty("https", is_https)
+        System.setProperty("user", user)
+        System.setProperty("password", password)
     }
     systemProperty('https', is_https)
     systemProperty('user', user)


### PR DESCRIPTION
### Description
Enabled security integration tests using `-Dhttps` flag. Now security enabled integration tests will run with the following commands 

- ./gradlew integTest -Dhttps=true -Duser=admin -Dpassword=admin
- ./gradlew integTest -Dsecurity.enabled=true

### Issues Resolved
Resolves https://github.com/opensearch-project/flow-framework/issues/469

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
