### PR TITLE
Don't fail create workflow on already-consumed OpenSearch REST params

### DIFF
--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -78,18 +78,17 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
         String workflowId = request.param(WORKFLOW_ID);
         String[] validation = request.paramAsStringArray(VALIDATION, new String[] { "all" });
         boolean provision = request.paramAsBoolean(PROVISION_WORKFLOW, false);
-        final List<String> validCreateParams = List.of(WORKFLOW_ID, VALIDATION, PROVISION_WORKFLOW);
         // If provisioning, consume all other params and pass to provision transport action
         Map<String, String> params = provision
             ? request.params()
                 .keySet()
                 .stream()
-                .filter(k -> !validCreateParams.contains(k))
+                .filter(k -> !request.consumedParams().contains(k))
                 .collect(Collectors.toMap(Function.identity(), request::param))
             : request.params()
                 .entrySet()
                 .stream()
-                .filter(e -> !validCreateParams.contains(e.getKey()))
+                .filter(e -> !request.consumedParams().contains(e.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         if (!flowFrameworkSettings.isFlowFrameworkEnabled()) {
             FlowFrameworkException ffe = new FlowFrameworkException(
@@ -105,7 +104,7 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
             params.keySet().stream().forEach(request::param);
             request.content();
             FlowFrameworkException ffe = new FlowFrameworkException(
-                "Only the parameters " + validCreateParams + " are permitted unless the provision parameter is set to true.",
+                "Only the parameters " + request.consumedParams() + " are permitted unless the provision parameter is set to true.",
                 RestStatus.BAD_REQUEST
             );
             return channel -> channel.sendResponse(

--- a/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
@@ -127,12 +127,7 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
         createWorkflowRestAction.handleRequest(request, channel, nodeClient);
         assertEquals(RestStatus.BAD_REQUEST, channel.capturedResponse().status());
         assertTrue(
-            channel.capturedResponse()
-                .content()
-                .utf8ToString()
-                .contains(
-                    "Only the parameters [workflow_id, validation, provision] are permitted unless the provision parameter is set to true."
-                )
+            channel.capturedResponse().content().utf8ToString().contains("are permitted unless the provision parameter is set to true.")
         );
     }
 


### PR DESCRIPTION
### Description

Some OpenSearch params are consumed before being passed to a plugin REST handler, such as pretty, format, error_trace, human, filter_path.  

This PR fixes the logic  in #525 to remove all previously-consumed parameters from the params list, so it will only fail in the same cases that the request would normally fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
