### PR TITLE
Ensure params are consumed before checking feature flag

### DIFF
--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -73,6 +73,8 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String workflowId = request.param(WORKFLOW_ID);
+        String[] validation = request.paramAsStringArray(VALIDATION, new String[] { "all" });
+        boolean provision = request.paramAsBoolean(PROVISION_WORKFLOW, false);
         if (!flowFrameworkSettings.isFlowFrameworkEnabled()) {
             FlowFrameworkException ffe = new FlowFrameworkException(
                 "This API is disabled. To enable it, set [" + FLOW_FRAMEWORK_ENABLED.getKey() + "] to true.",
@@ -86,8 +88,6 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
             XContentParser parser = request.contentParser();
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
             Template template = Template.parse(parser);
-            String[] validation = request.paramAsStringArray(VALIDATION, new String[] { "all" });
-            boolean provision = request.paramAsBoolean(PROVISION_WORKFLOW, false);
 
             WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, template, validation, provision);
 

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
@@ -57,6 +57,7 @@ public class RestGetWorkflowStateAction extends BaseRestHandler {
     @Override
     protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String workflowId = request.param(WORKFLOW_ID);
+        boolean all = request.paramAsBoolean("all", false);
         try {
             if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {
                 throw new FlowFrameworkException(
@@ -75,7 +76,6 @@ public class RestGetWorkflowStateAction extends BaseRestHandler {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);
             }
 
-            boolean all = request.paramAsBoolean("all", false);
             GetWorkflowStateRequest getWorkflowRequest = new GetWorkflowStateRequest(workflowId, all);
             return channel -> client.execute(GetWorkflowStateAction.INSTANCE, getWorkflowRequest, ActionListener.wrap(response -> {
                 XContentBuilder builder = response.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS);


### PR DESCRIPTION
### Description

Consumes params by assigning them before feature flag check, to prevent confusing error messages.

### Issues Resolved

Fixes #513

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
