### PR TITLE
Throw FlowFrameworkException instead of IOException on parsing errors

### DIFF
--- a/src/main/java/org/opensearch/flowframework/model/PipelineProcessor.java
+++ b/src/main/java/org/opensearch/flowframework/model/PipelineProcessor.java
@@ -8,9 +8,11 @@
  */
 package org.opensearch.flowframework.model;
 
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -75,11 +77,14 @@ public class PipelineProcessor implements ToXContentObject {
                     params = parseStringToStringMap(parser);
                     break;
                 default:
-                    throw new IOException("Unable to parse field [" + fieldName + "] in a pipeline processor object.");
+                    throw new FlowFrameworkException(
+                        "Unable to parse field [" + fieldName + "] in a pipeline processor object.",
+                        RestStatus.BAD_REQUEST
+                    );
             }
         }
         if (type == null) {
-            throw new IOException("A processor object requires a type field.");
+            throw new FlowFrameworkException("A processor object requires a type field.", RestStatus.BAD_REQUEST);
         }
 
         return new PipelineProcessor(type, params);

--- a/src/main/java/org/opensearch/flowframework/model/Template.java
+++ b/src/main/java/org/opensearch/flowframework/model/Template.java
@@ -13,10 +13,12 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.common.xcontent.yaml.YamlXContent;
 import org.opensearch.commons.authuser.User;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -292,7 +294,10 @@ public class Template implements ToXContentObject {
                                 }
                                 break;
                             default:
-                                throw new IOException("Unable to parse field [" + fieldName + "] in a version object.");
+                                throw new FlowFrameworkException(
+                                    "Unable to parse field [" + fieldName + "] in a version object.",
+                                    RestStatus.BAD_REQUEST
+                                );
                         }
                     }
                     break;
@@ -311,11 +316,14 @@ public class Template implements ToXContentObject {
                     user = User.parse(parser);
                     break;
                 default:
-                    throw new IOException("Unable to parse field [" + fieldName + "] in a template object.");
+                    throw new FlowFrameworkException(
+                        "Unable to parse field [" + fieldName + "] in a template object.",
+                        RestStatus.BAD_REQUEST
+                    );
             }
         }
         if (name == null) {
-            throw new IOException("A template object requires a name.");
+            throw new FlowFrameworkException("A template object requires a name.", RestStatus.BAD_REQUEST);
         }
 
         return new Builder().name(name)

--- a/src/main/java/org/opensearch/flowframework/model/Workflow.java
+++ b/src/main/java/org/opensearch/flowframework/model/Workflow.java
@@ -8,9 +8,11 @@
  */
 package org.opensearch.flowframework.model;
 
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.workflow.WorkflowData;
 
 import java.io.IOException;
@@ -118,7 +120,7 @@ public class Workflow implements ToXContentObject {
 
         }
         if (nodes.isEmpty()) {
-            throw new IOException("A workflow must have at least one node.");
+            throw new FlowFrameworkException("A workflow must have at least one node.", RestStatus.BAD_REQUEST);
         }
         // Iterate the nodes and infer edges from previous node inputs
         List<WorkflowEdge> inferredEdges = nodes.stream()

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowEdge.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowEdge.java
@@ -8,9 +8,11 @@
  */
 package org.opensearch.flowframework.model;
 
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -72,11 +74,14 @@ public class WorkflowEdge implements ToXContentObject {
                     destination = parser.text();
                     break;
                 default:
-                    throw new IOException("Unable to parse field [" + fieldName + "] in an edge object.");
+                    throw new FlowFrameworkException(
+                        "Unable to parse field [" + fieldName + "] in an edge object.",
+                        RestStatus.BAD_REQUEST
+                    );
             }
         }
         if (source == null || destination == null) {
-            throw new IOException("An edge object requires both a source and dest field.");
+            throw new FlowFrameworkException("An edge object requires both a source and dest field.", RestStatus.BAD_REQUEST);
         }
 
         return new WorkflowEdge(source, destination);

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
@@ -9,9 +9,11 @@
 package org.opensearch.flowframework.model;
 
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.workflow.ProcessNode;
 import org.opensearch.flowframework.workflow.WorkflowData;
 import org.opensearch.flowframework.workflow.WorkflowStep;
@@ -190,23 +192,29 @@ public class WorkflowNode implements ToXContentObject {
                                         userInputs.put(inputFieldName, parser.bigIntegerValue());
                                         break;
                                     default:
-                                        throw new IOException("Unable to parse field [" + inputFieldName + "] in a node object.");
+                                        throw new FlowFrameworkException(
+                                            "Unable to parse field [" + inputFieldName + "] in a node object.",
+                                            RestStatus.BAD_REQUEST
+                                        );
                                 }
                                 break;
                             case VALUE_BOOLEAN:
                                 userInputs.put(inputFieldName, parser.booleanValue());
                                 break;
                             default:
-                                throw new IOException("Unable to parse field [" + inputFieldName + "] in a node object.");
+                                throw new FlowFrameworkException(
+                                    "Unable to parse field [" + inputFieldName + "] in a node object.",
+                                    RestStatus.BAD_REQUEST
+                                );
                         }
                     }
                     break;
                 default:
