### PR TITLE
Add created, updated, and provisioned timestamps to saved template

### DIFF
--- a/.github/workflows/test_bwc.yml
+++ b/.github/workflows/test_bwc.yml
@@ -1,0 +1,45 @@
+name: BWC
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  Build-ff-linux:
+    strategy:
+      matrix:
+        java: [11,17,21]
+      fail-fast: false
+
+    name: Test Flow Framework BWC
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+
+      - name: Checkout Flow Framework
+        uses: actions/checkout@v4
+
+      - name: Assemble Flow Framework
+        run: |
+          plugin_version=`./gradlew properties -q | grep "opensearch_build:" | awk '{print $2}'`
+          echo plugin_version $plugin_version
+          ./gradlew assemble
+          echo "Creating ./src/test/resources/org/opensearch/flowframework/bwc/flow-framework/$plugin_version ..."
+          mkdir -p ./src/test/resources/org/opensearch/flowframework/bwc/flow-framework/$plugin_version
+          echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/flowframework/bwc/flow-framework/$plugin_version ..."
+          ls ./build/distributions/
+          cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/flowframework/bwc/flow-framework/$plugin_version
+          echo "Copied ./build/distributions/*.zip to ./src/test/resources/org/opensearch/flowframework/bwc/flow-framework/$plugin_version ..."
+          ls ./src/test/resources/org/opensearch/flowframework/bwc/flow-framework/$plugin_version
+      - name: Run Flow Framework Backwards Compatibility Tests
+        run: |
+          echo "Running backwards compatibility tests ..."
+          ./gradlew bwcTestSuite -Dtests.security.manager=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Added an optional workflow_step param to the get workflow steps API ([#538](https://github.com/opensearch-project/flow-framework/pull/538))
 
 ### Enhancements
+- Add created, updated, and provisioned timestamps to saved template ([#551](https://github.com/opensearch-project/flow-framework/pull/551))
+
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import java.nio.file.Files
 import org.opensearch.gradle.testclusters.OpenSearchCluster
+import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 import org.opensearch.gradle.test.RestIntegTestTask
 import java.util.concurrent.Callable
 import java.nio.file.Paths
@@ -23,6 +24,16 @@ buildscript {
         opensearch_no_snapshot = opensearch_build.replace("-SNAPSHOT","")
         System.setProperty('tests.security.manager', 'false')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
+
+        bwcVersionShort = "2.12.0"
+        bwcVersion = bwcVersionShort + ".0"
+        bwcOpenSearchFFDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + bwcVersionShort + '/latest/linux/x64/tar/builds/' +
+                'opensearch/plugins/opensearch-flow-framework-' + bwcVersion + '.zip'
+        baseName = "ffBwcCluster"
+        bwcFilePath = "src/test/resources/org/opensearch/flowframework/bwc/"
+        bwcFlowFrameworkPath = bwcFilePath + "flowframework/"
+
+        isSameMajorVersion = opensearch_version.split("\\.")[0] == bwcVersionShort.split("\\.")[0]
     }
 
     repositories {
@@ -78,6 +89,9 @@ dependencyLicenses.enabled = false
 // This requires an additional Jar not published as part of build-tools
 loggerUsageCheck.enabled = false
 thirdPartyAudit.enabled = false
+// Allow test cases to be named Tests without having to be inherited from LuceneTestCase.
+// see https://github.com/elastic/elasticsearch/blob/323f312bbc829a63056a79ebe45adced5099f6e6/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
+testingConventions.enabled = false
 
 // No need to validate pom, as we do not upload to maven/sonatype
 validateNebulaPom.enabled = false
@@ -192,6 +206,12 @@ jacocoTestReport {
 }
 tasks.named("check").configure { dependsOn(jacocoTestReport) }
 
+tasks.named("yamlRestTest").configure {
+    filter {
+        excludeTestsMatching "org.opensearch.flowframework.rest.*IT"
+        excludeTestsMatching "org.opensearch.flowframework.bwc.*IT"
+    }
+}
 
 // Set up integration tests
 task integTest(type: RestIntegTestTask) {
@@ -228,6 +248,13 @@ integTest {
     if (System.getProperty("tests.rest.cluster") != null) {
         filter {
             includeTestsMatching "org.opensearch.flowframework.rest.*IT"
+        }
+    }
+
+    // Exclude BWC tests, run separately
+    if (System.getProperty("tests.rest.bwcsuite") == null) {
+        filter {
+            excludeTestsMatching "org.opensearch.flowframework.bwc.*IT"
         }
     }
 
@@ -425,6 +452,166 @@ task integTestRemote(type: RestIntegTestTask) {
     }
 }
 
+2.times {i ->
+    testClusters {
+        "${baseName}$i" {
+            testDistribution = "ARCHIVE"
+            versions = [bwcVersionShort, opensearch_version]
+            numberOfNodes = 3
+            plugin(provider(new Callable<RegularFile>(){
+                @Override
+                RegularFile call() throws Exception {
+                    return new RegularFile() {
+                        @Override
+                        File getAsFile() {
+                            if (new File("$project.rootDir/$bwcFilePath/flow-framework/$bwcVersion").exists()) {
+                                project.delete(files("$project.rootDir/$bwcFilePath/flow-framework/$bwcVersion"))
+                            }
+                            project.mkdir bwcFlowFrameworkPath + bwcVersion
+                            ant.get(src: bwcOpenSearchFFDownload,
+                                    dest: bwcFlowFrameworkPath + bwcVersion,
+                                    httpusecaches: false)
+                            return fileTree(bwcFlowFrameworkPath + bwcVersion).getSingleFile()
+                        }
+                    }
+                }
+            }))
+            setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+            setting 'http.content_type.required', 'true'
+        }
+    }
+}
+
+List<Provider<RegularFile>> plugins = [
+        provider(new Callable<RegularFile>(){
+            @Override
+            RegularFile call() throws Exception {
+                return new RegularFile() {
+                    @Override
+                    File getAsFile() {
+                        return configurations.zipArchive.asFileTree.getSingleFile()
+                    }
+                }
+            }
+        }),
+        provider(new Callable<RegularFile>(){
+            @Override
+            RegularFile call() throws Exception {
+                return new RegularFile() {
+                    @Override
+                    File getAsFile() {
+                        return fileTree(bwcFilePath + "flow-framework/" + project.version).getSingleFile()
+            }
+                }
+            }
+        })
+    ]
+
+// Creates 2 test clusters with 3 nodes of the old version.
+2.times {i ->
+    task "${baseName}#oldVersionClusterTask$i"(type: StandaloneRestIntegTestTask) {
+        onlyIf { isSameMajorVersion || (i == 1) }
+        useCluster testClusters."${baseName}$i"
+        filter {
+            includeTestsMatching "org.opensearch.flowframework.bwc.*IT"
+        }
+        systemProperty 'tests.rest.bwcsuite', 'old_cluster'
+        systemProperty 'tests.rest.bwcsuite_round', 'old'
+        systemProperty 'tests.plugin_bwc_version', bwcVersion
+        nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}$i".allHttpSocketURI.join(",")}")
+        nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}$i".getName()}")
+    }
+}
+
+// Upgrades one node of the old cluster to new OpenSearch version with upgraded plugin version
+// This results in a mixed cluster with 2 nodes on the old version and 1 upgraded node.
+// This is also used as a one third upgraded cluster for a rolling upgrade.
+task "${baseName}#mixedClusterTask"(type: StandaloneRestIntegTestTask) {
+    onlyIf { isSameMajorVersion }
+    useCluster testClusters."${baseName}0"
+    dependsOn "${baseName}#oldVersionClusterTask0"
+    doFirst {
+      testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+    }
+    filter {
+      includeTestsMatching "org.opensearch.flowframework.bwc.*IT"
+    }
+    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+    systemProperty 'tests.rest.bwcsuite_round', 'first'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+}
+
+// Upgrades the second node to new OpenSearch version with upgraded plugin version after the first node is upgraded.
+// This results in a mixed cluster with 1 node on the old version and 2 upgraded nodes.
+// This is used for rolling upgrade.
+task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTask) {
+    onlyIf { isSameMajorVersion }
+    dependsOn "${baseName}#mixedClusterTask"
+    useCluster testClusters."${baseName}0"
+    doFirst {
+      testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+    }
+    filter {
+      includeTestsMatching "org.opensearch.flowframework.bwc.*IT"
+    }
+    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+    systemProperty 'tests.rest.bwcsuite_round', 'second'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+}
+
+// Upgrades the third node to new OpenSearch version with upgraded plugin version after the second node is upgraded.
+// This results in a fully upgraded cluster.
+// This is used for rolling upgrade.
+task "${baseName}#rollingUpgradeClusterTask"(type: StandaloneRestIntegTestTask) {
+    onlyIf { isSameMajorVersion }
+    dependsOn "${baseName}#twoThirdsUpgradedClusterTask"
+    useCluster testClusters."${baseName}0"
+    doFirst {
+      testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+    }
+    filter {
+      includeTestsMatching "org.opensearch.flowframework.bwc.*IT"
+    }
+    mustRunAfter "${baseName}#mixedClusterTask"
+    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+    systemProperty 'tests.rest.bwcsuite_round', 'third'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+}
+
+// Upgrades all the nodes of the old cluster to new OpenSearch version with upgraded plugin version
+// at the same time resulting in a fully upgraded cluster.
+task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#oldVersionClusterTask1"
+    useCluster testClusters."${baseName}1"
+    doFirst {
+      testClusters."${baseName}1".upgradeAllNodesAndPluginsToNextVersion(plugins)
+    }
+    filter {
+      includeTestsMatching "org.opensearch.flowframework.bwc.*IT"
+    }
+    systemProperty 'tests.rest.bwcsuite', 'upgraded_cluster'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}1".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}1".getName()}")
+}
+
+// A bwc test suite which runs all the bwc tasks combined.
+task bwcTestSuite(type: StandaloneRestIntegTestTask) {
+    filter {
+        excludeTestsMatching '**.*Test*'
+        excludeTestsMatching '**.*IT*'
+        setFailOnNoMatchingTests(false)
+    }
+    dependsOn tasks.named("${baseName}#mixedClusterTask")
+    dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
+    dependsOn tasks.named("${baseName}#fullRestartClusterTask")
+}
 
 // test retry configuration
 allprojects {
@@ -437,6 +624,11 @@ allprojects {
                 failOnPassedAfterRetry = false
             }
         }
