### PR TITLE
Added an optional workflow_step param to the get workflow steps API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Enhancements
 - Substitute REST path or body parameters in Workflow Steps ([#525](https://github.com/opensearch-project/flow-framework/pull/525))
+- Added an optional workflow_step param to the get workflow steps API ([#538](https://github.com/opensearch-project/flow-framework/pull/538))
 
 ### Bug Fixes
 ### Infrastructure

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -65,7 +65,7 @@ public class CommonValue {
     /** The field name for provision workflow within a use case template*/
     public static final String PROVISION_WORKFLOW = "provision";
     /** The field name for workflow steps. This field represents the name of the workflow steps to be fetched. */
-    public static final String STEP = "step";
+    public static final String WORKFLOW_STEP = "workflow_step";
 
     /*
      * Constants associated with plugin configuration

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -65,7 +65,7 @@ public class CommonValue {
     /** The field name for provision workflow within a use case template*/
     public static final String PROVISION_WORKFLOW = "provision";
     /** The field name for workflow steps. This field represents the name of the workflow steps to be fetched. */
-    public static final String STEPS = "steps";
+    public static final String STEP = "step";
 
     /*
      * Constants associated with plugin configuration

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -64,6 +64,8 @@ public class CommonValue {
     public static final String VALIDATION = "validation";
     /** The field name for provision workflow within a use case template*/
     public static final String PROVISION_WORKFLOW = "provision";
+    /** The field name for workflow steps. This field represents the name of the workflow steps to be fetched. */
+    public static final String STEPS = "steps";
 
     /*
      * Constants associated with plugin configuration

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.opensearch.flowframework.common.CommonValue.STEPS;
+import static org.opensearch.flowframework.common.CommonValue.STEP;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
 
@@ -65,7 +65,7 @@ public class RestGetWorkflowStepAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
 
-        String[] steps = request.paramAsStringArray(STEPS, Strings.EMPTY_ARRAY);
+        String[] steps = request.paramAsStringArray(STEP, Strings.EMPTY_ARRAY);
         try {
             if (!flowFrameworkSettings.isFlowFrameworkEnabled()) {
                 throw new FlowFrameworkException(
@@ -76,7 +76,7 @@ public class RestGetWorkflowStepAction extends BaseRestHandler {
 
             Map<String, String> params = new HashMap<>();
             for (String step : steps) {
-                params.put(step, STEPS);
+                params.put(step, STEP);
             }
 
             WorkflowRequest workflowRequest = new WorkflowRequest(null, null, params);

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
@@ -31,7 +31,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.opensearch.flowframework.common.CommonValue.*;
+import static org.opensearch.flowframework.common.CommonValue.STEPS;
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
 
 /**
@@ -75,7 +76,7 @@ public class RestGetWorkflowStepAction extends BaseRestHandler {
 
             Map<String, String> params = new HashMap<>();
             for (String step : steps) {
-                params.put(STEPS, step);
+                params.put(step, STEPS);
             }
 
             WorkflowRequest workflowRequest = new WorkflowRequest(null, null, params);

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.opensearch.flowframework.common.CommonValue.STEP;
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STEP;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
 
@@ -65,7 +65,7 @@ public class RestGetWorkflowStepAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
 
-        String[] steps = request.paramAsStringArray(STEP, Strings.EMPTY_ARRAY);
+        String[] steps = request.paramAsStringArray(WORKFLOW_STEP, Strings.EMPTY_ARRAY);
         try {
             if (!flowFrameworkSettings.isFlowFrameworkEnabled()) {
                 throw new FlowFrameworkException(
@@ -76,7 +76,7 @@ public class RestGetWorkflowStepAction extends BaseRestHandler {
 
             Map<String, String> params = new HashMap<>();
             for (String step : steps) {
-                params.put(step, STEP);
+                params.put(step, WORKFLOW_STEP);
             }
 
             WorkflowRequest workflowRequest = new WorkflowRequest(null, null, params);

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -26,7 +25,7 @@ import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -64,8 +63,6 @@ public class RestGetWorkflowStepAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-
-        String[] steps = request.paramAsStringArray(WORKFLOW_STEP, Strings.EMPTY_ARRAY);
         try {
             if (!flowFrameworkSettings.isFlowFrameworkEnabled()) {
                 throw new FlowFrameworkException(
@@ -74,10 +71,9 @@ public class RestGetWorkflowStepAction extends BaseRestHandler {
                 );
             }
 
-            Map<String, String> params = new HashMap<>();
-            for (String step : steps) {
-                params.put(step, WORKFLOW_STEP);
-            }
+            Map<String, String> params = request.hasParam(WORKFLOW_STEP)
+                ? Map.of(WORKFLOW_STEP, request.param(WORKFLOW_STEP))
+                : Collections.emptyMap();
 
             WorkflowRequest workflowRequest = new WorkflowRequest(null, null, params);
             return channel -> client.execute(GetWorkflowStepAction.INSTANCE, workflowRequest, ActionListener.wrap(response -> {

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportAction.java
@@ -51,10 +51,13 @@ public class GetWorkflowStepTransportAction extends HandledTransportAction<Workf
     @Override
     protected void doExecute(Task task, WorkflowRequest request, ActionListener<GetWorkflowStepResponse> listener) {
         try {
-
-            List<String> steps = new ArrayList<>(request.getParams().values());
-            WorkflowValidator workflowValidator = this.workflowStepFactory.getWorkflowValidatorByStep(steps);
-
+            List<String> steps = new ArrayList<>(request.getParams().keySet());
+            WorkflowValidator workflowValidator;
+            if (steps.isEmpty()) {
+                workflowValidator = this.workflowStepFactory.getWorkflowValidator();
+            } else {
+                workflowValidator = this.workflowStepFactory.getWorkflowValidatorByStep(steps);
+            }
             listener.onResponse(new GetWorkflowStepResponse(workflowValidator));
         } catch (Exception e) {
             logger.error("Failed to retrieve workflow step json.", e);

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportAction.java
@@ -11,7 +11,6 @@ package org.opensearch.flowframework.transport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
@@ -22,10 +21,13 @@ import org.opensearch.flowframework.workflow.WorkflowStepFactory;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Transport action to retrieve a workflow step json
  */
-public class GetWorkflowStepTransportAction extends HandledTransportAction<ActionRequest, GetWorkflowStepResponse> {
+public class GetWorkflowStepTransportAction extends HandledTransportAction<WorkflowRequest, GetWorkflowStepResponse> {
 
     private final Logger logger = LogManager.getLogger(GetWorkflowStepTransportAction.class);
     private final WorkflowStepFactory workflowStepFactory;
@@ -47,9 +49,12 @@ public class GetWorkflowStepTransportAction extends HandledTransportAction<Actio
     }
 
     @Override
-    protected void doExecute(Task task, ActionRequest request, ActionListener<GetWorkflowStepResponse> listener) {
+    protected void doExecute(Task task, WorkflowRequest request, ActionListener<GetWorkflowStepResponse> listener) {
         try {
-            WorkflowValidator workflowValidator = this.workflowStepFactory.getWorkflowValidator();
+
+            List<String> steps = new ArrayList<>(request.getParams().values());
+            WorkflowValidator workflowValidator = this.workflowStepFactory.getWorkflowValidatorByStep(steps);
+
             listener.onResponse(new GetWorkflowStepResponse(workflowValidator));
         } catch (Exception e) {
             logger.error("Failed to retrieve workflow step json.", e);

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportAction.java
@@ -67,7 +67,7 @@ public class GetWorkflowStepTransportAction extends HandledTransportAction<Workf
             listener.onResponse(new GetWorkflowStepResponse(workflowValidator));
         } catch (Exception e) {
             if (e instanceof FlowFrameworkException) {
-                logger.error("Invalid step name");
+                logger.error(e.getMessage());
                 listener.onFailure(e);
             }
             logger.error("Failed to retrieve workflow step json.", e);

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportAction.java
@@ -60,6 +60,10 @@ public class GetWorkflowStepTransportAction extends HandledTransportAction<Workf
             }
             listener.onResponse(new GetWorkflowStepResponse(workflowValidator));
         } catch (Exception e) {
+            if (e instanceof FlowFrameworkException) {
+                logger.error("Please only use only valid step name");
+                listener.onFailure(e);
+            }
             logger.error("Failed to retrieve workflow step json.", e);
             listener.onFailure(new FlowFrameworkException(e.getMessage(), ExceptionsHelper.status(e)));
         }

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
@@ -64,7 +64,7 @@ public class WorkflowRequest extends ActionRequest {
      * @param template the use case template which describes the workflow
      * @param params The parameters from the REST path
      */
-    public WorkflowRequest(String workflowId, @Nullable Template template, Map<String, String> params) {
+    public WorkflowRequest(@Nullable String workflowId, @Nullable Template template, Map<String, String> params) {
         this(workflowId, template, new String[] { "all" }, true, params);
     }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -364,6 +364,11 @@ public class WorkflowStepFactory {
         return new WorkflowValidator(workflowStepValidators);
     }
 
+    /**
+     * Get the object of WorkflowValidator consisting of passed workflow steps
+     * @param steps workflow steps
+     * @return WorkflowValidator
+     */
     public WorkflowValidator getWorkflowValidatorByStep(List<String> steps) {
         Map<String, WorkflowStepValidator> workflowStepValidators = new HashMap<>();
 
@@ -371,6 +376,10 @@ public class WorkflowStepFactory {
             if (steps.contains(mapping.getWorkflowStepName())) {
                 workflowStepValidators.put(mapping.getWorkflowStepName(), mapping.getWorkflowStepValidator());
             }
+        }
+
+        if (workflowStepValidators.isEmpty()) {
+            throw new FlowFrameworkException("Please only use only valid step name", RestStatus.BAD_REQUEST);
         }
 
         return new WorkflowValidator(workflowStepValidators);

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -364,6 +364,18 @@ public class WorkflowStepFactory {
         return new WorkflowValidator(workflowStepValidators);
     }
 
+    public WorkflowValidator getWorkflowValidatorByStep(List<String> steps) {
+        Map<String, WorkflowStepValidator> workflowStepValidators = new HashMap<>();
+
+        for (WorkflowSteps mapping : WorkflowSteps.values()) {
+            if (steps.contains(mapping.getWorkflowStepName())) {
+                workflowStepValidators.put(mapping.getWorkflowStepName(), mapping.getWorkflowStepValidator());
+            }
+        }
+
+        return new WorkflowValidator(workflowStepValidators);
+    }
+
     /**
      * Create a new instance of a {@link WorkflowStep}.
      * @param type The type of instance to create

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -23,8 +23,10 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.opensearch.flowframework.common.CommonValue.ACTIONS_FIELD;
@@ -371,15 +373,18 @@ public class WorkflowStepFactory {
      */
     public WorkflowValidator getWorkflowValidatorByStep(List<String> steps) {
         Map<String, WorkflowStepValidator> workflowStepValidators = new HashMap<>();
+        Set<String> invalidSteps = new HashSet<>(steps);
 
         for (WorkflowSteps mapping : WorkflowSteps.values()) {
-            if (steps.contains(mapping.getWorkflowStepName())) {
+            String step = mapping.getWorkflowStepName();
+            if (steps.contains(step)) {
                 workflowStepValidators.put(mapping.getWorkflowStepName(), mapping.getWorkflowStepValidator());
+                invalidSteps.remove(step);
             }
         }
 
-        if (workflowStepValidators.isEmpty()) {
-            throw new FlowFrameworkException("Please only use only valid step name", RestStatus.BAD_REQUEST);
+        if (!invalidSteps.isEmpty()) {
+            throw new FlowFrameworkException("Invalid step name: " + invalidSteps, RestStatus.BAD_REQUEST);
         }
 
         return new WorkflowValidator(workflowStepValidators);

--- a/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStepActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStepActionTests.java
@@ -111,7 +111,7 @@ public class RestGetWorkflowStepActionTests extends OpenSearchTestCase {
 
     public void testFailedWorkflowSteps() throws Exception {
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
-            .withPath(this.getPath + "?step=xyz")
+            .withPath(this.getPath + "?workflow_step=xyz")
             .build();
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
@@ -127,7 +127,7 @@ public class RestGetWorkflowStepActionTests extends OpenSearchTestCase {
             FlowFrameworkException.class,
             () -> restGetWorkflowStepAction.handleRequest(request, channel, nodeClient)
         );
-        assertEquals("Please only use only valid step name", exception.getMessage());
+        assertEquals("Invalid step name: [xyz]", exception.getMessage());
     }
 
     public void testFeatureFlagNotEnabled() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStepActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStepActionTests.java
@@ -92,7 +92,7 @@ public class RestGetWorkflowStepActionTests extends OpenSearchTestCase {
 
     public void testWorkflowSteps() throws Exception {
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
-            .withPath(this.getPath + "?step=create_connector")
+            .withPath(this.getPath + "?workflow_step=create_connector")
             .build();
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);

--- a/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStepActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStepActionTests.java
@@ -9,20 +9,32 @@
 package org.opensearch.flowframework.rest;
 
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.model.WorkflowValidator;
+import org.opensearch.flowframework.transport.GetWorkflowStepResponse;
+import org.opensearch.flowframework.transport.WorkflowRequest;
+import org.opensearch.flowframework.workflow.WorkflowStepFactory;
+import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.rest.FakeRestChannel;
 import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.ThreadPool;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,12 +43,22 @@ public class RestGetWorkflowStepActionTests extends OpenSearchTestCase {
     private String getPath;
     private FlowFrameworkSettings flowFrameworkFeatureEnabledSetting;
     private NodeClient nodeClient;
+    private WorkflowStepFactory workflowStepFactory;
+    private FlowFrameworkSettings flowFrameworkSettings;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
 
+        flowFrameworkSettings = mock(FlowFrameworkSettings.class);
+        when(flowFrameworkSettings.isFlowFrameworkEnabled()).thenReturn(true);
+
         this.getPath = String.format(Locale.ROOT, "%s/%s", WORKFLOW_URI, "_steps");
+        ThreadPool threadPool = mock(ThreadPool.class);
+        MachineLearningNodeClient mlClient = mock(MachineLearningNodeClient.class);
+        FlowFrameworkIndicesHandler flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
+
+        this.workflowStepFactory = new WorkflowStepFactory(threadPool, mlClient, flowFrameworkIndicesHandler, flowFrameworkSettings);
         flowFrameworkFeatureEnabledSetting = mock(FlowFrameworkSettings.class);
         when(flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()).thenReturn(true);
         this.restGetWorkflowStepAction = new RestGetWorkflowStepAction(flowFrameworkFeatureEnabledSetting);
@@ -66,6 +88,46 @@ public class RestGetWorkflowStepActionTests extends OpenSearchTestCase {
             restGetWorkflowStepAction.handleRequest(request, channel, nodeClient);
         });
         assertEquals("request [GET /_plugins/_flow_framework/workflow/_steps] does not support having a body", ex.getMessage());
+    }
+
+    public void testWorkflowSteps() throws Exception {
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath(this.getPath + "?step=create_connector")
+            .build();
+
+        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
+        List<String> steps = new ArrayList<>();
+        steps.add("create_connector");
+        doAnswer(invocation -> {
+            ActionListener<GetWorkflowStepResponse> actionListener = invocation.getArgument(2);
+            WorkflowValidator workflowValidator = this.workflowStepFactory.getWorkflowValidatorByStep(steps);
+            actionListener.onResponse(new GetWorkflowStepResponse(workflowValidator));
+            return null;
+        }).when(nodeClient).execute(any(), any(WorkflowRequest.class), any());
+        restGetWorkflowStepAction.handleRequest(request, channel, nodeClient);
+        assertEquals(RestStatus.OK, channel.capturedResponse().status());
+        assertTrue(channel.capturedResponse().content().utf8ToString().contains("create_connector"));
+    }
+
+    public void testFailedWorkflowSteps() throws Exception {
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath(this.getPath + "?step=xyz")
+            .build();
+
+        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
+        List<String> steps = new ArrayList<>();
+        steps.add("xyz");
+        doAnswer(invocation -> {
+            ActionListener<GetWorkflowStepResponse> actionListener = invocation.getArgument(2);
+            WorkflowValidator workflowValidator = this.workflowStepFactory.getWorkflowValidatorByStep(steps);
+            actionListener.onResponse(new GetWorkflowStepResponse(workflowValidator));
+            return null;
+        }).when(nodeClient).execute(any(), any(WorkflowRequest.class), any());
+        FlowFrameworkException exception = expectThrows(
+            FlowFrameworkException.class,
+            () -> restGetWorkflowStepAction.handleRequest(request, channel, nodeClient)
+        );
+        assertEquals("Please only use only valid step name", exception.getMessage());
     }
 
     public void testFeatureFlagNotEnabled() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportActionTests.java
@@ -16,13 +16,17 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.mockito.ArgumentCaptor;
 
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STEP;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@SuppressWarnings("unchecked")
 public class GetWorkflowStepTransportActionTests extends OpenSearchTestCase {
 
     private GetWorkflowStepTransportAction getWorkflowStepTransportAction;
@@ -45,5 +49,18 @@ public class GetWorkflowStepTransportActionTests extends OpenSearchTestCase {
 
         ArgumentCaptor<GetWorkflowStepResponse> stepCaptor = ArgumentCaptor.forClass(GetWorkflowStepResponse.class);
         verify(listener, times(1)).onResponse(stepCaptor.capture());
+    }
+
+    public void testGetWorkflowStepValidator() throws IOException {
+        Map<String, String> params = new HashMap<>();
+        params.put(WORKFLOW_STEP, "create_connector, delete_model");
+
+        WorkflowRequest workflowRequest = new WorkflowRequest(null, null, params);
+        ActionListener<GetWorkflowStepResponse> listener = mock(ActionListener.class);
+        getWorkflowStepTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
+        ArgumentCaptor<GetWorkflowStepResponse> stepCaptor = ArgumentCaptor.forClass(GetWorkflowStepResponse.class);
+        verify(listener, times(1)).onResponse(stepCaptor.capture());
+        assertEquals(GetWorkflowStepResponse.class, stepCaptor.getValue().getClass());
+
     }
 }

--- a/src/test/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/GetWorkflowStepTransportActionTests.java
@@ -45,6 +45,5 @@ public class GetWorkflowStepTransportActionTests extends OpenSearchTestCase {
 
         ArgumentCaptor<GetWorkflowStepResponse> stepCaptor = ArgumentCaptor.forClass(GetWorkflowStepResponse.class);
         verify(listener, times(1)).onResponse(stepCaptor.capture());
-
     }
 }


### PR DESCRIPTION
### Description

Added an optional workflow_step param to the get workflow steps API.

Request:
```
GET localhost:9200/_plugins/_flow_framework/workflow/_steps?workflow_step=create_connector,delete_model,deploy_model
```
Response:
```
{
    "create_connector": {
        "inputs": [
            "name",
            "description",
            "version",
            "protocol",
            "parameters",
            "credential",
            "actions"
        ],
        "outputs": [
            "connector_id"
        ],
        "required_plugins": [
            "opensearch-ml"
        ],
        "timeout": "1m"
    },
    "deploy_model": {
        "inputs": [
            "model_id"
        ],
        "outputs": [
            "model_id"
        ],
        "required_plugins": [
            "opensearch-ml"
        ],
        "timeout": "15s"
    },
    "delete_model": {
        "inputs": [
            "model_id"
        ],
        "outputs": [
            "model_id"
        ],
        "required_plugins": [
            "opensearch-ml"
        ]
    }
}
```

### Issues Resolved
Resolves https://github.com/opensearch-project/flow-framework/issues/456

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
