### PR TITLE
Improve provisioning exceptions with step ID and hide exception details

### DIFF
--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -522,11 +522,10 @@ public class FlowFrameworkIndicesHandler {
         } else {
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
                 UpdateRequest updateRequest = new UpdateRequest(WORKFLOW_STATE_INDEX, documentId);
-                Map<String, Object> updatedContent = new HashMap<>();
-                updatedContent.putAll(updatedFields);
+                Map<String, Object> updatedContent = new HashMap<>(updatedFields);
                 updateRequest.doc(updatedContent);
                 updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-                updateRequest.retryOnConflict(3);
+                updateRequest.retryOnConflict(5);
                 // TODO: decide what condition can be considered as an update conflict and add retry strategy
                 client.update(updateRequest, ActionListener.runBefore(listener, context::restore));
             } catch (Exception e) {


### PR DESCRIPTION
### Description

Handles exceptions during the provisioning workflow better:
 - includes the workflow step ID that caused the exception
 - Includes only the exception class type but not the exception message details

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
