### PR TITLE
Filter out system indices from deletion for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,6 +216,9 @@ integTest {
         is_https = is_https == null ? 'true' : is_https
         user = user == null ? 'admin' : user
         password = password == null ? 'admin' : password
+        System.setProperty("https", is_https)
+        System.setProperty("user", user)
+        System.setProperty("password", password)
     }
     systemProperty('https', is_https)
     systemProperty('user', user)
@@ -229,14 +232,14 @@ integTest {
     }
 
     // Exclude integration tests that require security plugin
-    if (System.getProperty("security.enabled") == null || System.getProperty("security.enabled") == "false") {
+    if (System.getProperty("https") == null || System.getProperty("https") == "false") {
         filter {
             excludeTestsMatching "org.opensearch.flowframework.rest.FlowFrameworkSecureRestApiIT"
         }
     }
 
     // Include only secure integration tests in security enabled clusters
-    if (System.getProperty("security.enabled") != null && System.getProperty("security.enabled") == "true") {
+    if (System.getProperty("https") != null && System.getProperty("https") == "true") {
         filter {
             includeTestsMatching "org.opensearch.flowframework.rest.FlowFrameworkSecureRestApiIT"
             excludeTestsMatching "org.opensearch.flowframework.rest.FlowFrameworkRestApiIT"
@@ -269,7 +272,7 @@ testClusters.integTest {
     testDistribution = "ARCHIVE"
 
     // Optionally install security
-    if (System.getProperty("security.enabled") != null && System.getProperty("security.enabled") == "true") {
+    if (System.getProperty("https") != null && System.getProperty("https") == "true") {
         // Retrieve Security Plugin Zip from zipArchive
         configurations.secureIntegTestPluginArchive.asFileTree.each {
             if(it.name.contains("opensearch-security")) {
@@ -376,6 +379,9 @@ task integTestRemote(type: RestIntegTestTask) {
         is_https = is_https == null ? 'true' : is_https
         user = user == null ? 'admin' : user
         password = password == null ? 'admin' : password
+        System.setProperty("https", is_https)
+        System.setProperty("user", user)
+        System.setProperty("password", password)
     }
     systemProperty('https', is_https)
     systemProperty('user', user)

--- a/build.gradle
+++ b/build.gradle
@@ -333,7 +333,8 @@ testClusters.integTest {
                 '".plugins-ml-config", ' +
                 '".plugins-ml-connector", ' +
                 '".plugins-ml-model-group", ' +
-                '".plugins-ml-model", ".plugins-ml-task", ' +
+                '".plugins-ml-model", ' +
+                '".plugins-ml-task", ' +
                 '".plugins-ml-conversation-meta", ' +
                 '".plugins-ml-conversation-interactions", ' +
                 '".plugins-flow-framework-config", ' +

--- a/build.gradle
+++ b/build.gradle
@@ -336,21 +336,6 @@ testClusters.integTest {
                 '".plugins-ml-model", ".plugins-ml-task", ' +
                 '".plugins-ml-conversation-meta", ' +
                 '".plugins-ml-conversation-interactions", ' +
-                '".opendistro-alerting-config", ' +
-                '".opendistro-alerting-alert*", ' +
-                '".opendistro-anomaly-results*", ' +
-                '".opendistro-anomaly-detector*", ' +
-                '".opendistro-anomaly-checkpoints", ' +
-                '".opendistro-anomaly-detection-state", ' +
-                '".opendistro-reports-*", ' +
-                '".opensearch-notifications-*", ' +
-                '".opensearch-notebooks", ' +
-                '".opensearch-observability", ' +
-                '".ql-datasources", ' +
-                '".opendistro-asynchronous-search-response*", ' +
-                '".replication-metadata-store", ' +
-                '".opensearch-knn-models", ' +
-                '".geospatial-ip2geo-data*", ' +
                 '".plugins-flow-framework-config", ' +
                 '".plugins-flow-framework-templates", ' +
                 '".plugins-flow-framework-state"' +

--- a/build.gradle
+++ b/build.gradle
@@ -329,6 +329,33 @@ testClusters.integTest {
         setting("plugins.security.authcz.admin_dn", "\n- CN=kirk,OU=client,O=client,L=test, C=de")
         setting('plugins.security.restapi.roles_enabled', '["all_access", "security_rest_api_access"]')
         setting('plugins.security.system_indices.enabled', "true")
+        setting('plugins.security.system_indices.indices', '[' +
+                '".plugins-ml-config", ' +
+                '".plugins-ml-connector", ' +
+                '".plugins-ml-model-group", ' +
+                '".plugins-ml-model", ".plugins-ml-task", ' +
+                '".plugins-ml-conversation-meta", ' +
+                '".plugins-ml-conversation-interactions", ' +
+                '".opendistro-alerting-config", ' +
+                '".opendistro-alerting-alert*", ' +
+                '".opendistro-anomaly-results*", ' +
+                '".opendistro-anomaly-detector*", ' +
+                '".opendistro-anomaly-checkpoints", ' +
+                '".opendistro-anomaly-detection-state", ' +
+                '".opendistro-reports-*", ' +
+                '".opensearch-notifications-*", ' +
+                '".opensearch-notebooks", ' +
+                '".opensearch-observability", ' +
+                '".ql-datasources", ' +
+                '".opendistro-asynchronous-search-response*", ' +
+                '".replication-metadata-store", ' +
+                '".opensearch-knn-models", ' +
+                '".geospatial-ip2geo-data*", ' +
+                '".plugins-flow-framework-config", ' +
+                '".plugins-flow-framework-templates", ' +
+                '".plugins-flow-framework-state"' +
+                ']'
+        )
         setSecure(true)
     }
 

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -297,7 +297,10 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
                     if (isHttps() && isSystemIndex(indexName)) {
                         continue;
                     }
-                    adminClient().performRequest(new Request("DELETE", "/" + indexName));
+                    // Do not reset ML/Flow Framework encryption index as this is needed to encrypt connector credentials
+                    if (!".plugins-ml-config".equals(indexName) && !".plugins-flow-framework-config".equals(indexName)) {
+                        adminClient().performRequest(new Request("DELETE", "/" + indexName));
+                    }
                 }
             }
         }

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -295,8 +295,9 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
                 // Do not reset ML/Flow Framework encryption index as this is needed to encrypt connector credentials
                 if (indexName != null
                     && !".opendistro_security".equals(indexName)
-                    && !".plugins-ml-config".equals(indexName)
-                    && !".plugins-flow-framework-config".equals(indexName)) {
+                    && !indexName.startsWith(".opensearch")
+                    && !indexName.startsWith(".plugins-flow-framework")
+                    && !indexName.startsWith(".plugins-ml")) {
                     adminClient().performRequest(new Request("DELETE", "/" + indexName));
                 }
             }

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -292,16 +292,22 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
 
             for (Map<String, Object> index : parserList) {
                 String indexName = (String) index.get("index");
-                // Do not reset ML/Flow Framework encryption index as this is needed to encrypt connector credentials
-                if (indexName != null
-                    && !".opendistro_security".equals(indexName)
-                    && !indexName.startsWith(".opensearch")
-                    && !indexName.startsWith(".plugins-flow-framework")
-                    && !indexName.startsWith(".plugins-ml")) {
+                if (indexName != null) {
+                    // Filter out system index deletion only when running security enabled tests
+                    if (isHttps() && isSystemIndex(indexName)) {
+                        continue;
+                    }
                     adminClient().performRequest(new Request("DELETE", "/" + indexName));
                 }
             }
         }
+    }
+
+    private boolean isSystemIndex(String indexName) {
+        return ".opendistro_security".equals(indexName)
+            || indexName.startsWith(".opensearch")
+            || indexName.startsWith(".plugins-flow-framework")
+            || indexName.startsWith(".plugins-ml");
     }
 
     /**


### PR DESCRIPTION
### Description

The autocut issue shows that the error comes from attempting to delete protected system indices registered [here](https://github.com/opensearch-project/security/blob/2dab119387212d5047062100f799934b7ffbffea/tools/install_demo_configuration.sh#L388). I suspect that setting is applied during the distribution build, but it was ommitted here in our tests in order to delete these indices (in an attempt to mitigate flaky tests that come from lack of storage). This PR adds those settings back and filters out the ML/ Flow Framework system indices from deletion
```
2> REPRODUCE WITH: ./gradlew ':integTest' --tests "org.opensearch.flowframework.rest.FlowFrameworkSecureRestApiIT.testCreateWorkflowWithReadAccess" -Dtests.seed=D479F832B8590D9D -Dtests.security.manager=false -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=zh-Hans-SG -Dtests.timezone=Pacific/Tahiti -Druntime.java=21

  2> org.opensearch.client.ResponseException: method [DELETE], host [https://localhost:9200/], URI [/.plugins-ml-model-group], status line [HTTP/1.1 403 Forbidden]

    {"error":{"root_cause":[{"type":"security_exception","reason":"no permissions for [] and User [name=admin, backend_roles=[admin], requestedTenant=null]"}],"type":"security_exception","reason":"no permissions for [] and User [name=admin, backend_roles=[admin], requestedTenant=null]"},"status":403}
```

### Issues Resolved
#469 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
