### PR TITLE
Fix bug passing params to workflows

### DIFF
--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -158,7 +158,8 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                                                 if (request.isProvision()) {
                                                     WorkflowRequest workflowRequest = new WorkflowRequest(
                                                         globalContextResponse.getId(),
-                                                        null
+                                                        null,
+                                                        request.getParams()
                                                     );
                                                     logger.info(
                                                         "Provisioning parameter is set, continuing to provision workflow {}",

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -123,8 +123,8 @@ public class WorkflowProcessSorter {
             ProcessNode processNode = new ProcessNode(
                 node.id(),
                 step,
-                params,
                 node.previousNodeInputs(),
+                params,
                 data,
                 predecessorNodes,
                 threadPool,


### PR DESCRIPTION
### Description

Fixes two bugs with parameter substitution:
 - Method arguments for previous node inputs and user params were swapped when executing workflows.  This wasn't obvious because of a "catch all" fallback when previous node inputs isn't included, that got them anyway
 - When provisioning via create workflow REST API, the new workflow request didn't pass along the params map

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
