### PR TITLE
Redacting credentials from Get Workflows and Search Workflows API

### DIFF
--- a/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
@@ -210,13 +210,14 @@ public class EncryptorUtils {
         return new String(decryptedResult.getResult(), StandardCharsets.UTF_8);
     }
 
+    // TODO : Improve redactTemplateCredentials to redact different fields
     /**
      * Removes the credential fields from a template
      * @param template the template
      * @return the redacted template
      */
     public Template redactTemplateCredentials(Template template) {
-        Template.Builder processedTemplateBuilder = new Template.Builder();
+        Template.Builder redactedTemplateBuilder = new Template.Builder();
 
         Map<String, Workflow> processedWorkflows = new HashMap<>();
         for (Map.Entry<String, Workflow> entry : template.workflows().entrySet()) {
@@ -226,18 +227,11 @@ public class EncryptorUtils {
                 if (node.userInputs().containsKey(CREDENTIAL_FIELD)) {
 
                     // Remove credential field field in node user inputs
-                    Map<String, Object> processedUserInputs = new HashMap<>();
-                    processedUserInputs.putAll(node.userInputs());
+                    Map<String, Object> processedUserInputs = new HashMap<>(node.userInputs());
                     processedUserInputs.remove(CREDENTIAL_FIELD);
 
                     // build new node to add to processed nodes
-                    WorkflowNode processedWorkflowNode = new WorkflowNode(
-                        node.id(),
-                        node.type(),
-                        node.previousNodeInputs(),
-                        processedUserInputs
-                    );
-                    processedNodes.add(processedWorkflowNode);
+                    processedNodes.add(new WorkflowNode(node.id(), node.type(), node.previousNodeInputs(), processedUserInputs));
                 } else {
                     processedNodes.add(node);
                 }
@@ -247,7 +241,7 @@ public class EncryptorUtils {
             processedWorkflows.put(entry.getKey(), new Workflow(entry.getValue().userParams(), processedNodes, entry.getValue().edges()));
         }
 
-        Template processedTemplate = processedTemplateBuilder.name(template.name())
+        Template processedTemplate = redactedTemplateBuilder.name(template.name())
             .description(template.description())
             .useCase(template.useCase())
             .templateVersion(template.templateVersion())

--- a/src/test/java/org/opensearch/flowframework/transport/GetWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/GetWorkflowTransportActionTests.java
@@ -13,6 +13,7 @@ import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -25,6 +26,7 @@ import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.model.Workflow;
 import org.opensearch.flowframework.model.WorkflowEdge;
 import org.opensearch.flowframework.model.WorkflowNode;
+import org.opensearch.flowframework.util.EncryptorUtils;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
@@ -53,6 +55,7 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
     private GetWorkflowTransportAction getTemplateTransportAction;
     private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
     private Template template;
+    private EncryptorUtils encryptorUtils;
 
     @Override
     public void setUp() throws Exception {
@@ -60,11 +63,13 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
         this.threadPool = mock(ThreadPool.class);
         this.client = mock(Client.class);
         this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
+        this.encryptorUtils = new EncryptorUtils(mock(ClusterService.class), client);
         this.getTemplateTransportAction = new GetWorkflowTransportAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
             flowFrameworkIndicesHandler,
-            client
+            client,
+            encryptorUtils
         );
 
         Version templateVersion = Version.fromString("1.0.0");

--- a/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
@@ -190,4 +190,13 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
         assertNotNull(decryptedCredential);
         assertEquals(testCredentialValue, decryptedCredential);
     }
+
+    public void testRedactTemplateCredential() {
+        // Redact template with credential field
+        Template processedTemplate = encryptorUtils.redactTemplateCredentials(testTemplate);
+
+        // Validate the credential field has been removed
+        WorkflowNode node = processedTemplate.workflows().get("provision").nodes().get(0);
+        assertNull(node.userInputs().get(CREDENTIAL_FIELD));
+    }
 }

--- a/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
@@ -192,11 +192,15 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
     }
 
     public void testRedactTemplateCredential() {
+        // Confirm credentials are present in the non-redacted template
+        WorkflowNode node = testTemplate.workflows().get("provision").nodes().get(0);
+        assertNotNull(node.userInputs().get(CREDENTIAL_FIELD));
+
         // Redact template with credential field
-        Template processedTemplate = encryptorUtils.redactTemplateCredentials(testTemplate);
+        Template redactedTemplate = encryptorUtils.redactTemplateCredentials(testTemplate);
 
         // Validate the credential field has been removed
-        WorkflowNode node = processedTemplate.workflows().get("provision").nodes().get(0);
-        assertNull(node.userInputs().get(CREDENTIAL_FIELD));
+        WorkflowNode redactedNode = redactedTemplate.workflows().get("provision").nodes().get(0);
+        assertNull(redactedNode.userInputs().get(CREDENTIAL_FIELD));
     }
 }