-                    throw new IOException("Unable to parse field [" + fieldName + "] in a node object.");
+                    throw new FlowFrameworkException("Unable to parse field [" + fieldName + "] in a node object.", RestStatus.BAD_REQUEST);
             }
         }
         if (id == null || type == null) {
-            throw new IOException("An node object requires both an id and type field.");
+            throw new FlowFrameworkException("An node object requires both an id and type field.", RestStatus.BAD_REQUEST);
         }
 
         return new WorkflowNode(id, type, previousNodeInputs, userInputs);

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowState.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowState.java
@@ -372,7 +372,10 @@ public class WorkflowState implements ToXContentObject, Writeable {
                                 userOutputs.put(userOutputsFieldName, parseStringToStringMap(parser));
                                 break;
                             default:
-                                throw new IOException("Unable to parse field [" + userOutputsFieldName + "] in a user_outputs object.");
+                                throw new FlowFrameworkException(
+                                    "Unable to parse field [" + userOutputsFieldName + "] in a user_outputs object.",
+                                    RestStatus.BAD_REQUEST
+                                );
                         }
                     }
                     break;
@@ -390,7 +393,10 @@ public class WorkflowState implements ToXContentObject, Writeable {
                     }
                     break;
                 default:
-                    throw new IOException("Unable to parse field [" + fieldName + "] in a workflowState object.");
+                    throw new FlowFrameworkException(
+                        "Unable to parse field [" + fieldName + "] in a workflowState object.",
+                        RestStatus.BAD_REQUEST
+                    );
             }
         }
         return new Builder().workflowId(workflowId)

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowStepValidator.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowStepValidator.java
@@ -105,7 +105,10 @@ public class WorkflowStepValidator implements ToXContentObject {
                     }
                     break;
                 default:
-                    throw new IOException("Unable to parse field [" + fieldName + "] in a WorkflowStepValidator object.");
+                    throw new FlowFrameworkException(
+                        "Unable to parse field [" + fieldName + "] in a WorkflowStepValidator object.",
+                        RestStatus.BAD_REQUEST
+                    );
             }
         }
         return new WorkflowStepValidator(parsedInputs, parsedOutputs, requiredPlugins, timeout);

--- a/src/test/java/org/opensearch/flowframework/model/PipelineProcessorTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/PipelineProcessorTests.java
@@ -8,6 +8,8 @@
  */
 package org.opensearch.flowframework.model;
 
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -32,12 +34,17 @@ public class PipelineProcessorTests extends OpenSearchTestCase {
 
     public void testExceptions() throws IOException {
         String badJson = "{\"badField\":\"foo\",\"params\":{\"bar\":\"baz\"}}";
-        IOException e = assertThrows(IOException.class, () -> PipelineProcessor.parse(TemplateTestJsonUtil.jsonToParser(badJson)));
+        FlowFrameworkException e = assertThrows(
+            FlowFrameworkException.class,
+            () -> PipelineProcessor.parse(TemplateTestJsonUtil.jsonToParser(badJson))
+        );
         assertEquals("Unable to parse field [badField] in a pipeline processor object.", e.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, e.getRestStatus());
 
         String noTypeJson = "{\"params\":{\"bar\":\"baz\"}}";
-        e = assertThrows(IOException.class, () -> PipelineProcessor.parse(TemplateTestJsonUtil.jsonToParser(noTypeJson)));
+        e = assertThrows(FlowFrameworkException.class, () -> PipelineProcessor.parse(TemplateTestJsonUtil.jsonToParser(noTypeJson)));
         assertEquals("A processor object requires a type field.", e.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, e.getRestStatus());
     }
 
 }

