### PR TITLE
Enable Flow Framework by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 - Substitute REST path or body parameters in Workflow Steps ([#525](https://github.com/opensearch-project/flow-framework/pull/525))
 - Added an optional workflow_step param to the get workflow steps API ([#538](https://github.com/opensearch-project/flow-framework/pull/538))
+- Enable Flow Framework by default ([#553](https://github.com/opensearch-project/flow-framework/pull/553))
 
-### Enhancements
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/src/main/java/org/opensearch/flowframework/common/FlowFrameworkSettings.java
+++ b/src/main/java/org/opensearch/flowframework/common/FlowFrameworkSettings.java
@@ -62,7 +62,7 @@ public class FlowFrameworkSettings {
     /** This setting enables/disables the Flow Framework REST API */
     public static final Setting<Boolean> FLOW_FRAMEWORK_ENABLED = Setting.boolSetting(
         "plugins.flow_framework.enabled",
-        false,
+        true,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -76,19 +76,8 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
     @Before
     protected void setUpSettings() throws Exception {
 
-        // Enable Flow Framework Plugin Rest APIs
-        Response response = TestHelpers.makeRequest(
-            client(),
-            "PUT",
-            "_cluster/settings",
-            null,
-            "{\"transient\":{\"plugins.flow_framework.enabled\":true}}",
-            List.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
-        );
-        assertEquals(200, response.getStatusLine().getStatusCode());
-
         // Enable ML Commons to run on non-ml nodes
-        response = TestHelpers.makeRequest(
+        Response response = TestHelpers.makeRequest(
             client(),
             "PUT",
             "_cluster/settings",

--- a/src/test/java/org/opensearch/flowframework/common/FlowFrameworkSettingsTests.java
+++ b/src/test/java/org/opensearch/flowframework/common/FlowFrameworkSettingsTests.java
@@ -58,7 +58,7 @@ public class FlowFrameworkSettingsTests extends OpenSearchTestCase {
     }
 
     public void testSettings() throws IOException {
-        assertFalse(flowFrameworkSettings.isFlowFrameworkEnabled());
+        assertTrue(flowFrameworkSettings.isFlowFrameworkEnabled());
         assertEquals(Optional.of(TimeValue.timeValueSeconds(5)), Optional.ofNullable(flowFrameworkSettings.getRetryDuration()));
         assertEquals(Optional.of(50), Optional.ofNullable(flowFrameworkSettings.getMaxWorkflowSteps()));
         assertEquals(Optional.of(1000), Optional.ofNullable(flowFrameworkSettings.getMaxWorkflows()));


### PR DESCRIPTION
### Description

Flips the default setting of `plugins.flow_framework.enabled` to `true` for 2.13 GA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