### PR DESCRIPTION
### Description
Removes the credential field (if any) from the Get Workflows API response

Example get workflow response with create connector step : 
```
"user_inputs" : {
            "description" : "The connector to public OpenAI model service for GPT 3.5",
            "actions" : [
              {
                "method" : "POST",
                "action_type" : "predict",
                "url" : "https://${parameters.endpoint}/v1/chat/completions"
              }
            ],
            "parameters" : {
              "endpoint" : "api.openai.com",
              "model" : "gpt-3.5-turbo"
            },
            "version" : "1",
            "protocol" : "http",
            "name" : "OpenAI Chat Connector"
          }
        
```

Additionally applies a script to the Search Workflows search request which removes the credential field (if any) from the search response hits. 

For example : 

Creating the workflow : 
```
curl -i -XPOST "localhost:9200/_plugins/_flow_framework/workflow" -H "Content-Type:application/json" --data '{"name":"create-connector-register-deploy-model","description":"test case","use_case":"TEST_CASE","version":{"template":"1.0.0","compatibility":["2.12.0","3.0.0"]},"workflows":{"provision":{"nodes":[{"id":"workflow_step_1","type":"create_connector","user_inputs":{"name":"OpenAI Chat Connector","description":"The connector to public OpenAI model service for GPT 3.5","version":"1","protocol":"http","parameters":{"endpoint":"api.openai.com","model":"gpt-3.5-turbo"},"credential":{"openAI_key":"12345"},"actions":[{"action_type":"predict","method":"POST","url":"https://${parameters.endpoint}/v1/chat/completions"}]}},{"id":"workflow_step_2","type":"register_remote_model","previous_node_inputs":{"workflow_step_1":"connector_id"},"user_inputs":{"name":"openAI-gpt-3.5-turbo","function_name":"remote","description":"test model"}},{"id":"workflow_step_3","type":"deploy_model","previous_node_inputs":{"workflow_step_2":"model_id"}}],"edges":[{"source":"workflow_step_1","dest":"workflow_step_2"},{"source":"workflow_step_2","dest":"workflow_step_3"}]}}}'

HTTP/1.1 201 Created
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 38

{"workflow_id":"ZBsCi40BVKDmTfP-_jx6"}%           
```

Using a match all search (credentials are removed) :
```
curl -i -XGET "localhost:9200/_plugins/_flow_framework/workflow/_search?pretty" -H "Content-Type:application/json" -d '{"query":{"match_all":{}}}'
HTTP/1.1 200 OK
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 3248

{
  "took" : 168,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : ".plugins-flow-framework-templates",
        "_id" : "ZBsCi40BVKDmTfP-_jx6",
        "_version" : 1,
        "_seq_no" : 0,
        "_primary_term" : 1,
        "_score" : 1.0,
        "fields" : {
          "filter" : [
            {
              "use_case" : "TEST_CASE",
              "name" : "create-connector-register-deploy-model",
              "description" : "test case",
              "workflows" : {
                "provision" : {
                  "nodes" : [
                    {
                      "user_inputs" : {
                        "protocol" : "http",
                        "name" : "OpenAI Chat Connector",
                        "description" : "The connector to public OpenAI model service for GPT 3.5",
                        "parameters" : {
                          "endpoint" : "api.openai.com",
                          "model" : "gpt-3.5-turbo"
                        },
                        "version" : "1",
                        "actions" : [
                          {
                            "method" : "POST",
                            "action_type" : "predict",
                            "url" : "https://${parameters.endpoint}/v1/chat/completions"
                          }
                        ]
                      },
                      "id" : "workflow_step_1",
                      "type" : "create_connector",
                      "previous_node_inputs" : { }
                    },
                    {
                      "user_inputs" : {
                        "function_name" : "remote",
                        "name" : "openAI-gpt-3.5-turbo",
                        "description" : "test model"
                      },
                      "id" : "workflow_step_2",
                      "type" : "register_remote_model",
                      "previous_node_inputs" : {
                        "workflow_step_1" : "connector_id"
                      }
                    },
                    {
                      "user_inputs" : { },
                      "id" : "workflow_step_3",
                      "type" : "deploy_model",
                      "previous_node_inputs" : {
                        "workflow_step_2" : "model_id"
                      }
                    }
                  ],
                  "edges" : [
                    {
                      "source" : "workflow_step_1",
                      "dest" : "workflow_step_2"
                    },
                    {
                      "source" : "workflow_step_2",
                      "dest" : "workflow_step_3"
                    }
                  ],
                  "user_params" : { }
                }
              },
              "version" : {
                "template" : "1.0.0",
                "compatibility" : [
                  "2.12.0",
                  "3.0.0"
                ]
              }
            }
          ]
        }
      }
    ]
  }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
