### PR TITLE
Adding new exception type for workflow step failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Added an optional workflow_step param to the get workflow steps API ([#538](https://github.com/opensearch-project/flow-framework/pull/538))
 - Add created, updated, and provisioned timestamps to saved template ([#551](https://github.com/opensearch-project/flow-framework/pull/551))
 - Enable Flow Framework by default ([#553](https://github.com/opensearch-project/flow-framework/pull/553))
+- Adding new exception type for workflow step failures ([#577](https://github.com/opensearch-project/flow-framework/pull/577))
 
 ### Bug Fixes
 ### Infrastructure

--- a/src/main/java/org/opensearch/flowframework/exception/WorkflowStepException.java
+++ b/src/main/java/org/opensearch/flowframework/exception/WorkflowStepException.java
@@ -15,14 +15,12 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * Representation of Flow Framework Exceptions
+ * Representation of an exception that is caused by a workflow step failing outside of our plugin
+ * This is caught by an external client (e.g. ml-client) returning the failure
  */
-public class FlowFrameworkException extends RuntimeException implements ToXContentObject {
+public class WorkflowStepException extends FlowFrameworkException implements ToXContentObject {
 
     private static final long serialVersionUID = 1L;
-
-    /** The rest status code of this exception */
-    protected final RestStatus restStatus;
 
     /**
      * Constructor with error message.
@@ -30,9 +28,8 @@ public class FlowFrameworkException extends RuntimeException implements ToXConte
      * @param message message of the exception
      * @param restStatus HTTP status code of the response
      */
-    public FlowFrameworkException(String message, RestStatus restStatus) {
-        super(message);
-        this.restStatus = restStatus;
+    public WorkflowStepException(String message, RestStatus restStatus) {
+        super(message, restStatus);
     }
 
     /**
@@ -40,9 +37,8 @@ public class FlowFrameworkException extends RuntimeException implements ToXConte
      * @param cause exception cause
      * @param restStatus HTTP status code of the response
      */
-    public FlowFrameworkException(Throwable cause, RestStatus restStatus) {
-        super(cause);
-        this.restStatus = restStatus;
+    public WorkflowStepException(Throwable cause, RestStatus restStatus) {
+        super(cause, restStatus);
     }
 
     /**
@@ -51,9 +47,8 @@ public class FlowFrameworkException extends RuntimeException implements ToXConte
      * @param cause exception cause
      * @param restStatus HTTP status code of the response
      */
-    public FlowFrameworkException(String message, Throwable cause, RestStatus restStatus) {
-        super(message, cause);
-        this.restStatus = restStatus;
+    public WorkflowStepException(String message, Throwable cause, RestStatus restStatus) {
+        super(message, cause, restStatus);
     }
 
     /**

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -20,7 +20,6 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.common.DefaultUseCases;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.transport.CreateWorkflowAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
@@ -181,14 +180,9 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.CREATED, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex;
-                    if (exception instanceof WorkflowStepException) {
-                        ex = (WorkflowStepException) exception;
-                    } else if (exception instanceof FlowFrameworkException) {
-                        ex = (FlowFrameworkException) exception;
-                    } else {
-                        ex = new FlowFrameworkException("Failed to create workflow.", ExceptionsHelper.status(exception));
-                    }
+                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
+                        ? (FlowFrameworkException) exception
+                        : new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -20,6 +20,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.common.DefaultUseCases;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.transport.CreateWorkflowAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
@@ -180,9 +181,14 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.CREATED, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
-                        ? (FlowFrameworkException) exception
-                        : new FlowFrameworkException("Failed to create workflow.", ExceptionsHelper.status(exception));
+                    FlowFrameworkException ex;
+                    if (exception instanceof WorkflowStepException) {
+                        ex = (WorkflowStepException) exception;
+                    } else if (exception instanceof FlowFrameworkException) {
+                        ex = (FlowFrameworkException) exception;
+                    } else {
+                        ex = new FlowFrameworkException("Failed to create workflow.", ExceptionsHelper.status(exception));
+                    }
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
@@ -18,7 +18,6 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.transport.DeleteWorkflowAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -85,14 +84,9 @@ public class RestDeleteWorkflowAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex;
-                    if (exception instanceof WorkflowStepException) {
-                        ex = (WorkflowStepException) exception;
-                    } else if (exception instanceof FlowFrameworkException) {
-                        ex = (FlowFrameworkException) exception;
-                    } else {
-                        ex = new FlowFrameworkException("Failed to delete workflow.", ExceptionsHelper.status(exception));
-                    }
+                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
+                        ? (FlowFrameworkException) exception
+                        : new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
@@ -18,6 +18,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.transport.DeleteWorkflowAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -84,9 +85,14 @@ public class RestDeleteWorkflowAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
-                        ? (FlowFrameworkException) exception
-                        : new FlowFrameworkException("Failed to delete workflow.", ExceptionsHelper.status(exception));
+                    FlowFrameworkException ex;
+                    if (exception instanceof WorkflowStepException) {
+                        ex = (WorkflowStepException) exception;
+                    } else if (exception instanceof FlowFrameworkException) {
+                        ex = (FlowFrameworkException) exception;
+                    } else {
+                        ex = new FlowFrameworkException("Failed to delete workflow.", ExceptionsHelper.status(exception));
+                    }
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
@@ -18,7 +18,6 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.transport.DeprovisionWorkflowAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -80,14 +79,9 @@ public class RestDeprovisionWorkflowAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex;
-                    if (exception instanceof WorkflowStepException) {
-                        ex = (WorkflowStepException) exception;
-                    } else if (exception instanceof FlowFrameworkException) {
-                        ex = (FlowFrameworkException) exception;
-                    } else {
-                        ex = new FlowFrameworkException("Failed to deprovision workflow.", ExceptionsHelper.status(exception));
-                    }
+                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
+                        ? (FlowFrameworkException) exception
+                        : new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
@@ -18,6 +18,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.transport.DeprovisionWorkflowAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -66,8 +67,7 @@ public class RestDeprovisionWorkflowAction extends BaseRestHandler {
             }
             // Validate content
             if (request.hasContent()) {
-                // BaseRestHandler will give appropriate error message
-                return channel -> channel.sendResponse(null);
+                throw new FlowFrameworkException("deprovision request should have no payload", RestStatus.BAD_REQUEST);
             }
             // Validate params
             if (workflowId == null) {
@@ -80,9 +80,14 @@ public class RestDeprovisionWorkflowAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
-                        ? (FlowFrameworkException) exception
-                        : new FlowFrameworkException("Failed to deprovision workflow.", ExceptionsHelper.status(exception));
+                    FlowFrameworkException ex;
+                    if (exception instanceof WorkflowStepException) {
+                        ex = (WorkflowStepException) exception;
+                    } else if (exception instanceof FlowFrameworkException) {
+                        ex = (FlowFrameworkException) exception;
+                    } else {
+                        ex = new FlowFrameworkException("Failed to deprovision workflow.", ExceptionsHelper.status(exception));
+                    }
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
@@ -18,7 +18,6 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.transport.GetWorkflowAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -86,14 +85,9 @@ public class RestGetWorkflowAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex;
-                    if (exception instanceof WorkflowStepException) {
-                        ex = (WorkflowStepException) exception;
-                    } else if (exception instanceof FlowFrameworkException) {
-                        ex = (FlowFrameworkException) exception;
-                    } else {
-                        ex = new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
-                    }
+                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
+                        ? (FlowFrameworkException) exception
+                        : new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
@@ -18,6 +18,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.transport.GetWorkflowAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -85,9 +86,14 @@ public class RestGetWorkflowAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
-                        ? (FlowFrameworkException) exception
-                        : new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
+                    FlowFrameworkException ex;
+                    if (exception instanceof WorkflowStepException) {
+                        ex = (WorkflowStepException) exception;
+                    } else if (exception instanceof FlowFrameworkException) {
+                        ex = (FlowFrameworkException) exception;
+                    } else {
+                        ex = new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
+                    }
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
@@ -18,7 +18,6 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.transport.GetWorkflowStateAction;
 import org.opensearch.flowframework.transport.GetWorkflowStateRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -83,14 +82,9 @@ public class RestGetWorkflowStateAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex;
-                    if (exception instanceof WorkflowStepException) {
-                        ex = (WorkflowStepException) exception;
-                    } else if (exception instanceof FlowFrameworkException) {
-                        ex = (FlowFrameworkException) exception;
-                    } else {
-                        ex = new FlowFrameworkException("Failed to get workflow state.", ExceptionsHelper.status(exception));
-                    }
+                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
+                        ? (FlowFrameworkException) exception
+                        : new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
@@ -18,7 +18,6 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.transport.GetWorkflowStepAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -82,14 +81,9 @@ public class RestGetWorkflowStepAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex;
-                    if (exception instanceof WorkflowStepException) {
-                        ex = (WorkflowStepException) exception;
-                    } else if (exception instanceof FlowFrameworkException) {
-                        ex = (FlowFrameworkException) exception;
-                    } else {
-                        ex = new FlowFrameworkException("Failed to get workflow step.", ExceptionsHelper.status(exception));
-                    }
+                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
+                        ? (FlowFrameworkException) exception
+                        : new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
@@ -18,6 +18,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.transport.GetWorkflowStepAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -81,9 +82,14 @@ public class RestGetWorkflowStepAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
-                        ? (FlowFrameworkException) exception
-                        : new FlowFrameworkException("Failed to get workflow step.", ExceptionsHelper.status(exception));
+                    FlowFrameworkException ex;
+                    if (exception instanceof WorkflowStepException) {
+                        ex = (WorkflowStepException) exception;
+                    } else if (exception instanceof FlowFrameworkException) {
+                        ex = (FlowFrameworkException) exception;
+                    } else {
+                        ex = new FlowFrameworkException("Failed to get workflow step.", ExceptionsHelper.status(exception));
+                    }
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestProvisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestProvisionWorkflowAction.java
@@ -19,7 +19,6 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
-import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.transport.ProvisionWorkflowAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -93,14 +92,9 @@ public class RestProvisionWorkflowAction extends BaseRestHandler {
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             }, exception -> {
                 try {
-                    FlowFrameworkException ex;
-                    if (exception instanceof WorkflowStepException) {
-                        ex = (WorkflowStepException) exception;
-                    } else if (exception instanceof FlowFrameworkException) {
-                        ex = (FlowFrameworkException) exception;
-                    } else {
-                        ex = new FlowFrameworkException("Failed to provision workflow.", ExceptionsHelper.status(exception));
-                    }
+                    FlowFrameworkException ex = exception instanceof FlowFrameworkException
+                        ? (FlowFrameworkException) exception
+                        : new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -256,10 +256,18 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                 }, exception -> { logger.error("Failed to update workflow state for workflow {}", workflowId, exception); })
             );
         } catch (Exception ex) {
+            RestStatus status;
+            if (ex instanceof FlowFrameworkException) {
+                status = ((FlowFrameworkException) ex).getRestStatus();
+            } else {
+                status = ExceptionsHelper.status(ex);
+            }
             logger.error("Provisioning failed for workflow {} during step {}.", workflowId, currentStepId, ex);
             String errorMessage = (ex.getCause() == null ? ex.getClass().getName() : ex.getCause().getClass().getName())
                 + " during step "
-                + currentStepId;
+                + currentStepId
+                + ", restStatus: "
+                + status.toString();
             flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(
                 workflowId,
                 Map.ofEntries(

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractCreatePipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractCreatePipelineStep.java
@@ -22,6 +22,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 
@@ -140,7 +141,7 @@ public abstract class AbstractCreatePipelineStep implements WorkflowStep {
                 public void onFailure(Exception e) {
                     String errorMessage = "Failed step " + pipelineToBeCreated;
                     logger.error(errorMessage, e);
-                    createPipelineFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                    createPipelineFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
                 }
 
             };

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
@@ -15,6 +15,7 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -214,7 +215,7 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
             }, exception -> {
                 String errorMessage = "Failed to register local model in step " + currentNodeId;
                 logger.error(errorMessage, exception);
-                registerLocalModelFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception)));
+                registerLocalModelFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(exception)));
             }));
         } catch (FlowFrameworkException e) {
             registerLocalModelFuture.onFailure(e);

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRetryableWorkflowStep.java
@@ -18,6 +18,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTask;
@@ -127,7 +128,7 @@ public abstract class AbstractRetryableWorkflowStep implements WorkflowStep {
                 }, exception -> {
                     String errorMessage = workflowStep + " failed";
                     logger.error(errorMessage, exception);
-                    mlTaskListener.onFailure(new FlowFrameworkException(errorMessage, RestStatus.BAD_REQUEST));
+                    mlTaskListener.onFailure(new WorkflowStepException(errorMessage, RestStatus.BAD_REQUEST));
                 }));
                 try {
                     Thread.sleep(this.retryDuration.getMillis());

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -15,6 +15,7 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -123,7 +124,7 @@ public class CreateConnectorStep implements WorkflowStep {
             public void onFailure(Exception e) {
                 String errorMessage = "Failed to create connector";
                 logger.error(errorMessage, e);
-                createConnectorFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                createConnectorFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
             }
         };
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
@@ -15,6 +15,7 @@ import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 
@@ -84,7 +85,7 @@ public class DeleteAgentStep implements WorkflowStep {
                 public void onFailure(Exception e) {
                     String errorMessage = "Failed to delete agent " + agentId;
                     logger.error(errorMessage, e);
-                    deleteAgentFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                    deleteAgentFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
                 }
             });
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
@@ -15,6 +15,7 @@ import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 
@@ -84,7 +85,7 @@ public class DeleteConnectorStep implements WorkflowStep {
                 public void onFailure(Exception e) {
                     String errorMessage = "Failed to delete connector " + connectorId;
                     logger.error(errorMessage, e);
-                    deleteConnectorFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                    deleteConnectorFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
                 }
             });
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
@@ -15,6 +15,7 @@ import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 
@@ -85,7 +86,7 @@ public class DeleteModelStep implements WorkflowStep {
                 public void onFailure(Exception e) {
                     String errorMessage = "Failed to delete model " + modelId;
                     logger.error(errorMessage, e);
-                    deleteModelFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                    deleteModelFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
                 }
             });
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
@@ -15,6 +15,7 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -117,7 +118,7 @@ public class DeployModelStep extends AbstractRetryableWorkflowStep {
                 public void onFailure(Exception e) {
                     String errorMessage = "Failed to deploy model " + modelId;
                     logger.error(errorMessage, e);
-                    deployModelFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                    deployModelFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
                 }
             });
         } catch (FlowFrameworkException e) {

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -15,6 +15,7 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.Nullable;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -135,7 +136,7 @@ public class RegisterAgentStep implements WorkflowStep {
             public void onFailure(Exception e) {
                 String errorMessage = "Failed to register the agent";
                 logger.error(errorMessage, e);
-                registerAgentModelFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                registerAgentModelFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
             }
         };
 

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterModelGroupStep.java
@@ -15,6 +15,7 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -118,7 +119,7 @@ public class RegisterModelGroupStep implements WorkflowStep {
             public void onFailure(Exception e) {
                 String errorMessage = "Failed to register model group";
                 logger.error(errorMessage, e);
-                registerModelGroupFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                registerModelGroupFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
             }
         };
 

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -15,6 +15,7 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -177,7 +178,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
                 public void onFailure(Exception e) {
                     String errorMessage = "Failed to register remote model";
                     logger.error(errorMessage, e);
-                    registerRemoteModelFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                    registerRemoteModelFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
                 }
             });
 

--- a/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
@@ -16,6 +16,7 @@ import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.transport.undeploy.MLUndeployModelsResponse;
@@ -98,7 +99,7 @@ public class UndeployModelStep implements WorkflowStep {
                 public void onFailure(Exception e) {
                     String errorMessage = "Failed to undeploy model " + modelId;
                     logger.error(errorMessage, e);
-                    undeployModelFuture.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                    undeployModelFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
                 }
             });
         } catch (FlowFrameworkException e) {

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -593,7 +593,21 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
         Map<String, Object> responseMap = entityAsMap(response);
         assertEquals(stateStatus.name(), (String) responseMap.get(CommonValue.STATE_FIELD));
         assertEquals(provisioningStatus.name(), (String) responseMap.get(CommonValue.PROVISIONING_PROGRESS_FIELD));
+    }
 
+    /**
+     * Helper method to invoke the Get Workflow status Rest Action and get the error field
+     * @param client the rest client
+     * @param workflowId the workflow ID to get the status
+     * @return the error string
+     * @throws Exception if the request fails
+     */
+    protected String getAndWorkflowStatusError(RestClient client, String workflowId) throws Exception {
+        Response response = getWorkflowStatus(client, workflowId, true);
+        assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
+
+        Map<String, Object> responseMap = entityAsMap(response);
+        return (String) responseMap.get(CommonValue.ERROR_FIELD);
     }
 
     /**

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -401,9 +401,6 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
 
     public void testDefaultCohereUseCase() throws Exception {
 
-        // Using a 3 step template to create a connector, register remote model and deploy model
-        Template template = TestHelpers.createTemplateFromFile("ingest-search-pipeline-template.json");
-
         // Hit Create Workflow API with original template
         Response response = createWorkflowWithUseCase(client(), "cohere-embedding_model_deploy");
         assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
@@ -438,6 +435,37 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
 
         // This template should create 5 resources, connector_id, registered model_id, deployed model_id and pipelineId
         assertEquals(3, resourcesCreated.size());
+    }
+
+    public void testDefaultSemanticSearchUseCaseWithFailureExpected() throws Exception {
+
+        // Hit Create Workflow API with original template
+        Response response = createWorkflowWithUseCase(client(), "semantic_search");
+        assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
+
+        Map<String, Object> responseMap = entityAsMap(response);
+        String workflowId = (String) responseMap.get(WORKFLOW_ID);
+        getAndAssertWorkflowStatus(client(), workflowId, State.NOT_STARTED, ProvisioningProgress.NOT_STARTED);
+
+        // Ensure Ml config index is initialized as creating a connector requires this, then hit Provision API and assert status
+        if (!indexExistsWithAdminClient(".plugins-ml-config")) {
+            assertBusy(() -> assertTrue(indexExistsWithAdminClient(".plugins-ml-config")), 40, TimeUnit.SECONDS);
+            response = provisionWorkflow(client(), workflowId);
+        } else {
+            response = provisionWorkflow(client(), workflowId);
+        }
+
+        // expecting a failure since there is no neural-search plugin in cluster to provide text-embedding processor
+        assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
+        getAndAssertWorkflowStatus(client(), workflowId, State.FAILED, ProvisioningProgress.FAILED);
+
+        String error = getAndWorkflowStatusError(client(), workflowId);
+        assertTrue(
+            error.contains(
+                "org.opensearch.flowframework.exception.WorkflowStepException during step create_ingest_pipeline, restStatus: BAD_REQUEST"
+            )
+        );
+
     }
 
 }


### PR DESCRIPTION
### Description
Adds a new exception type to differentiate between errors that are due to flow-framework's fault during provisioning vs errors that are due to the downstream plugin's faults.

Also fixed error handling on deprovision:
previously if we gave a payload to the deprovision request we got a 500 error of `Channel is already closed`

The two error types: 

```
"error": "org.opensearch.flowframework.exception.WorkflowStepException during step create_ingest_pipeline, restStatus: BAD_REQUEST"
"error": "org.opensearch.flowframework.exception.WorkflowStepException during step create_ingest_pipeline, restStatus: BAD_REQUEST"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
