### PR TITLE
Make sure retryableGetMlTask evaluates task response at least once

### DIFF
--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -75,7 +75,7 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
         ActionListener<MLTask> mlTaskListener
     ) {
         CompletableFuture.runAsync(() -> {
-            while (!future.isDone()) {
+            do {
                 mlClient.getTask(taskId, ActionListener.wrap(response -> {
                     switch (response.getState()) {
                         case COMPLETED:
@@ -128,7 +128,7 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
                     FutureUtils.cancel(future);
                     Thread.currentThread().interrupt();
                 }
-            }
+            } while (!future.isDone());
         }, threadPool.executor(WORKFLOW_THREAD_POOL));
     }
 


### PR DESCRIPTION
### Description

Ensures the `AbstractRetryableWorkflowStep` evaluates the task completion state at least once.

### Issues Resolved

Fixes #493 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