+    }
+    // Needed for Gradle 9.0
+    tasks.withType(StandaloneRestIntegTestTask).configureEach {
+        testClassesDirs = sourceSets.test.output.classesDirs
+        classpath = sourceSets.test.runtimeClasspath
     }
 }
 

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -52,7 +52,7 @@ public class CommonValue {
     public static final String CREATED_TIME = "created_time";
     /** The last updated time field */
     public static final String LAST_UPDATED_TIME_FIELD = "last_updated_time";
-    /** The last updated time field */
+    /** The last provisioned time field */
     public static final String LAST_PROVISIONED_TIME_FIELD = "last_provisioned_time";
 
     /*

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -48,6 +48,12 @@ public class CommonValue {
     public static final String CREATE_TIME = "create_time";
     /** The template field name for the user who created the workflow **/
     public static final String USER_FIELD = "user";
+    /** The created time field */
+    public static final String CREATED_TIME = "created_time";
+    /** The last updated time field */
+    public static final String LAST_UPDATED_TIME_FIELD = "last_updated_time";
+    /** The last updated time field */
+    public static final String LAST_PROVISIONED_TIME_FIELD = "last_provisioned_time";
 
     /*
      * Constants associated with Rest or Transport actions
@@ -156,10 +162,6 @@ public class CommonValue {
     public static final String APP_TYPE_FIELD = "app_type";
     /** To include field for an agent response */
     public static final String INCLUDE_OUTPUT_IN_AGENT_RESPONSE = "include_output_in_agent_response";
-    /** The created time field for an agent */
-    public static final String CREATED_TIME = "created_time";
-    /** The last updated time field for an agent */
-    public static final String LAST_UPDATED_TIME_FIELD = "last_updated_time";
     /** HttpHost */
     public static final String HTTP_HOST_FIELD = "http_host";
     /** Http scheme */

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -403,9 +403,14 @@ public class FlowFrameworkIndicesHandler {
      * @param documentId the document Id
      * @param template the use-case template
      * @param listener action listener
-     * @param force if set true, ignores the requirement that the provisioning is not started
+     * @param ignoreNotStartedCheck if set true, ignores the requirement that the provisioning is not started
      */
-    public void updateTemplateInGlobalContext(String documentId, Template template, ActionListener<IndexResponse> listener, boolean force) {
+    public void updateTemplateInGlobalContext(
+        String documentId,
+        Template template,
+        ActionListener<IndexResponse> listener,
+        boolean ignoreNotStartedCheck
+    ) {
         if (!doesIndexExist(GLOBAL_CONTEXT_INDEX)) {
             String errorMessage = "Failed to update template for workflow_id : " + documentId + ", global_context index does not exist.";
             logger.error(errorMessage);
@@ -415,7 +420,7 @@ public class FlowFrameworkIndicesHandler {
         doesTemplateExist(documentId, templateExists -> {
             if (templateExists) {
                 isWorkflowNotStarted(documentId, workflowIsNotStarted -> {
-                    if (workflowIsNotStarted || force) {
+                    if (workflowIsNotStarted || ignoreNotStartedCheck) {
                         IndexRequest request = new IndexRequest(GLOBAL_CONTEXT_INDEX).id(documentId);
                         try (
                             XContentBuilder builder = XContentFactory.jsonBuilder();

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -395,6 +395,17 @@ public class FlowFrameworkIndicesHandler {
      * @param listener action listener
      */
     public void updateTemplateInGlobalContext(String documentId, Template template, ActionListener<IndexResponse> listener) {
+        updateTemplateInGlobalContext(documentId, template, listener, false);
+    }
+
+    /**
+     * Replaces a document in the global context index
+     * @param documentId the document Id
+     * @param template the use-case template
+     * @param listener action listener
+     * @param force if set true, ignores the requirement that the provisioning is not started
+     */
+    public void updateTemplateInGlobalContext(String documentId, Template template, ActionListener<IndexResponse> listener, boolean force) {
         if (!doesIndexExist(GLOBAL_CONTEXT_INDEX)) {
             String errorMessage = "Failed to update template for workflow_id : " + documentId + ", global_context index does not exist.";
             logger.error(errorMessage);
@@ -404,7 +415,7 @@ public class FlowFrameworkIndicesHandler {
         doesTemplateExist(documentId, templateExists -> {
             if (templateExists) {
                 isWorkflowNotStarted(documentId, workflowIsNotStarted -> {
-                    if (workflowIsNotStarted) {
+                    if (workflowIsNotStarted || force) {
                         IndexRequest request = new IndexRequest(GLOBAL_CONTEXT_INDEX).id(documentId);
                         try (
                             XContentBuilder builder = XContentFactory.jsonBuilder();

--- a/src/main/java/org/opensearch/flowframework/model/Template.java
+++ b/src/main/java/org/opensearch/flowframework/model/Template.java
@@ -24,6 +24,7 @@ import org.opensearch.flowframework.util.ParseUtils;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -114,8 +115,8 @@ public class Template implements ToXContentObject {
         private String description = "";
         private String useCase = "";
         private Version templateVersion = null;
-        private List<Version> compatibilityVersion = new ArrayList<>();
-        private Map<String, Workflow> workflows = new HashMap<>();
+        private List<Version> compatibilityVersion = Collections.emptyList();
+        private Map<String, Workflow> workflows = Collections.emptyMap();
         private Map<String, Object> uiMetadata = null;
         private User user = null;
         private Instant createdTime = null;
@@ -126,6 +127,30 @@ public class Template implements ToXContentObject {
          * Empty Constructor for the Builder object
          */
         public Builder() {}
+
+        /**
+         * Construct a Builder from an existing template
+         * @param t The existing template to copy
+         */
+        public Builder(Template t) {
+            this.name = t.name();
+            this.description = t.description();
+            this.useCase = t.useCase();
+            this.templateVersion = t.templateVersion;
+            if (t.compatibilityVersion() != null) {
+                this.compatibilityVersion = List.copyOf(t.compatibilityVersion());
+            }
+            if (t.workflows() != null) {
+                this.workflows = Map.copyOf(t.workflows());
+            }
+            if (t.getUiMetadata() != null) {
+                this.uiMetadata = Map.copyOf(t.getUiMetadata());
+            }
+            this.user = t.getUser();
+            this.createdTime = t.createdTime();
+            this.lastUpdatedTime = t.lastUpdatedTime();
+            this.lastProvisionedTime = t.lastProvisionedTime();
+        }
 
         /**
          * Builder method for adding template name

--- a/src/main/java/org/opensearch/flowframework/model/Template.java
+++ b/src/main/java/org/opensearch/flowframework/model/Template.java
@@ -101,8 +101,8 @@ public class Template implements ToXContentObject {
         this.workflows = Map.copyOf(workflows);
         this.uiMetadata = uiMetadata;
         this.user = user;
-        this.createdTime = createdTime == null ? Instant.now() : createdTime;
-        this.lastUpdatedTime = (lastUpdatedTime == null || lastUpdatedTime.isBefore(this.createdTime)) ? this.createdTime : lastUpdatedTime;
+        this.createdTime = createdTime;
+        this.lastUpdatedTime = lastUpdatedTime;
         this.lastProvisionedTime = lastProvisionedTime;
     }
 

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -96,6 +96,7 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
     protected void doExecute(Task task, WorkflowRequest request, ActionListener<WorkflowResponse> listener) {
 
         User user = getUserContext(client);
+        Instant creationTime = Instant.now();
         Template templateWithUser = new Template(
             request.getTemplate().name(),
             request.getTemplate().description(),
@@ -105,9 +106,9 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
             request.getTemplate().workflows(),
             request.getTemplate().getUiMetadata(),
             user,
-            request.getTemplate().createdTime(),
-            request.getTemplate().lastUpdatedTime(),
-            request.getTemplate().lastProvisionedTime()
+            creationTime,
+            creationTime,
+            null
         );
 
         String[] validateAll = { "all" };

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -93,7 +93,7 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
     protected void doExecute(Task task, WorkflowRequest request, ActionListener<WorkflowResponse> listener) {
 
         User user = getUserContext(client);
-        Template templateWithUser = new Template(
+        Template templateWithUserAndTimestamps = new Template(
             request.getTemplate().name(),
             request.getTemplate().description(),
             request.getTemplate().useCase(),
@@ -101,15 +101,18 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
             request.getTemplate().compatibilityVersion(),
             request.getTemplate().workflows(),
             request.getTemplate().getUiMetadata(),
-            user
+            user,
+            -1L,
+            -1L,
+            -1L
         );
 
         String[] validateAll = { "all" };
         if (Arrays.equals(request.getValidation(), validateAll)) {
             try {
-                validateWorkflows(templateWithUser);
+                validateWorkflows(templateWithUserAndTimestamps);
             } catch (Exception e) {
-                String errorMessage = "Workflow validation failed for template " + templateWithUser.name();
+                String errorMessage = "Workflow validation failed for template " + templateWithUserAndTimestamps.name();
                 logger.error(errorMessage, e);
                 listener.onFailure(
                     e instanceof FlowFrameworkException ? e : new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e))
@@ -140,7 +143,7 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                             } else {
                                 // Create new global context and state index entries
                                 flowFrameworkIndicesHandler.putTemplateToGlobalContext(
-                                    templateWithUser,
+                                    templateWithUserAndTimestamps,
                                     ActionListener.wrap(globalContextResponse -> {
                                         flowFrameworkIndicesHandler.putInitialStateToWorkflowState(
                                             globalContextResponse.getId(),

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -240,15 +240,7 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                     if (getResponse.isExists()) {
                         Template existingTemplate = Template.parse(getResponse.getSourceAsString());
                         // Update existing entry, full document replacement
-                        Template template = new Template.Builder().name(templateWithUser.name())
-                            .description(templateWithUser.description())
-                            .useCase(templateWithUser.useCase())
-                            .templateVersion(templateWithUser.templateVersion())
-                            .compatibilityVersion(templateWithUser.compatibilityVersion())
-                            .workflows(templateWithUser.workflows())
-                            .uiMetadata(templateWithUser.getUiMetadata())
-                            .user(templateWithUser.getUser()) // Should we care about old user here?
-                            .createdTime(existingTemplate.createdTime())
+                        Template template = new Template.Builder(templateWithUser).createdTime(existingTemplate.createdTime())
                             .lastUpdatedTime(Instant.now())
                             .lastProvisionedTime(existingTemplate.lastProvisionedTime())
                             .build();

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.transport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -38,12 +39,14 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static java.lang.Boolean.FALSE;
+import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.PROVISIONING_PROGRESS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.STATE_FIELD;
 import static org.opensearch.flowframework.util.ParseUtils.getUserContext;
@@ -120,8 +123,9 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                 return;
             }
         }
-
-        if (request.getWorkflowId() == null) {
+        String workflowId = request.getWorkflowId();
+        if (workflowId == null) {
+            // This is a new workflow (POST)
             // Throttle incoming requests
             checkMaxWorkflows(
                 flowFrameworkSettings.getRequestTimeout(),
@@ -226,40 +230,74 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                 })
             );
         } else {
-            // Update existing entry, full document replacement
-            flowFrameworkIndicesHandler.updateTemplateInGlobalContext(
-                request.getWorkflowId(),
-                request.getTemplate(),
-                ActionListener.wrap(response -> {
-                    flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(
-                        request.getWorkflowId(),
-                        Map.ofEntries(
-                            Map.entry(STATE_FIELD, State.NOT_STARTED),
-                            Map.entry(PROVISIONING_PROGRESS_FIELD, ProvisioningProgress.NOT_STARTED)
-                        ),
-                        ActionListener.wrap(updateResponse -> {
-                            logger.info("updated workflow {} state to {}", request.getWorkflowId(), State.NOT_STARTED.name());
-                            listener.onResponse(new WorkflowResponse(request.getWorkflowId()));
-                        }, exception -> {
-                            String errorMessage = "Failed to update workflow " + request.getWorkflowId() + " in template index";
-                            logger.error(errorMessage, exception);
-                            if (exception instanceof FlowFrameworkException) {
-                                listener.onFailure(exception);
-                            } else {
-                                listener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception)));
-                            }
-                        })
-                    );
-                }, exception -> {
-                    String errorMessage = "Failed to update use case template " + request.getWorkflowId();
-                    logger.error(errorMessage, exception);
-                    if (exception instanceof FlowFrameworkException) {
-                        listener.onFailure(exception);
+            // This is an existing workflow (PUT)
+            // Fetch existing entry for time stamps
+            logger.info("Querying existing workflow from global context: {}", workflowId);
+            try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+                client.get(new GetRequest(GLOBAL_CONTEXT_INDEX, workflowId), ActionListener.wrap(getResponse -> {
+                    context.restore();
+                    if (getResponse.isExists()) {
+                        Template existingTemplate = Template.parse(getResponse.getSourceAsString());
+                        Template newTemplate = request.getTemplate();
+                        // Update existing entry, full document replacement
+                        Template template = new Template.Builder().name(newTemplate.name())
+                            .description(newTemplate.description())
+                            .useCase(newTemplate.useCase())
+                            .templateVersion(newTemplate.templateVersion())
+                            .compatibilityVersion(newTemplate.compatibilityVersion())
+                            .workflows(newTemplate.workflows())
+                            .uiMetadata(newTemplate.getUiMetadata())
+                            .user(newTemplate.getUser()) // Should we care about old user here?
+                            .createdTime(existingTemplate.createdTime())
+                            .lastUpdatedTime(Instant.now().toEpochMilli())
+                            .lastProvisionedTime(existingTemplate.lastProvisionedTime())
+                            .build();
+                        flowFrameworkIndicesHandler.updateTemplateInGlobalContext(
+                            request.getWorkflowId(),
+                            template,
+                            ActionListener.wrap(response -> {
+                                flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(
+                                    request.getWorkflowId(),
+                                    Map.ofEntries(
+                                        Map.entry(STATE_FIELD, State.NOT_STARTED),
+                                        Map.entry(PROVISIONING_PROGRESS_FIELD, ProvisioningProgress.NOT_STARTED)
+                                    ),
+                                    ActionListener.wrap(updateResponse -> {
+                                        logger.info("updated workflow {} state to {}", request.getWorkflowId(), State.NOT_STARTED.name());
+                                        listener.onResponse(new WorkflowResponse(request.getWorkflowId()));
+                                    }, exception -> {
+                                        String errorMessage = "Failed to update workflow " + request.getWorkflowId() + " in template index";
+                                        logger.error(errorMessage, exception);
+                                        if (exception instanceof FlowFrameworkException) {
+                                            listener.onFailure(exception);
+                                        } else {
+                                            listener.onFailure(
+                                                new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception))
+                                            );
+                                        }
+                                    })
+                                );
+                            }, exception -> {
+                                String errorMessage = "Failed to update use case template " + request.getWorkflowId();
+                                logger.error(errorMessage, exception);
+                                if (exception instanceof FlowFrameworkException) {
+                                    listener.onFailure(exception);
+                                } else {
+                                    listener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception)));
+                                }
+                            })
+                        );
                     } else {
-                        listener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception)));
+                        String errorMessage = "Failed to retrieve template (" + workflowId + ") from global context.";
+                        logger.error(errorMessage);
+                        listener.onFailure(new FlowFrameworkException(errorMessage, RestStatus.NOT_FOUND));
                     }
-                })
-            );
+                }, exception -> {
+                    String errorMessage = "Failed to retrieve template (" + workflowId + ") from global context.";
+                    logger.error(errorMessage, exception);
+                    listener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception)));
+                }));
+            }
         }
     }
 

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -118,10 +118,10 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                 }
 
                 // Parse template from document source
-                Template template = Template.parse(response.getSourceAsString());
+                Template parsedTemplate = Template.parse(response.getSourceAsString());
 
                 // Decrypt template
-                template = encryptorUtils.decryptTemplateCredentials(template);
+                final Template template = encryptorUtils.decryptTemplateCredentials(parsedTemplate);
 
                 // Sort and validate graph
                 Workflow provisionWorkflow = template.workflows().get(PROVISION_WORKFLOW);
@@ -134,6 +134,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
 
                 flowFrameworkIndicesHandler.isWorkflowNotStarted(workflowId, workflowIsNotStarted -> {
                     if (TRUE.equals(workflowIsNotStarted)) {
+                        // update state index
                         flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(
                             workflowId,
                             Map.ofEntries(
@@ -145,7 +146,36 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                             ActionListener.wrap(updateResponse -> {
                                 logger.info("updated workflow {} state to {}", request.getWorkflowId(), State.PROVISIONING);
                                 executeWorkflowAsync(workflowId, provisionProcessSequence, listener);
-                                listener.onResponse(new WorkflowResponse(workflowId));
+                                // update last provisioned field in template
+                                Template newTemplate = new Template.Builder().name(template.name())
+                                    .description(template.description())
+                                    .useCase(template.useCase())
+                                    .templateVersion(template.templateVersion())
+                                    .compatibilityVersion(template.compatibilityVersion())
+                                    .workflows(template.workflows())
+                                    .uiMetadata(template.getUiMetadata())
+                                    .user(template.getUser()) // Should we care about old user here?
+                                    .createdTime(template.createdTime())
+                                    .lastUpdatedTime(template.lastUpdatedTime())
+                                    .lastProvisionedTime(Instant.now().toEpochMilli())
+                                    .build();
+                                flowFrameworkIndicesHandler.updateTemplateInGlobalContext(
+                                    request.getWorkflowId(),
+                                    newTemplate,
+                                    ActionListener.wrap(templateResponse -> {
+                                        listener.onResponse(new WorkflowResponse(request.getWorkflowId()));
+                                    }, exception -> {
+                                        String errorMessage = "Failed to update use case template " + request.getWorkflowId();
+                                        logger.error(errorMessage, exception);
+                                        if (exception instanceof FlowFrameworkException) {
+                                            listener.onFailure(exception);
+                                        } else {
+                                            listener.onFailure(
+                                                new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception))
+                                            );
+                                        }
+                                    })
+                                );
                             }, exception -> {
                                 String errorMessage = "Failed to update workflow state: " + workflowId;
                                 logger.error(errorMessage, exception);

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -174,7 +174,9 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                                                 new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception))
                                             );
                                         }
-                                    })
+                                    }),
+                                    // We've already checked workflow is not started, ignore second check
+                                    true
                                 );
                             }, exception -> {
                                 String errorMessage = "Failed to update workflow state: " + workflowId;

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -147,18 +147,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                                 logger.info("updated workflow {} state to {}", request.getWorkflowId(), State.PROVISIONING);
                                 executeWorkflowAsync(workflowId, provisionProcessSequence, listener);
                                 // update last provisioned field in template
-                                Template newTemplate = new Template.Builder().name(template.name())
-                                    .description(template.description())
-                                    .useCase(template.useCase())
-                                    .templateVersion(template.templateVersion())
-                                    .compatibilityVersion(template.compatibilityVersion())
-                                    .workflows(template.workflows())
-                                    .uiMetadata(template.getUiMetadata())
-                                    .user(template.getUser()) // Should we care about old user here?
-                                    .createdTime(template.createdTime())
-                                    .lastUpdatedTime(template.lastUpdatedTime())
-                                    .lastProvisionedTime(Instant.now())
-                                    .build();
+                                Template newTemplate = new Template.Builder(template).lastProvisionedTime(Instant.now()).build();
                                 flowFrameworkIndicesHandler.updateTemplateInGlobalContext(
                                     request.getWorkflowId(),
                                     newTemplate,

--- a/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
@@ -159,18 +159,7 @@ public class EncryptorUtils {
             processedWorkflows.put(entry.getKey(), new Workflow(entry.getValue().userParams(), processedNodes, entry.getValue().edges()));
         }
 
-        return new Template.Builder().name(template.name())
-            .description(template.description())
-            .useCase(template.useCase())
-            .templateVersion(template.templateVersion())
-            .compatibilityVersion(template.compatibilityVersion())
-            .workflows(processedWorkflows)
-            .uiMetadata(template.getUiMetadata())
-            .user(template.getUser())
-            .createdTime(template.createdTime())
-            .lastUpdatedTime(template.lastUpdatedTime())
-            .lastProvisionedTime(template.lastProvisionedTime())
-            .build();
+        return new Template.Builder(template).workflows(processedWorkflows).build();
     }
 
     /**
@@ -238,18 +227,7 @@ public class EncryptorUtils {
             processedWorkflows.put(entry.getKey(), new Workflow(entry.getValue().userParams(), processedNodes, entry.getValue().edges()));
         }
 
-        return new Template.Builder().name(template.name())
-            .description(template.description())
-            .useCase(template.useCase())
-            .templateVersion(template.templateVersion())
-            .compatibilityVersion(template.compatibilityVersion())
-            .workflows(processedWorkflows)
-            .uiMetadata(template.getUiMetadata())
-            .user(template.getUser())
-            .createdTime(template.createdTime())
-            .lastUpdatedTime(template.lastUpdatedTime())
-            .lastProvisionedTime(template.lastProvisionedTime())
-            .build();
+        return new Template.Builder(template).workflows(processedWorkflows).build();
     }
 
     /**

--- a/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
@@ -126,8 +126,6 @@ public class EncryptorUtils {
      * @return template with encrypted credentials
      */
     private Template processTemplateCredentials(Template template, Function<String, String> cipherFunction) {
-        Template.Builder processedTemplateBuilder = new Template.Builder();
-
         Map<String, Workflow> processedWorkflows = new HashMap<>();
         for (Map.Entry<String, Workflow> entry : template.workflows().entrySet()) {
 
@@ -161,7 +159,7 @@ public class EncryptorUtils {
             processedWorkflows.put(entry.getKey(), new Workflow(entry.getValue().userParams(), processedNodes, entry.getValue().edges()));
         }
 
-        Template processedTemplate = processedTemplateBuilder.name(template.name())
+        return new Template.Builder().name(template.name())
             .description(template.description())
             .useCase(template.useCase())
             .templateVersion(template.templateVersion())
@@ -169,9 +167,10 @@ public class EncryptorUtils {
             .workflows(processedWorkflows)
             .uiMetadata(template.getUiMetadata())
             .user(template.getUser())
+            .createdTime(template.createdTime())
+            .lastUpdatedTime(template.lastUpdatedTime())
+            .lastProvisionedTime(template.lastProvisionedTime())
             .build();
-
-        return processedTemplate;
     }
 
     /**
@@ -217,8 +216,6 @@ public class EncryptorUtils {
      * @return the redacted template
      */
     public Template redactTemplateCredentials(Template template) {
-        Template.Builder redactedTemplateBuilder = new Template.Builder();
-
         Map<String, Workflow> processedWorkflows = new HashMap<>();
         for (Map.Entry<String, Workflow> entry : template.workflows().entrySet()) {
 
@@ -241,7 +238,7 @@ public class EncryptorUtils {
             processedWorkflows.put(entry.getKey(), new Workflow(entry.getValue().userParams(), processedNodes, entry.getValue().edges()));
         }
 
-        Template processedTemplate = redactedTemplateBuilder.name(template.name())
+        return new Template.Builder().name(template.name())
             .description(template.description())
             .useCase(template.useCase())
             .templateVersion(template.templateVersion())
@@ -249,9 +246,10 @@ public class EncryptorUtils {
             .workflows(processedWorkflows)
             .uiMetadata(template.getUiMetadata())
             .user(template.getUser())
+            .createdTime(template.createdTime())
+            .lastUpdatedTime(template.lastUpdatedTime())
+            .lastProvisionedTime(template.lastProvisionedTime())
             .build();
-
-        return processedTemplate;
     }
 
     /**

--- a/src/main/resources/mappings/global-context.json
+++ b/src/main/resources/mappings/global-context.json
@@ -1,7 +1,7 @@
 {
   "dynamic": false,
   "_meta": {
-    "schema_version": 1
+    "schema_version": 2
   },
   "properties": {
     "workflow_id": {
@@ -73,6 +73,18 @@
           }
         }
       }
+    },
+    "created_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "last_updated_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "last_provisioned_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
     }
   }
 }

--- a/src/test/java/org/opensearch/flowframework/bwc/FlowFrameworkBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/flowframework/bwc/FlowFrameworkBackwardsCompatibilityIT.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.bwc;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.opensearch.client.Response;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.TestHelpers;
+import org.opensearch.flowframework.model.Template;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
+
+public class FlowFrameworkBackwardsCompatibilityIT extends OpenSearchRestTestCase {
+
+    private static final ClusterType CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.bwcsuite"));
+    private static final String CLUSTER_NAME = System.getProperty("tests.clustername");
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setupSettings();
+    }
+
+    private void setupSettings() throws IOException {
+        // Enable Flow Framework Plugin Rest APIs
+        Response response = TestHelpers.makeRequest(
+            client(),
+            "PUT",
+            "_cluster/settings",
+            null,
+            "{\"transient\":{\"plugins.flow_framework.enabled\":true}}",
+            List.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+        );
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    @Override
+    protected final boolean preserveIndicesUponCompletion() {
+        return true;
+    }
+
+    @Override
+    protected final boolean preserveReposUponCompletion() {
+        return true;
+    }
+
+    @Override
+    protected boolean preserveTemplatesUponCompletion() {
+        return true;
+    }
+
+    @Override
+    protected final Settings restClientSettings() {
+        return Settings.builder()
+            .put(super.restClientSettings())
+            // increase the timeout here to 90 seconds to handle long waits for a green
+            // cluster health. the waits for green need to be longer than a minute to
+            // account for delayed shards
+            .put(OpenSearchRestTestCase.CLIENT_SOCKET_TIMEOUT, "90s")
+            .build();
+    }
+
+    private enum ClusterType {
+        OLD,
+        MIXED,
+        UPGRADED;
+
+        public static ClusterType parse(String value) {
+            switch (value) {
+                case "old_cluster":
+                    return OLD;
+                case "mixed_cluster":
+                    return MIXED;
+                case "upgraded_cluster":
+                    return UPGRADED;
+                default:
+                    throw new AssertionError("unknown cluster type: " + value);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testBackwardsCompatibility() throws Exception {
+        String uri = getUri();
+        Map<String, Map<String, Object>> responseMap = (Map<String, Map<String, Object>>) getAsMap(uri).get("nodes");
+        for (Map<String, Object> response : responseMap.values()) {
+            List<Map<String, Object>> plugins = (List<Map<String, Object>>) response.get("plugins");
+            Set<Object> pluginNames = plugins.stream().map(map -> map.get("name")).collect(Collectors.toSet());
+            String workflowId = createNoopTemplate();
+            Template t = getTemplate(workflowId);
+            switch (CLUSTER_TYPE) {
+                case OLD:
+                    assertTrue(pluginNames.contains("opensearch-flow-framework"));
+                    // mapping for 2.12 does not include time stamps
+                    assertNull(t.createdTime());
+                    assertNull(t.lastUpdatedTime());
+                    assertNull(t.lastProvisionedTime());
+                    break;
+                case MIXED:
+                    assertTrue(pluginNames.contains("opensearch-flow-framework"));
+                    // Time stamps may or may not be null depending on whether index has been accessed by new version node
+                    // So just test that the template parses
+                    assertNull(t.lastProvisionedTime());
+                    break;
+                case UPGRADED:
+                    assertTrue(pluginNames.contains("opensearch-flow-framework"));
+                    // mapping for 2.13+ includes time stamps
+                    assertNotNull(t.createdTime());
+                    assertEquals(t.createdTime(), t.lastUpdatedTime());
+                    assertNull(t.lastProvisionedTime());
+                    break;
+            }
+            break;
+        }
+    }
+
+    private String getUri() {
+        switch (CLUSTER_TYPE) {
+            case OLD:
+                return "_nodes/" + CLUSTER_NAME + "-0/plugins";
+            case MIXED:
+                String round = System.getProperty("tests.rest.bwcsuite_round");
+                if (round.equals("second")) {
+                    return "_nodes/" + CLUSTER_NAME + "-1/plugins";
+                } else if (round.equals("third")) {
+                    return "_nodes/" + CLUSTER_NAME + "-2/plugins";
+                } else {
+                    return "_nodes/" + CLUSTER_NAME + "-0/plugins";
+                }
+            case UPGRADED:
+                return "_nodes/plugins";
+            default:
+                throw new AssertionError("unknown cluster type: " + CLUSTER_TYPE);
+        }
+    }
+
+    private String createNoopTemplate() throws IOException, ParseException {
+        Response response = TestHelpers.makeRequest(
+            client(),
+            "POST",
+            "_plugins/_flow_framework/workflow",
+            null,
+            "{\"name\":\"test\", \"workflows\":{\"provision\": {\"nodes\": [{\"id\":\"test-step\", \"type\":\"noop\"}]}}}",
+            List.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+        );
+        assertEquals(RestStatus.CREATED.getStatus(), response.getStatusLine().getStatusCode());
+
+        Map<String, Object> responseMap = entityAsMap(response);
+        String workflowId = (String) responseMap.get(WORKFLOW_ID);
+        assertNotNull(workflowId);
+        return workflowId;
+    }
+
+    private Template getTemplate(String workflowId) throws IOException, ParseException {
+        Response response = TestHelpers.makeRequest(
+            client(),
+            "GET",
+            "_plugins/_flow_framework/workflow/" + workflowId,
+            null,
+            "",
+            List.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+        );
+        assertEquals(RestStatus.OK.getStatus(), response.getStatusLine().getStatusCode());
+
+        String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+        return Template.parse(body);
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/bwc/FlowFrameworkBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/flowframework/bwc/FlowFrameworkBackwardsCompatibilityIT.java
@@ -102,29 +102,29 @@ public class FlowFrameworkBackwardsCompatibilityIT extends OpenSearchRestTestCas
 
     @SuppressWarnings("unchecked")
     public void testBackwardsCompatibility() throws Exception {
+        // This iteration of nodes is only to get plugins installed on each node. We don't currently use its functionality but in case we
+        // ever need version-based dependencies in future BWC tests it will be needed. It's directly copied from similar implementations
+        // in other plugins.
         String uri = getUri();
         Map<String, Map<String, Object>> responseMap = (Map<String, Map<String, Object>>) getAsMap(uri).get("nodes");
         for (Map<String, Object> response : responseMap.values()) {
             List<Map<String, Object>> plugins = (List<Map<String, Object>>) response.get("plugins");
             Set<Object> pluginNames = plugins.stream().map(map -> map.get("name")).collect(Collectors.toSet());
+            assertTrue(pluginNames.contains("opensearch-flow-framework"));
             String workflowId = createNoopTemplate();
             Template t = getTemplate(workflowId);
             switch (CLUSTER_TYPE) {
                 case OLD:
-                    assertTrue(pluginNames.contains("opensearch-flow-framework"));
                     // mapping for 2.12 does not include time stamps
                     assertNull(t.createdTime());
                     assertNull(t.lastUpdatedTime());
                     assertNull(t.lastProvisionedTime());
                     break;
                 case MIXED:
-                    assertTrue(pluginNames.contains("opensearch-flow-framework"));
                     // Time stamps may or may not be null depending on whether index has been accessed by new version node
-                    // So just test that the template parses
                     assertNull(t.lastProvisionedTime());
                     break;
                 case UPGRADED:
-                    assertTrue(pluginNames.contains("opensearch-flow-framework"));
                     // mapping for 2.13+ includes time stamps
                     assertNotNull(t.createdTime());
                     assertEquals(t.createdTime(), t.lastUpdatedTime());

--- a/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
+++ b/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
@@ -120,7 +120,10 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
             compatibilityVersions,
             Map.of("workflow", workflow),
             Collections.emptyMap(),
-            TestHelpers.randomUser()
+            TestHelpers.randomUser(),
+            -1L,
+            -1L,
+            -1L
         );
     }
 

--- a/src/test/java/org/opensearch/flowframework/model/TemplateTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/TemplateTests.java
@@ -12,9 +12,9 @@ import org.opensearch.Version;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.test.OpenSearchTestCase;
-import org.joda.time.Instant;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -63,8 +63,8 @@ public class TemplateTests extends OpenSearchTestCase {
         assertEquals(uiMetadata, template.getUiMetadata());
         Workflow wf = template.workflows().get("workflow");
         assertNotNull(wf);
-        assertTrue(template.createdTime() > Instant.now().minus(10_000).getMillis());
-        assertTrue(template.createdTime() < Instant.now().getMillis());
+        assertTrue(template.createdTime() > Instant.now().minusSeconds(10).toEpochMilli());
+        assertTrue(template.createdTime() <= Instant.now().toEpochMilli());
         assertEquals(template.createdTime(), template.lastUpdatedTime());
         assertEquals(-1, template.lastProvisionedTime());
         assertEquals("Workflow [userParams={key=value}, nodes=[A, B], edges=[A->B]]", wf.toString());
@@ -80,8 +80,8 @@ public class TemplateTests extends OpenSearchTestCase {
         assertEquals(uiMetadata, templateX.getUiMetadata());
         Workflow wfX = templateX.workflows().get("workflow");
         assertNotNull(wfX);
-        assertTrue(template.createdTime() > Instant.now().minus(10_000).getMillis());
-        assertTrue(template.createdTime() < Instant.now().getMillis());
+        assertTrue(template.createdTime() > Instant.now().minusSeconds(10).toEpochMilli());
+        assertTrue(template.createdTime() <= Instant.now().toEpochMilli());
         assertEquals(template.lastUpdatedTime(), template.createdTime());
         assertEquals(-1, template.lastProvisionedTime());
         assertEquals("Workflow [userParams={key=value}, nodes=[A, B], edges=[A->B]]", wfX.toString());

--- a/src/test/java/org/opensearch/flowframework/model/TemplateTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/TemplateTests.java
@@ -41,6 +41,7 @@ public class TemplateTests extends OpenSearchTestCase {
         Workflow workflow = new Workflow(Map.of("key", "value"), nodes, edges);
         Map<String, Object> uiMetadata = null;
 
+        Instant now = Instant.now();
         Template template = new Template(
             "test",
             "a test template",
@@ -50,8 +51,8 @@ public class TemplateTests extends OpenSearchTestCase {
             Map.of("workflow", workflow),
             uiMetadata,
             null,
-            null,
-            null,
+            now,
+            now,
             null
         );
 
@@ -63,9 +64,8 @@ public class TemplateTests extends OpenSearchTestCase {
         assertEquals(uiMetadata, template.getUiMetadata());
         Workflow wf = template.workflows().get("workflow");
         assertNotNull(wf);
-        assertTrue(template.createdTime().isAfter(Instant.now().minusSeconds(10)));
-        assertFalse(template.createdTime().isAfter(Instant.now()));
-        assertEquals(template.createdTime(), template.lastUpdatedTime());
+        assertEquals(now, template.createdTime());
+        assertEquals(now, template.lastUpdatedTime());
         assertNull(template.lastProvisionedTime());
         assertEquals("Workflow [userParams={key=value}, nodes=[A, B], edges=[A->B]]", wf.toString());
 
@@ -80,9 +80,8 @@ public class TemplateTests extends OpenSearchTestCase {
         assertEquals(uiMetadata, templateX.getUiMetadata());
         Workflow wfX = templateX.workflows().get("workflow");
         assertNotNull(wfX);
-        assertTrue(template.createdTime().isAfter(Instant.now().minusSeconds(10)));
-        assertFalse(template.createdTime().isAfter(Instant.now()));
-        assertEquals(template.createdTime(), template.lastUpdatedTime());
+        assertEquals(now, template.createdTime());
+        assertEquals(now, template.lastUpdatedTime());
         assertNull(template.lastProvisionedTime());
         assertEquals("Workflow [userParams={key=value}, nodes=[A, B], edges=[A->B]]", wfX.toString());
     }

--- a/src/test/java/org/opensearch/flowframework/model/TemplateTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/TemplateTests.java
@@ -12,6 +12,7 @@ import org.opensearch.Version;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.test.OpenSearchTestCase;
+import org.joda.time.Instant;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -48,7 +49,10 @@ public class TemplateTests extends OpenSearchTestCase {
             compatibilityVersion,
             Map.of("workflow", workflow),
             uiMetadata,
-            null
+            null,
+            -1L,
+            -1L,
+            -1L
         );
 
         assertEquals("test", template.name());
@@ -59,6 +63,10 @@ public class TemplateTests extends OpenSearchTestCase {
         assertEquals(uiMetadata, template.getUiMetadata());
         Workflow wf = template.workflows().get("workflow");
         assertNotNull(wf);
+        assertTrue(template.createdTime() > Instant.now().minus(10_000).getMillis());
+        assertTrue(template.createdTime() < Instant.now().getMillis());
+        assertEquals(template.createdTime(), template.lastUpdatedTime());
+        assertEquals(-1, template.lastProvisionedTime());
         assertEquals("Workflow [userParams={key=value}, nodes=[A, B], edges=[A->B]]", wf.toString());
 
         String json = TemplateTestJsonUtil.parseToJson(template);
@@ -72,6 +80,10 @@ public class TemplateTests extends OpenSearchTestCase {
         assertEquals(uiMetadata, templateX.getUiMetadata());
         Workflow wfX = templateX.workflows().get("workflow");
         assertNotNull(wfX);
+        assertTrue(template.createdTime() > Instant.now().minus(10_000).getMillis());
+        assertTrue(template.createdTime() < Instant.now().getMillis());
+        assertEquals(template.lastUpdatedTime(), template.createdTime());
+        assertEquals(-1, template.lastProvisionedTime());
         assertEquals("Workflow [userParams={key=value}, nodes=[A, B], edges=[A->B]]", wfX.toString());
     }
 

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -131,15 +131,7 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
             )
             .collect(Collectors.toList());
         Workflow missingInputs = new Workflow(originalWorkflow.userParams(), modifiednodes, originalWorkflow.edges());
-        Template templateWithMissingInputs = new Template.Builder().name(template.name())
-            .description(template.description())
-            .useCase(template.useCase())
-            .templateVersion(template.templateVersion())
-            .compatibilityVersion(template.compatibilityVersion())
-            .workflows(Map.of(PROVISION_WORKFLOW, missingInputs))
-            .uiMetadata(template.getUiMetadata())
-            .user(template.getUser())
-            .build();
+        Template templateWithMissingInputs = new Template.Builder(template).workflows(Map.of(PROVISION_WORKFLOW, missingInputs)).build();
 
         // Hit Create Workflow API with invalid template
         Response response = createWorkflow(client(), templateWithMissingInputs);
@@ -191,15 +183,7 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
             List.of(new WorkflowEdge("workflow_step_2", "workflow_step_3"), new WorkflowEdge("workflow_step_3", "workflow_step_2"))
         );
 
-        Template cyclicalTemplate = new Template.Builder().name(template.name())
-            .description(template.description())
-            .useCase(template.useCase())
-            .templateVersion(template.templateVersion())
-            .compatibilityVersion(template.compatibilityVersion())
-            .workflows(Map.of(PROVISION_WORKFLOW, cyclicalWorkflow))
-            .uiMetadata(template.getUiMetadata())
-            .user(template.getUser())
-            .build();
+        Template cyclicalTemplate = new Template.Builder(template).workflows(Map.of(PROVISION_WORKFLOW, cyclicalWorkflow)).build();
 
         // Hit dry run
         ResponseException exception = expectThrows(ResponseException.class, () -> createWorkflowValidation(client(), cyclicalTemplate));

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -80,7 +80,7 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         Template template = TestHelpers.createTemplateFromFile("createconnector-registerremotemodel-deploymodel.json");
 
         ResponseException exception = expectThrows(ResponseException.class, () -> updateWorkflow(client(), "123", template));
-        assertTrue(exception.getMessage().contains("Failed to get template: 123"));
+        assertTrue(exception.getMessage().contains("Failed to retrieve template (123) from global context."));
 
         Response response = createWorkflow(client(), template);
         assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));

--- a/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
@@ -73,7 +73,10 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
             compatibilityVersions,
             Map.of("workflow", workflow),
             Collections.emptyMap(),
-            TestHelpers.randomUser()
+            TestHelpers.randomUser(),
+            -1L,
+            -1L,
+            -1L
         );
 
         // Invalid template configuration, wrong field name

--- a/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
@@ -123,7 +123,10 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             compatibilityVersions,
             Map.of("workflow", workflow),
             Collections.emptyMap(),
-            TestHelpers.randomUser()
+            TestHelpers.randomUser(),
+            -1L,
+            -1L,
+            -1L
         );
     }
 
@@ -185,7 +188,10 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0")),
             Map.of("workflow", workflow),
             Collections.emptyMap(),
-            TestHelpers.randomUser()
+            TestHelpers.randomUser(),
+            -1L,
+            -1L,
+            -1L
         );
 
         @SuppressWarnings("unchecked")
@@ -501,7 +507,10 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0")),
             Map.of("workflow", workflow),
             Collections.emptyMap(),
-            TestHelpers.randomUser()
+            TestHelpers.randomUser(),
+            -1L,
+            -1L,
+            -1L
         );
 
         return validTemplate;

--- a/src/test/java/org/opensearch/flowframework/transport/GetWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/GetWorkflowTransportActionTests.java
@@ -89,7 +89,10 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
             compatibilityVersions,
             Map.of("provision", workflow),
             Collections.emptyMap(),
-            TestHelpers.randomUser()
+            TestHelpers.randomUser(),
+            -1L,
+            -1L,
+            -1L
         );
 
         ThreadPool clientThreadPool = mock(ThreadPool.class);

--- a/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.transport;
 import org.opensearch.Version;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Client;
@@ -19,6 +20,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.TestHelpers;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
@@ -146,6 +148,12 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
             actionListener.onResponse(mock(UpdateResponse.class));
             return null;
         }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(any(), any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(new IndexResponse(new ShardId(GLOBAL_CONTEXT_INDEX, "", 1), "1", 1L, 1L, 1L, true));
+            return null;
+        }).when(flowFrameworkIndicesHandler).updateTemplateInGlobalContext(any(), any(Template.class), any());
 
         provisionWorkflowTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
         ArgumentCaptor<WorkflowResponse> responseCaptor = ArgumentCaptor.forClass(WorkflowResponse.class);

--- a/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
@@ -99,7 +99,10 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
             compatibilityVersions,
             Map.of("provision", workflow),
             Collections.emptyMap(),
-            TestHelpers.randomUser()
+            TestHelpers.randomUser(),
+            -1L,
+            -1L,
+            -1L
         );
 
         ThreadPool clientThreadPool = mock(ThreadPool.class);

--- a/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
@@ -46,6 +46,7 @@ import org.mockito.ArgumentCaptor;
 
 import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -153,7 +154,7 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
             ActionListener<IndexResponse> responseListener = invocation.getArgument(2);
             responseListener.onResponse(new IndexResponse(new ShardId(GLOBAL_CONTEXT_INDEX, "", 1), "1", 1L, 1L, 1L, true));
             return null;
-        }).when(flowFrameworkIndicesHandler).updateTemplateInGlobalContext(any(), any(Template.class), any());
+        }).when(flowFrameworkIndicesHandler).updateTemplateInGlobalContext(any(), any(Template.class), any(), anyBoolean());
 
         provisionWorkflowTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
         ArgumentCaptor<WorkflowResponse> responseCaptor = ArgumentCaptor.forClass(WorkflowResponse.class);

--- a/src/test/java/org/opensearch/flowframework/transport/WorkflowRequestResponseTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/WorkflowRequestResponseTests.java
@@ -52,7 +52,10 @@ public class WorkflowRequestResponseTests extends OpenSearchTestCase {
             compatibilityVersions,
             Map.of("workflow", workflow),
             Collections.emptyMap(),
-            TestHelpers.randomUser()
+            TestHelpers.randomUser(),
+            -1L,
+            -1L,
+            -1L
         );
     }
 
@@ -71,7 +74,7 @@ public class WorkflowRequestResponseTests extends OpenSearchTestCase {
         WorkflowRequest streamInputRequest = new WorkflowRequest(in);
 
         assertEquals(nullIdRequest.getWorkflowId(), streamInputRequest.getWorkflowId());
-        assertEquals(nullIdRequest.getTemplate().toJson(), streamInputRequest.getTemplate().toJson());
+        assertEquals(nullIdRequest.getTemplate().toString(), streamInputRequest.getTemplate().toString());
         assertNull(nullIdRequest.validate());
         assertFalse(nullIdRequest.isProvision());
         assertTrue(nullIdRequest.getParams().isEmpty());
@@ -113,7 +116,7 @@ public class WorkflowRequestResponseTests extends OpenSearchTestCase {
         WorkflowRequest streamInputRequest = new WorkflowRequest(in);
 
         assertEquals(workflowRequest.getWorkflowId(), streamInputRequest.getWorkflowId());
-        assertEquals(workflowRequest.getTemplate().toJson(), streamInputRequest.getTemplate().toJson());
+        assertEquals(workflowRequest.getTemplate().toString(), streamInputRequest.getTemplate().toString());
         assertNull(workflowRequest.validate());
         assertFalse(workflowRequest.isProvision());
         assertTrue(workflowRequest.getParams().isEmpty());
@@ -134,7 +137,7 @@ public class WorkflowRequestResponseTests extends OpenSearchTestCase {
         WorkflowRequest streamInputRequest = new WorkflowRequest(in);
 
         assertEquals(workflowRequest.getWorkflowId(), streamInputRequest.getWorkflowId());
-        assertEquals(workflowRequest.getTemplate().toJson(), streamInputRequest.getTemplate().toJson());
+        assertEquals(workflowRequest.getTemplate().toString(), streamInputRequest.getTemplate().toString());
         assertNull(workflowRequest.validate());
         assertTrue(workflowRequest.isProvision());
         assertEquals("bar", workflowRequest.getParams().get("foo"));

--- a/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
@@ -77,7 +77,10 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
             compatibilityVersions,
             Map.of("provision", workflow),
             Collections.emptyMap(),
-            TestHelpers.randomUser()
+            TestHelpers.randomUser(),
+            -1L,
+            -1L,
+            -1L
         );
 
         ClusterState clusterState = mock(ClusterState.class);

--- a/src/test/resources/template/noop.json
+++ b/src/test/resources/template/noop.json
@@ -1,0 +1,13 @@
+{
+    "name": "noop",
+    "workflows": {
+      "provision": {
+        "nodes": [
+          {
+            "id": "no-op",
+            "type": "noop"
+          }
+        ]
+      }
+    }
+}


### PR DESCRIPTION
### Description

Adds created time, last updated time, and last provisioned time to the template stored in the global context.
 - Updates the last updated time when updating a workflow
 - Updates the last provisioned time when provisoning a workflow

Also adds BWC tests!

Also fixes Integ tests which were essentially running twice since yamlRestTest was not properly filtered and was running them a second time.

### Issues Resolved

Fixes #548 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
