### PR TITLE
Add skip-changelog label to version bump PRs

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -32,6 +32,7 @@
       ":gitSignOff",
       "github>whitesource/merge-confidence:beta"
     ],
+    "addLabels": ["skip-changelog"],
     "workflowRules": {
       "enabled": true
     }


### PR DESCRIPTION
### Description

Automatically appends the `skip-changelog` label to Mend Remediate version bump PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
