### PR TITLE
Adding create search pipeline step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.12...2.x)
 ### Features
 - Adding create ingest pipeline step ([#558](https://github.com/opensearch-project/flow-framework/pull/558))
-- adding create search pipeline step ([#569](https://github.com/opensearch-project/flow-framework/pull/569))
+- Adding create search pipeline step ([#569](https://github.com/opensearch-project/flow-framework/pull/569))
 
 ### Enhancements
 - Substitute REST path or body parameters in Workflow Steps ([#525](https://github.com/opensearch-project/flow-framework/pull/525))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.12...2.x)
 ### Features
 - Adding create ingest pipeline step ([#558](https://github.com/opensearch-project/flow-framework/pull/558))
+- adding create search pipeline step ([#569](https://github.com/opensearch-project/flow-framework/pull/569))
 
 ### Enhancements
 - Substitute REST path or body parameters in Workflow Steps ([#525](https://github.com/opensearch-project/flow-framework/pull/525))

--- a/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
+++ b/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
@@ -15,6 +15,7 @@ import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.workflow.CreateConnectorStep;
 import org.opensearch.flowframework.workflow.CreateIndexStep;
 import org.opensearch.flowframework.workflow.CreateIngestPipelineStep;
+import org.opensearch.flowframework.workflow.CreateSearchPipelineStep;
 import org.opensearch.flowframework.workflow.DeleteAgentStep;
 import org.opensearch.flowframework.workflow.DeleteConnectorStep;
 import org.opensearch.flowframework.workflow.DeleteModelStep;
@@ -56,7 +57,9 @@ public enum WorkflowResources {
     /** Workflow steps for creating an index and associated created resource */
     CREATE_INDEX(CreateIndexStep.NAME, WorkflowResources.INDEX_NAME, null), // TODO delete step
     /** Workflow steps for registering/deleting an agent and the associated created resource */
-    REGISTER_AGENT(RegisterAgentStep.NAME, WorkflowResources.AGENT_ID, DeleteAgentStep.NAME);
+    REGISTER_AGENT(RegisterAgentStep.NAME, WorkflowResources.AGENT_ID, DeleteAgentStep.NAME),
+    /** Workflow steps for creating an ingest-pipeline and associated created resource */
+    CREATE_SEARCH_PIPELINE(CreateSearchPipelineStep.NAME, WorkflowResources.PIPELINE_ID, null); // TODO delete step
 
     /** Connector Id for a remote model connector */
     public static final String CONNECTOR_ID = "connector_id";

--- a/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
+++ b/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
@@ -54,12 +54,12 @@ public enum WorkflowResources {
     DEPLOY_MODEL(DeployModelStep.NAME, WorkflowResources.MODEL_ID, UndeployModelStep.NAME),
     /** Workflow steps for creating an ingest-pipeline and associated created resource */
     CREATE_INGEST_PIPELINE(CreateIngestPipelineStep.NAME, WorkflowResources.PIPELINE_ID, null), // TODO delete step
+    /** Workflow steps for creating an ingest-pipeline and associated created resource */
+    CREATE_SEARCH_PIPELINE(CreateSearchPipelineStep.NAME, WorkflowResources.PIPELINE_ID, null), // TODO delete step
     /** Workflow steps for creating an index and associated created resource */
     CREATE_INDEX(CreateIndexStep.NAME, WorkflowResources.INDEX_NAME, null), // TODO delete step
     /** Workflow steps for registering/deleting an agent and the associated created resource */
-    REGISTER_AGENT(RegisterAgentStep.NAME, WorkflowResources.AGENT_ID, DeleteAgentStep.NAME),
-    /** Workflow steps for creating an ingest-pipeline and associated created resource */
-    CREATE_SEARCH_PIPELINE(CreateSearchPipelineStep.NAME, WorkflowResources.PIPELINE_ID, null); // TODO delete step
+    REGISTER_AGENT(RegisterAgentStep.NAME, WorkflowResources.AGENT_ID, DeleteAgentStep.NAME);
 
     /** Connector Id for a remote model connector */
     public static final String CONNECTOR_ID = "connector_id";

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractCreatePipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractCreatePipelineStep.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.ingest.PutPipelineRequest;
+import org.opensearch.action.search.PutSearchPipelineRequest;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.client.Client;
+import org.opensearch.client.ClusterAdminClient;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.util.ParseUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.flowframework.common.CommonValue.CONFIGURATIONS;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.PIPELINE_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.getResourceByWorkflowStep;
+
+/**
+ * Step to create either a search or ingest pipeline
+ */
+public abstract class AbstractCreatePipelineStep implements WorkflowStep {
+    private static final Logger logger = LogManager.getLogger(AbstractCreatePipelineStep.class);
+
+    // Client to store a pipeline in the cluster state
+    private final ClusterAdminClient clusterAdminClient;
+
+    private final FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
+
+    /**
+     * Instantiates a new AbstractCreatePipelineStep
+     * @param client The client to create a pipeline and store workflow data into the global context index
+     * @param flowFrameworkIndicesHandler FlowFrameworkIndicesHandler class to update system indices
+     */
+    protected AbstractCreatePipelineStep(Client client, FlowFrameworkIndicesHandler flowFrameworkIndicesHandler) {
+        this.clusterAdminClient = client.admin().cluster();
+        this.flowFrameworkIndicesHandler = flowFrameworkIndicesHandler;
+    }
+
+    @Override
+    public PlainActionFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs,
+        Map<String, String> params
+    ) {
+
+        PlainActionFuture<WorkflowData> createPipelineFuture = PlainActionFuture.newFuture();
+
+        Set<String> requiredKeys = Set.of(PIPELINE_ID, CONFIGURATIONS);
+
+        // currently, we are supporting an optional param of model ID into the various processors
+        Set<String> optionalKeys = Set.of(MODEL_ID);
+
+        try {
+            Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
+                requiredKeys,
+                optionalKeys,
+                currentNodeInputs,
+                outputs,
+                previousNodeInputs,
+                params
+            );
+
+            String pipelineId = (String) inputs.get(PIPELINE_ID);
+            String configurations = (String) inputs.get(CONFIGURATIONS);
+
+            byte[] byteArr = configurations.getBytes(StandardCharsets.UTF_8);
+            BytesReference configurationsBytes = new BytesArray(byteArr);
+
+            String pipelineToBeCreated = this.getName();
+            ActionListener<AcknowledgedResponse> putPipelineActionListener = new ActionListener<>() {
+
+                @Override
+                public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                    String resourceName = getResourceByWorkflowStep(getName());
+                    try {
+                        flowFrameworkIndicesHandler.updateResourceInStateIndex(
+                            currentNodeInputs.getWorkflowId(),
+                            currentNodeId,
+                            getName(),
+                            pipelineId,
+                            ActionListener.wrap(updateResponse -> {
+                                logger.info("successfully updated resources created in state index: {}", updateResponse.getIndex());
+                                // PutPipelineRequest returns only an AcknowledgeResponse, saving pipelineId instead
+                                // TODO: revisit this concept of pipeline_id to be consistent with what makes most sense to end user here
+                                createPipelineFuture.onResponse(
+                                    new WorkflowData(
+                                        Map.of(resourceName, pipelineId),
+                                        currentNodeInputs.getWorkflowId(),
+                                        currentNodeInputs.getNodeId()
+                                    )
+                                );
+                            }, exception -> {
+                                String errorMessage = "Failed to update new created "
+                                    + currentNodeId
+                                    + " resource "
+                                    + getName()
+                                    + " id "
+                                    + pipelineId;
+                                logger.error(errorMessage, exception);
+                                createPipelineFuture.onFailure(
+                                    new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception))
+                                );
+                            })
+                        );
+
+                    } catch (Exception e) {
+                        String errorMessage = "Failed to parse and update new created resource";
+                        logger.error(errorMessage, e);
+                        createPipelineFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    String errorMessage = "Failed step " + pipelineToBeCreated;
+                    logger.error(errorMessage, e);
+                    createPipelineFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                }
+
+            };
+
+            if (pipelineToBeCreated.equals(CreateSearchPipelineStep.NAME)) {
+                PutSearchPipelineRequest putSearchPipelineRequest = new PutSearchPipelineRequest(
+                    pipelineId,
+                    configurationsBytes,
+                    XContentType.JSON
+                );
+                clusterAdminClient.putSearchPipeline(putSearchPipelineRequest, putPipelineActionListener);
+            } else {
+                PutPipelineRequest putPipelineRequest = new PutPipelineRequest(pipelineId, configurationsBytes, XContentType.JSON);
+                clusterAdminClient.putPipeline(putPipelineRequest, putPipelineActionListener);
+            }
+
+        } catch (FlowFrameworkException e) {
+            createPipelineFuture.onFailure(e);
+        }
+        return createPipelineFuture;
+
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateSearchPipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateSearchPipelineStep.java
@@ -14,20 +14,20 @@ import org.opensearch.client.Client;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 
 /**
- * Step to create an ingest pipeline
+ * Step to create a search pipeline
  */
-public class CreateIngestPipelineStep extends AbstractCreatePipelineStep {
-    private static final Logger logger = LogManager.getLogger(CreateIngestPipelineStep.class);
+public class CreateSearchPipelineStep extends AbstractCreatePipelineStep {
+    private static final Logger logger = LogManager.getLogger(CreateSearchPipelineStep.class);
 
     /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
-    public static final String NAME = "create_ingest_pipeline";
+    public static final String NAME = "create_search_pipeline";
 
     /**
-     * Instantiates a new CreateIngestPipelineStep
+     * Instantiates a new CreateSearchPipelineStep
      * @param client The client to create a pipeline and store workflow data into the global context index
      * @param flowFrameworkIndicesHandler FlowFrameworkIndicesHandler class to update system indices
      */
-    public CreateIngestPipelineStep(Client client, FlowFrameworkIndicesHandler flowFrameworkIndicesHandler) {
+    public CreateSearchPipelineStep(Client client, FlowFrameworkIndicesHandler flowFrameworkIndicesHandler) {
         super(client, flowFrameworkIndicesHandler);
     }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -108,6 +108,7 @@ public class WorkflowStepFactory {
         stepMap.put(RegisterAgentStep.NAME, () -> new RegisterAgentStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(DeleteAgentStep.NAME, () -> new DeleteAgentStep(mlClient));
         stepMap.put(CreateIngestPipelineStep.NAME, () -> new CreateIngestPipelineStep(client, flowFrameworkIndicesHandler));
+        stepMap.put(CreateSearchPipelineStep.NAME, () -> new CreateSearchPipelineStep(client, flowFrameworkIndicesHandler));
     }
 
     /**
@@ -207,6 +208,15 @@ public class WorkflowStepFactory {
         /** Create Ingest Pipeline Step */
         CREATE_INGEST_PIPELINE(
             CreateIngestPipelineStep.NAME,
+            List.of(PIPELINE_ID, CONFIGURATIONS),
+            List.of(PIPELINE_ID),
+            Collections.emptyList(),
+            null
+        ),
+
+        /** Create Ingest Pipeline Step */
+        CREATE_SEARCH_PIPELINE(
+            CreateSearchPipelineStep.NAME,
             List.of(PIPELINE_ID, CONFIGURATIONS),
             List.of(PIPELINE_ID),
             Collections.emptyList(),

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -214,7 +214,7 @@ public class WorkflowStepFactory {
             null
         ),
 
-        /** Create Ingest Pipeline Step */
+        /** Create Search Pipeline Step */
         CREATE_SEARCH_PIPELINE(
             CreateSearchPipelineStep.NAME,
             List.of(PIPELINE_ID, CONFIGURATIONS),

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowValidatorTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowValidatorTests.java
@@ -46,7 +46,7 @@ public class WorkflowValidatorTests extends OpenSearchTestCase {
 
         WorkflowValidator validator = new WorkflowValidator(workflowStepValidators);
 
-        assertEquals(15, validator.getWorkflowStepValidators().size());
+        assertEquals(16, validator.getWorkflowStepValidators().size());
 
         assertTrue(validator.getWorkflowStepValidators().keySet().contains("create_connector"));
         assertEquals(7, validator.getWorkflowStepValidators().get("create_connector").getInputs().size());

--- a/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
@@ -82,6 +82,12 @@ public class ParseUtilsTests extends OpenSearchTestCase {
         assertEquals(stringMap.get("one"), parsedMap.get("one"));
     }
 
+    public void testParseArbitraryStringToObjectMapToString() throws IOException {
+        Map<String, Object> map = Map.ofEntries(Map.entry("test-1", Map.of("test-1", "test-1")));
+        String parsedMap = ParseUtils.parseArbitraryStringToObjectMapToString(map);
+        assertEquals("{\"test-1\":{\"test-1\":\"test-1\"}}", parsedMap);
+    }
+
     public void testGetInputsFromPreviousSteps() {
         WorkflowData currentNodeInputs = new WorkflowData(
             Map.ofEntries(

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("deprecation")
 public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
 
     private WorkflowData inputData;

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateSearchPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateSearchPipelineStepTests.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("deprecation")
 public class CreateSearchPipelineStepTests extends OpenSearchTestCase {
 
     private WorkflowData inputData;

--- a/src/test/resources/template/ingest-search-pipeline-template.json
+++ b/src/test/resources/template/ingest-search-pipeline-template.json
@@ -81,6 +81,31 @@
               ]
             }
           }
+        },
+        {
+          "id": "create_search_pipeline",
+          "type": "create_search_pipeline",
+          "previous_node_inputs": {
+            "deploy_openai_model": "model_id"
+          },
+          "user_inputs": {
+            "pipeline_id": "rag_pipeline",
+            "configurations": {
+              "request_processors": [
+                {
+                  "filter_query" : {
+                    "tag" : "tag1",
+                    "description" : "This processor is going to restrict to publicly visible documents",
+                    "query" : {
+                      "term": {
+                        "visibility": "public"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
### Description
Added create search pipeline step by creating an abstract create pipeline step since both have same required in puts and almost exact same logic:

example:
```
{
                    "id": "create_search_pipeline",
                    "type": "create_search_pipeline",
                    "previous_node_inputs": {
                        "deploy_openai_model": "model_id"
                    },
                    "user_inputs": {
                        "pipeline_id": "rag_pipeline",
                        "configurations": {
                            "response_processors": [
                                {
                                    "retrieval_augmented_generation": {
                                        "tag": "openai_pipeline_demo",
                                        "description": "Demo pipeline Using OpenAI Connector",
                                        "model_id":"${{deploy_openai_model.model_id}}",
                                        "context_field_list": [
                                            "text"
                                        ],
                                        "system_prompt": "You are a helpful assistant",
                                        "user_instructions": "Generate a concise and informative answer in less than 100 words for the given question"
                                    }
                                }
                            ]
                        }
                    }
                }
   ```
### Issues Resolved
resolves #545 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