--- a/src/test/java/org/opensearch/flowframework/model/TemplateTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/TemplateTests.java
@@ -9,6 +9,8 @@
 package org.opensearch.flowframework.model;
 
 import org.opensearch.Version;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -74,15 +76,17 @@ public class TemplateTests extends OpenSearchTestCase {
     }
 
     public void testExceptions() throws IOException {
-        IOException e;
+        FlowFrameworkException e;
 
         String badTemplateField = expectedTemplate.replace("use_case", "badField");
-        e = assertThrows(IOException.class, () -> Template.parse(badTemplateField));
+        e = assertThrows(FlowFrameworkException.class, () -> Template.parse(badTemplateField));
         assertEquals("Unable to parse field [badField] in a template object.", e.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, e.getRestStatus());
 
         String badVersionField = expectedTemplate.replace("compatibility", "badField");
-        e = assertThrows(IOException.class, () -> Template.parse(badVersionField));
+        e = assertThrows(FlowFrameworkException.class, () -> Template.parse(badVersionField));
         assertEquals("Unable to parse field [version] in a version object.", e.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, e.getRestStatus());
     }
 
     public void testStrings() throws IOException {

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowEdgeTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowEdgeTests.java
@@ -8,6 +8,8 @@
  */
 package org.opensearch.flowframework.model;
 
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -43,12 +45,17 @@ public class WorkflowEdgeTests extends OpenSearchTestCase {
 
     public void testExceptions() throws IOException {
         String badJson = "{\"badField\":\"A\",\"dest\":\"B\"}";
-        IOException e = assertThrows(IOException.class, () -> WorkflowEdge.parse(TemplateTestJsonUtil.jsonToParser(badJson)));
+        FlowFrameworkException e = assertThrows(
+            FlowFrameworkException.class,
+            () -> WorkflowEdge.parse(TemplateTestJsonUtil.jsonToParser(badJson))
+        );
         assertEquals("Unable to parse field [badField] in an edge object.", e.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, e.getRestStatus());
 
         String missingJson = "{\"dest\":\"B\"}";
-        e = assertThrows(IOException.class, () -> WorkflowEdge.parse(TemplateTestJsonUtil.jsonToParser(missingJson)));
+        e = assertThrows(FlowFrameworkException.class, () -> WorkflowEdge.parse(TemplateTestJsonUtil.jsonToParser(missingJson)));
         assertEquals("An edge object requires both a source and dest field.", e.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, e.getRestStatus());
     }
 
 }

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowNodeTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowNodeTests.java
@@ -8,6 +8,8 @@
  */
 package org.opensearch.flowframework.model;
 
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -87,11 +89,16 @@ public class WorkflowNodeTests extends OpenSearchTestCase {
 
     public void testExceptions() throws IOException {
         String badJson = "{\"badField\":\"A\",\"type\":\"a-type\",\"user_inputs\":{\"foo\":\"bar\"}}";
-        IOException e = assertThrows(IOException.class, () -> WorkflowNode.parse(TemplateTestJsonUtil.jsonToParser(badJson)));
+        FlowFrameworkException e = assertThrows(
+            FlowFrameworkException.class,
+            () -> WorkflowNode.parse(TemplateTestJsonUtil.jsonToParser(badJson))
+        );
         assertEquals("Unable to parse field [badField] in a node object.", e.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, e.getRestStatus());
 
         String missingJson = "{\"id\":\"A\",\"user_inputs\":{\"foo\":\"bar\"}}";
-        e = assertThrows(IOException.class, () -> WorkflowNode.parse(TemplateTestJsonUtil.jsonToParser(missingJson)));
+        e = assertThrows(FlowFrameworkException.class, () -> WorkflowNode.parse(TemplateTestJsonUtil.jsonToParser(missingJson)));
         assertEquals("An node object requires both an id and type field.", e.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, e.getRestStatus());
     }
 }

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowStepValidatorTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowStepValidatorTests.java
@@ -8,7 +8,9 @@
  */
 package org.opensearch.flowframework.model;
 
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -38,9 +40,9 @@ public class WorkflowStepValidatorTests extends OpenSearchTestCase {
 
     public void testFailedParseWorkflowStepValidator() throws IOException {
         XContentParser parser = TemplateTestJsonUtil.jsonToParser(invalidValidator);
-        IOException ex = expectThrows(IOException.class, () -> WorkflowStepValidator.parse(parser));
+        FlowFrameworkException ex = expectThrows(FlowFrameworkException.class, () -> WorkflowStepValidator.parse(parser));
         assertEquals("Unable to parse field [invalid_field] in a WorkflowStepValidator object.", ex.getMessage());
-
+        assertEquals(RestStatus.BAD_REQUEST, ex.getRestStatus());
     }
 
 }

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowValidatorTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowValidatorTests.java
@@ -15,8 +15,10 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -71,8 +73,9 @@ public class WorkflowValidatorTests extends OpenSearchTestCase {
 
     public void testFailedParseWorkflowValidator() throws IOException {
         XContentParser parser = TemplateTestJsonUtil.jsonToParser(invalidWorkflowStepJson);
-        IOException ex = expectThrows(IOException.class, () -> WorkflowValidator.parse(parser));
+        FlowFrameworkException ex = expectThrows(FlowFrameworkException.class, () -> WorkflowValidator.parse(parser));
         assertEquals("Unable to parse field [bad_field] in a WorkflowStepValidator object.", ex.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, ex.getRestStatus());
     }
 
     public void testWorkflowStepFactoryHasValidators() throws IOException {

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -242,8 +242,12 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
 
     public void testNoEdges() throws IOException {
         List<String> workflow;
-        Exception ex = assertThrows(IOException.class, () -> parse(workflow(Collections.emptyList(), Collections.emptyList())));
+        FlowFrameworkException ex = assertThrows(
+            FlowFrameworkException.class,
+            () -> parse(workflow(Collections.emptyList(), Collections.emptyList()))
+        );
         assertEquals(MUST_HAVE_AT_LEAST_ONE_NODE, ex.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, ex.getRestStatus());
 
         workflow = parse(workflow(List.of(node("A")), Collections.emptyList()));
         assertEquals(1, workflow.size());


### PR DESCRIPTION
### Description

Throws a FlowFrameworkException with 400 status on template parsing errors, rather than an IOException which results in a 500 status.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
