### PR TITLE
Adding default use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Added create ingest pipeline step ([#558](https://github.com/opensearch-project/flow-framework/pull/558))
 - Added create search pipeline step ([#569](https://github.com/opensearch-project/flow-framework/pull/569))
 - Added create index step ([#574](https://github.com/opensearch-project/flow-framework/pull/574))
+- Added default use cases ([#583](https://github.com/opensearch-project/flow-framework/pull/583))
 
 ### Enhancements
 - Substitute REST path or body parameters in Workflow Steps ([#525](https://github.com/opensearch-project/flow-framework/pull/525))

--- a/build.gradle
+++ b/build.gradle
@@ -180,6 +180,7 @@ dependencies {
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
+
     secureIntegTestPluginArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
 
     configurations.all {

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -72,6 +72,8 @@ public class CommonValue {
     public static final String PROVISION_WORKFLOW = "provision";
     /** The field name for workflow steps. This field represents the name of the workflow steps to be fetched. */
     public static final String WORKFLOW_STEP = "workflow_step";
+    /** The param name for default use case, used by the create workflow API */
+    public static final String USE_CASE = "use_case";
 
     /*
      * Constants associated with plugin configuration

--- a/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
+++ b/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.common;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Enum encapsulating the different default use cases and templates we have stored
+ */
+public enum DefaultUseCases {
+
+    /** defaults file and substitution ready template for OpenAI embedding model */
+    OPEN_AI_EMBEDDING_MODEL_DEPLOY(
+        "open_ai_embedding_model_deploy",
+        "defaults/open-ai-embedding-defaults.json",
+        "substitutionTemplates/deploy-remote-model-template.json"
+    ),
+    /** defaults file and substitution ready template for cohere embedding model */
+    COHERE_EMBEDDING_MODEL_DEPLOY(
+        "cohere-embedding_model_deploy",
+        "defaults/cohere-embedding-defaults.json",
+        "substitutionTemplates/deploy-remote-model-template-extra-params.json"
+    ),
+    LOCAL_NEURAL_SPARSE_SEARCH(
+        "local_neural_sparse_search",
+        "defaults/local-sparse-search-defaults.json",
+        "substitutionTemplates/neural-sparse-local-template.json"
+    ),
+    /** defaults file and substitution ready template for cohere embedding model */ // TODO: not finalized
+    COHERE_EMBEDDING_MODEL_DEPLOY_SEMANTIC_SEARCH(
+        "cohere-embedding_model_deploy_semantic_search",
+        "defaults/cohere-embedding-defaults.json",
+        "substitutionTemplates/deploy-remote-model-template-v1.json"
+    );
+
+    private final String useCaseName;
+    private final String defaultsFile;
+    private final String substitutionReadyFile;
+    private static final Logger logger = LogManager.getLogger(DefaultUseCases.class);
+    private static final Set<String> allResources = Stream.of(values()).map(DefaultUseCases::getDefaultsFile).collect(Collectors.toSet());
+
+    DefaultUseCases(String useCaseName, String defaultsFile, String substitutionReadyFile) {
+        this.useCaseName = useCaseName;
+        this.defaultsFile = defaultsFile;
+        this.substitutionReadyFile = substitutionReadyFile;
+    }
+
+    /**
+     * Returns the useCaseName for the given enum Constant
+     * @return the useCaseName of this use case.
+     */
+    public String getUseCaseName() {
+        return useCaseName;
+    }
+
+    /**
+     * Returns the defaultsFile for the given enum Constant
+     * @return the defaultsFile of this for the given useCase.
+     */
+    public String getDefaultsFile() {
+        return defaultsFile;
+    }
+
+    /**
+     * Returns the substitutionReadyFile for the given enum Constant
+     * @return the substitutionReadyFile of the given useCase
+     */
+    public String getSubstitutionReadyFile() {
+        return substitutionReadyFile;
+    }
+
+    /**
+     * Gets the defaultsFile based on the given use case.
+     * @param useCaseName name of the given use case
+     * @return the deafultsFile for that usecase
+     * @throws FlowFrameworkException if the use case doesn't exist in enum
+     */
+    public static String getDefaultsFileByUseCaseName(String useCaseName) throws FlowFrameworkException {
+        if (useCaseName != null && !useCaseName.isEmpty()) {
+            for (DefaultUseCases mapping : values()) {
+                if (useCaseName.equals(mapping.getUseCaseName())) {
+                    return mapping.getDefaultsFile();
+                }
+            }
+        }
+        logger.error("Unable to find defaults file for use case: {}", useCaseName);
+        throw new FlowFrameworkException("Unable to find defaults file for use case: " + useCaseName, RestStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Gets the substitutionReadyFile based on the given use case
+     * @param useCaseName name of the given use case
+     * @return the substitutionReadyFile which has the template
+     * @throws FlowFrameworkException if the use case doesn't exist in enum
+     */
+    public static String getSubstitutionReadyFileByUseCaseName(String useCaseName) throws FlowFrameworkException {
+        if (useCaseName != null && !useCaseName.isEmpty()) {
+            for (DefaultUseCases mapping : values()) {
+                if (mapping.getUseCaseName().equals(useCaseName)) {
+                    return mapping.getSubstitutionReadyFile();
+                }
+            }
+        }
+        logger.error("Unable to find substitution ready file for use case: {}", useCaseName);
+        throw new FlowFrameworkException("Unable to find substitution ready file for use case: " + useCaseName, RestStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
+++ b/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
@@ -38,12 +38,6 @@ public enum DefaultUseCases {
         "local_neural_sparse_search",
         "defaults/local-sparse-search-defaults.json",
         "substitutionTemplates/neural-sparse-local-template.json"
-    ),
-    /** defaults file and substitution ready template for cohere embedding model */ // TODO: not finalized
-    COHERE_EMBEDDING_MODEL_DEPLOY_SEMANTIC_SEARCH(
-        "cohere-embedding_model_deploy_semantic_search",
-        "defaults/cohere-embedding-defaults.json",
-        "substitutionTemplates/deploy-remote-model-template-v1.json"
     );
 
     private final String useCaseName;

--- a/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
+++ b/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
@@ -13,10 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 /**
  * Enum encapsulating the different default use cases and templates we have stored
  */
@@ -45,7 +41,6 @@ public enum DefaultUseCases {
     private final String defaultsFile;
     private final String substitutionReadyFile;
     private static final Logger logger = LogManager.getLogger(DefaultUseCases.class);
-    private static final Set<String> allResources = Stream.of(values()).map(DefaultUseCases::getDefaultsFile).collect(Collectors.toSet());
 
     DefaultUseCases(String useCaseName, String defaultsFile, String substitutionReadyFile) {
         this.useCaseName = useCaseName;
@@ -85,9 +80,9 @@ public enum DefaultUseCases {
      */
     public static String getDefaultsFileByUseCaseName(String useCaseName) throws FlowFrameworkException {
         if (useCaseName != null && !useCaseName.isEmpty()) {
-            for (DefaultUseCases mapping : values()) {
-                if (useCaseName.equals(mapping.getUseCaseName())) {
-                    return mapping.getDefaultsFile();
+            for (DefaultUseCases usecase : values()) {
+                if (useCaseName.equals(usecase.getUseCaseName())) {
+                    return usecase.getDefaultsFile();
                 }
             }
         }
@@ -103,9 +98,9 @@ public enum DefaultUseCases {
      */
     public static String getSubstitutionReadyFileByUseCaseName(String useCaseName) throws FlowFrameworkException {
         if (useCaseName != null && !useCaseName.isEmpty()) {
-            for (DefaultUseCases mapping : values()) {
-                if (mapping.getUseCaseName().equals(useCaseName)) {
-                    return mapping.getSubstitutionReadyFile();
+            for (DefaultUseCases useCase : values()) {
+                if (useCase.getUseCaseName().equals(useCaseName)) {
+                    return useCase.getSubstitutionReadyFile();
                 }
             }
         }

--- a/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
+++ b/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
@@ -34,6 +34,7 @@ public enum DefaultUseCases {
         "defaults/cohere-embedding-defaults.json",
         "substitutionTemplates/deploy-remote-model-template-extra-params.json"
     ),
+    /** defaults file and substitution ready template for local neural sparse model and ingest pipeline*/
     LOCAL_NEURAL_SPARSE_SEARCH(
         "local_neural_sparse_search",
         "defaults/local-sparse-search-defaults.json",
@@ -79,7 +80,7 @@ public enum DefaultUseCases {
     /**
      * Gets the defaultsFile based on the given use case.
      * @param useCaseName name of the given use case
-     * @return the deafultsFile for that usecase
+     * @return the defaultsFile for that usecase
      * @throws FlowFrameworkException if the use case doesn't exist in enum
      */
     public static String getDefaultsFileByUseCaseName(String useCaseName) throws FlowFrameworkException {

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -120,6 +120,8 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
 
             Template template;
             Map<String, String> useCaseDefaultsMap = Collections.emptyMap();
+            XContentParser parser = request.contentParser();
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
             if (useCase != null) {
                 String json = ParseUtils.resourceToString("/" + DefaultUseCases.getSubstitutionReadyFileByUseCaseName(useCase));
                 String defaultsFilePath = DefaultUseCases.getDefaultsFileByUseCaseName(useCase);
@@ -127,8 +129,6 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
 
                 if (request.hasContent()) {
                     try {
-                        XContentParser parser = request.contentParser();
-                        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                         Map<String, String> userDefaults = ParseUtils.parseStringToStringMap(parser);
                         // updates the default params with anything user has given that matches
                         for (Map.Entry<String, String> userDefaultsEntry : userDefaults.entrySet()) {
@@ -151,8 +151,7 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                 template = Template.parse(parserTestJson);
 
             } else {
-                XContentParser parser = request.contentParser();
-                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+
                 template = Template.parse(parser);
             }
 

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -137,9 +137,10 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                             }
                         }
                     } catch (Exception ex) {
+                        RestStatus status = ex instanceof IOException ? RestStatus.BAD_REQUEST : ExceptionsHelper.status(ex);
                         String errorMessage = "failure parsing request body when a use case is given";
                         logger.error(errorMessage, ex);
-                        throw new FlowFrameworkException(errorMessage, ExceptionsHelper.status(ex));
+                        throw new FlowFrameworkException(errorMessage, status);
                     }
 
                 }

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -17,16 +17,19 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.flowframework.common.DefaultUseCases;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.transport.CreateWorkflowAction;
 import org.opensearch.flowframework.transport.WorkflowRequest;
+import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -35,6 +38,7 @@ import java.util.stream.Collectors;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW;
+import static org.opensearch.flowframework.common.CommonValue.USE_CASE;
 import static org.opensearch.flowframework.common.CommonValue.VALIDATION;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
@@ -78,6 +82,7 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
         String workflowId = request.param(WORKFLOW_ID);
         String[] validation = request.paramAsStringArray(VALIDATION, new String[] { "all" });
         boolean provision = request.paramAsBoolean(PROVISION_WORKFLOW, false);
+        String useCase = request.param(USE_CASE);
         // If provisioning, consume all other params and pass to provision transport action
         Map<String, String> params = provision
             ? request.params()
@@ -112,11 +117,54 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
             );
         }
         try {
-            XContentParser parser = request.contentParser();
-            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-            Template template = Template.parse(parser);
 
-            WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, template, validation, provision, params);
+            Template template;
+            Map<String, String> useCaseDefaultsMap = Collections.emptyMap();
+            if (useCase != null) {
+                String json = ParseUtils.resourceToString("/" + DefaultUseCases.getSubstitutionReadyFileByUseCaseName(useCase));
+                String defaultsFilePath = DefaultUseCases.getDefaultsFileByUseCaseName(useCase);
+                useCaseDefaultsMap = ParseUtils.parseJsonFileToStringToStringMap("/" + defaultsFilePath);
+
+                if (request.hasContent()) {
+                    try {
+                        XContentParser parser = request.contentParser();
+                        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                        Map<String, String> userDefaults = ParseUtils.parseStringToStringMap(parser);
+                        // updates the default params with anything user has given that matches
+                        for (Map.Entry<String, String> userDefaultsEntry : userDefaults.entrySet()) {
+                            if (useCaseDefaultsMap.containsKey(userDefaultsEntry.getKey())) {
+                                useCaseDefaultsMap.put(userDefaultsEntry.getKey(), userDefaultsEntry.getValue());
+                            }
+                        }
+                    } catch (Exception ex) {
+                        String errorMessage = "failure parsing request body when a use case is given";
+                        logger.error(errorMessage, ex);
+                        throw new FlowFrameworkException(errorMessage, ExceptionsHelper.status(ex));
+                    }
+
+                }
+
+                json = (String) ParseUtils.conditionallySubstitute(json, null, useCaseDefaultsMap);
+
+                XContentParser parserTestJson = ParseUtils.jsonToParser(json);
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parserTestJson.currentToken(), parserTestJson);
+                template = Template.parse(parserTestJson);
+
+            } else {
+                XContentParser parser = request.contentParser();
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                template = Template.parse(parser);
+            }
+
+            WorkflowRequest workflowRequest = new WorkflowRequest(
+                workflowId,
+                template,
+                validation,
+                provision,
+                params,
+                useCase,
+                useCaseDefaultsMap
+            );
 
             return channel -> client.execute(CreateWorkflowAction.INSTANCE, workflowRequest, ActionListener.wrap(response -> {
                 XContentBuilder builder = response.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS);
@@ -134,11 +182,14 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                     channel.sendResponse(new BytesRestResponse(ExceptionsHelper.status(e), errorMessage));
                 }
             }));
+
         } catch (FlowFrameworkException e) {
+            logger.error("failed to prepare rest request", e);
             return channel -> channel.sendResponse(
                 new BytesRestResponse(e.getRestStatus(), e.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS))
             );
-        } catch (IOException e) {
+        } catch (Exception e) {
+            logger.error("failed to prepare rest request", e);
             FlowFrameworkException ex = new FlowFrameworkException(
                 "IOException: template content invalid for specified Content-Type.",
                 RestStatus.BAD_REQUEST

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
@@ -79,6 +79,17 @@ public class WorkflowRequest extends ActionRequest {
     }
 
     /**
+     * Instantiates a new WorkflowRequest with params map, set validation to all, provisioning to true
+     * @param workflowId the documentId of the workflow
+     * @param template the use case template which describes the workflow
+     * @param useCase the default use case give by user
+     * @param defaultParams The parameters from the REST body when a use case is given
+     */
+    public WorkflowRequest(@Nullable String workflowId, @Nullable Template template, String useCase, Map<String, String> defaultParams) {
+        this(workflowId, template, new String[] { "all" }, false, Collections.emptyMap(), useCase, defaultParams);
+    }
+
+    /**
      * Instantiates a new WorkflowRequest
      * @param workflowId the documentId of the workflow
      * @param template the use case template which describes the workflow
@@ -167,8 +178,8 @@ public class WorkflowRequest extends ActionRequest {
     }
 
     /**
-     * Gets the params map
-     * @return the params map
+     * Gets the use case
+     * @return the use case
      */
     public String getUseCase() {
         return this.useCase;

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
@@ -50,12 +50,22 @@ public class WorkflowRequest extends ActionRequest {
     private Map<String, String> params;
 
     /**
+     * use case flag
+     */
+    private String useCase;
+
+    /**
+     * Deafult params map from use case
+     */
+    private Map<String, String> defaultParams;
+
+    /**
      * Instantiates a new WorkflowRequest, set validation to all, no provisioning
      * @param workflowId the documentId of the workflow
      * @param template the use case template which describes the workflow
      */
     public WorkflowRequest(@Nullable String workflowId, @Nullable Template template) {
-        this(workflowId, template, new String[] { "all" }, false, Collections.emptyMap());
+        this(workflowId, template, new String[] { "all" }, false, Collections.emptyMap(), null, Collections.emptyMap());
     }
 
     /**
@@ -65,7 +75,7 @@ public class WorkflowRequest extends ActionRequest {
      * @param params The parameters from the REST path
      */
     public WorkflowRequest(@Nullable String workflowId, @Nullable Template template, Map<String, String> params) {
-        this(workflowId, template, new String[] { "all" }, true, params);
+        this(workflowId, template, new String[] { "all" }, true, params, null, Collections.emptyMap());
     }
 
     /**
@@ -75,13 +85,17 @@ public class WorkflowRequest extends ActionRequest {
      * @param validation flag to indicate if validation is necessary
      * @param provision flag to indicate if provision is necessary
      * @param params map of REST path params. If provision is false, must be an empty map.
+     * @param useCase default use case given
+     * @param defaultParams the params to be used in the substitution based on the default use case.
      */
     public WorkflowRequest(
         @Nullable String workflowId,
         @Nullable Template template,
         String[] validation,
         boolean provision,
-        Map<String, String> params
+        Map<String, String> params,
+        String useCase,
+        Map<String, String> defaultParams
     ) {
         this.workflowId = workflowId;
         this.template = template;
@@ -91,6 +105,8 @@ public class WorkflowRequest extends ActionRequest {
             throw new IllegalArgumentException("Params may only be included when provisioning.");
         }
         this.params = params;
+        this.useCase = useCase;
+        this.defaultParams = defaultParams;
     }
 
     /**
@@ -148,6 +164,22 @@ public class WorkflowRequest extends ActionRequest {
      */
     public Map<String, String> getParams() {
         return Map.copyOf(this.params);
+    }
+
+    /**
+     * Gets the params map
+     * @return the params map
+     */
+    public String getUseCase() {
+        return this.useCase;
+    }
+
+    /**
+     * Gets the params map
+     * @return the params map
+     */
+    public Map<String, String> getDefaultParams() {
+        return Map.copyOf(this.defaultParams);
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
@@ -380,11 +380,7 @@ public class ParseUtils {
 
                     // Special handling for JSON strings that contain placeholders (connectors action)
                     replacement = Matcher.quoteReplacement(replacement.replace("\"", "\\\""));
-
-                    // Use Pattern.compile().matcher() to avoid issues with replaceAll's direct pattern compilation
-                    Pattern pattern = Pattern.compile(regex);
-                    Matcher matcher = pattern.matcher((String) value);
-                    value = matcher.replaceAll(replacement);
+                    value = ((String) value).replaceAll(regex, replacement);
                 }
             }
         }

--- a/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
@@ -109,8 +109,6 @@ public class ParseUtils {
     public static void buildStringToStringMap(XContentBuilder xContentBuilder, Map<?, ?> map) throws IOException {
         xContentBuilder.startObject();
         for (Entry<?, ?> e : map.entrySet()) {
-            String key = (String) e.getKey();
-            String value = (String) e.getValue();
             xContentBuilder.field((String) e.getKey(), (String) e.getValue());
         }
         xContentBuilder.endObject();

--- a/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
@@ -61,6 +61,8 @@ public class ParseUtils {
 
     private ParseUtils() {}
 
+    private static final ObjectMapper mapper = new ObjectMapper();
+
     /**
      * Converts a JSON string into an XContentParser
      *
@@ -373,17 +375,19 @@ public class ParseUtils {
             m.appendTail(result);
             value = result.toString();
 
-            for (Map.Entry<String, String> e : params.entrySet()) {
-                String regex = "\\$\\{\\{\\s*" + Pattern.quote(e.getKey()) + "\\s*\\}\\}";
-                String replacement = e.getValue();
+            if (params != null) {
+                for (Map.Entry<String, String> e : params.entrySet()) {
+                    String regex = "\\$\\{\\{\\s*" + Pattern.quote(e.getKey()) + "\\s*\\}\\}";
+                    String replacement = e.getValue();
 
-                // Special handling for JSON strings that contain placeholders (connectors action)
-                replacement = Matcher.quoteReplacement(replacement.replace("\"", "\\\""));
+                    // Special handling for JSON strings that contain placeholders (connectors action)
+                    replacement = Matcher.quoteReplacement(replacement.replace("\"", "\\\""));
 
-                // Use Pattern.compile().matcher() to avoid issues with replaceAll's direct pattern compilation
-                Pattern pattern = Pattern.compile(regex);
-                Matcher matcher = pattern.matcher((String) value);
-                value = matcher.replaceAll(replacement);
+                    // Use Pattern.compile().matcher() to avoid issues with replaceAll's direct pattern compilation
+                    Pattern pattern = Pattern.compile(regex);
+                    Matcher matcher = pattern.matcher((String) value);
+                    value = matcher.replaceAll(replacement);
+                }
             }
         }
         return value;
@@ -396,7 +400,6 @@ public class ParseUtils {
      * @throws JsonProcessingException JsonProcessingException from Jackson for issues processing map
      */
     public static String parseArbitraryStringToObjectMapToString(Map<String, Object> map) throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
         // Convert the map to a JSON string
         String mappedString = mapper.writeValueAsString(map);
         return mappedString;
@@ -409,7 +412,6 @@ public class ParseUtils {
      * @throws JsonProcessingException JsonProcessingException from Jackson for issues processing map
      */
     public static Map<String, String> parseJsonFileToStringToStringMap(String path) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         String jsonContent = resourceToString(path);
         Map<String, String> mappedJsonFile = mapper.readValue(jsonContent, Map.class);
         return mappedJsonFile;

--- a/src/main/resources/defaults/cohere-embedding-defaults.json
+++ b/src/main/resources/defaults/cohere-embedding-defaults.json
@@ -1,0 +1,18 @@
+{
+    "template.name": "deploy-cohere-model",
+    "template.description": "deploying cohere embedding model",
+    "create_connector.name": "cohere-embedding-connector",
+    "create_connector.description": "The connector to Cohere's public embed API",
+    "create_connector.protocol": "http",
+    "create_connector.model": "embed-english-v3.0",
+    "create_connector.input_type": "search_document",
+    "create_connector.truncate": "end",
+    "create_connector.endpoint": "api.openai.com",
+    "create_connector.credential.key": "123",
+    "create_connector.actions.url": "https://api.cohere.ai/v1/embed",
+    "create_connector.actions.request_body": "{ \"texts\": ${parameters.texts}, \"truncate\": \"${parameters.truncate}\", \"model\": \"${parameters.model}\", \"input_type\": \"${parameters.input_type}\" }",
+    "create_connector.actions.pre_process_function": "connector.pre_process.cohere.embedding",
+    "create_connector.actions.post_process_function": "connector.post_process.cohere.embedding",
+    "register_remote_model.name": "Cohere english embed model",
+    "register_remote_model.description": "cohere-embedding-model"
+}

--- a/src/main/resources/defaults/local-sparse-search-defaults.json
+++ b/src/main/resources/defaults/local-sparse-search-defaults.json
@@ -1,0 +1,17 @@
+{
+    "template.name": "local-model-neural-sparse-search",
+    "template.description": "setting up neural sparse search with local model",
+    "register_local_sparse_encoding_model.name": "neural-sparse/opensearch-neural-sparse-tokenizer-v1-v2",
+    "register_local_sparse_encoding_model.description": "This is a neural sparse tokenizer model: It tokenize input sentence into tokens and assign pre-defined weight from IDF to each. It serves only in query.",
+    "register_local_sparse_encoding_model.node_timeout": "60s",
+    "register_local_sparse_encoding_model.model_format": "TORCH_SCRIPT",
+    "register_local_sparse_encoding_model.function_name": "SPARSE_TOKENIZE",
+    "register_local_sparse_encoding_model.model_content_hash_value": "b3487da9c58ac90541b720f3b367084f271d280c7f3bdc3e6d9c9a269fb31950",
+    "register_local_sparse_encoding_model.url": "https://artifacts.opensearch.org/models/ml-models/amazon/neural-sparse/opensearch-neural-sparse-tokenizer-v1/1.0.0/torch_script/opensearch-neural-sparse-tokenizer-v1-1.0.0.zip",
+    "register_local_sparse_encoding_model.deploy": "true",
+    "create_ingest_pipeline.pipeline_id": "nlp-ingest-pipeline-sparse",
+    "create_ingest_pipeline.description": "A sparse encoding ingest pipeline",
+    "create_ingest_pipeline.text_embedding.field_map.input": "passage_text",
+    "create_ingest_pipeline.text_embedding.field_map.output": "passage_embedding",
+    "create_index.name": "my-nlp-index"
+}

--- a/src/main/resources/defaults/open-ai-embedding-defaults.json
+++ b/src/main/resources/defaults/open-ai-embedding-defaults.json
@@ -1,0 +1,18 @@
+{
+    "open_ai_embedding_deploy": {
+      "template.name": "deploy-openai-model",
+      "template.description": "deploying openAI embedding model",
+      "create_connector.name": "OpenAI-embedding-connector",
+      "create_connector.description": "Connector to public OpenAI model",
+      "create_connector.protocol": "http",
+      "create_connector.model": "text-embedding-ada-002",
+      "create_connector.endpoint": "api.openai.com",
+      "create_connector.credential.key": "123",
+      "create_connector.actions.url": "https://api.openai.com/v1/embeddings",
+      "create_connector.actions.request_body": "{ \"input\": ${parameters.input}, \"model\": \"${parameters.model}\" }",
+      "create_connector.actions.pre_process_function": "connector.pre_process.openai.embedding",
+      "create_connector.actions.post_process_function": "connector.post_process.openai.embedding",
+      "register_remote_model_1.name": "OpenAI embedding model",
+      "register_remote_model_1.description": "openai-embedding-model"
+    }
+}

--- a/src/main/resources/mappings/deploy-remote-model-template-draft.json
+++ b/src/main/resources/mappings/deploy-remote-model-template-draft.json
@@ -1,0 +1,77 @@
+{
+  "name": "{template.name}",
+  "description": "{template.description}",
+  "use_case": "DEPLOY_MODEL",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": [
+      "2.12.0",
+      "3.0.0"
+    ]
+  },
+  "workflows": {
+    "provision": {
+      "nodes": [
+        {
+          "id": "create_connector",
+          "type": "create_connector",
+          "user_inputs": {
+            "name": "${{create_connector_1}}",
+            "description": "${{create_connector_1.description}}",
+            "version": "1",
+            "protocol": "${{create_connector_1.protocol}}",
+            "parameters": {
+              "endpoint": "${{create_connector_1.endpoint}}",
+              "model": "${{create_connector_1.model}}"
+            },
+            "credential": {
+              "key": "${{create_connector_1.credential.key}}",
+            },
+            "actions": [
+              {
+                "action_type": "predict",
+                "method": "POST",
+                "url": "https://api.openai.com/v1/embeddings",
+                "headers": {
+                  "Authorization": "Bearer ${credential.openAI_key}"
+                },
+                "request_body": "{ \"input\": ${parameters.input}, \"model\": \"${parameters.model}\" }",
+                "pre_process_function": "connector.pre_process.openai.embedding",
+                "post_process_function": "connector.post_process.openai.embedding"
+              }
+            ]
+          }
+        },
+        {
+          "id": "register_model",
+          "type": "register_remote_model",
+          "previous_node_inputs": {
+            "create_connector_step_1": "parameters"
+          },
+          "user_inputs": {
+            "name": "${register_remote_model.name}",
+            "function_name": "remote",
+            "description": "${register_remote_model.description}"
+          }
+        },
+        {
+          "id": "deploy_model",
+          "type": "deploy_model",
+          "previous_node_inputs": {
+            "register_model_1": "model_id"
+          }
+        }
+      ],
+      "edges": [
+        {
+          "source": "create_connector",
+          "dest": "register_model"
+        },
+        {
+          "source": "register_model",
+          "dest": "deploy_model"
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/mappings/open-ai-defaults.json
+++ b/src/main/resources/mappings/open-ai-defaults.json
@@ -1,0 +1,36 @@
+{
+  "deploy-remote-model-defaults": [
+    {
+      "openai_embedding_deploy": {
+        "template.name": "deploy-openai-model",
+        "template.description": "deploying openAI embedding model",
+        "create_connector_1.name": "OpenAI-embedding-connector",
+        "create_connector_1.description": "Connector to public AI model service for GPT 3.5",
+        "create_connector_1.protocol": "http",
+        "create_connector_1.model": "gpt-3.5-turbo",
+        "create_connector_1.endpoint": "api.openai.com",
+        "create_connector_1.credential.key": "123",
+        "create_connector_1.request_body": "{ \"input\": ${parameters.input}, \"model\": \"${parameters.model}\" }",
+        "create_connector_1.pre_process_function": "connector.pre_process.openai.embedding",
+        "create_connector_1.post_process_function": "connector.post_process.openai.embedding",
+        "register_remote_model_1.name": "test-description"
+      }
+    },
+    {
+      "cohere_embedding_deploy": {
+        "template.name": "deploy-cohere-embedding-model",
+        "template.description": "deploying cohere embedding model",
+        "create_connector_1.name": "cohere-embedding-connector",
+        "create_connector_1.description": "Connector to public AI model service for GPT 3.5",
+        "create_connector_1.protocol": "http",
+        "create_connector_1.model": "gpt-3.5-turbo",
+        "create_connector_1.endpoint": "api.openai.com",
+        "create_connector_1.credential.key": "123",
+        "create_connector_1.request_body": "{ \"input\": ${parameters.input}, \"model\": \"${parameters.model}\" }",
+        "create_connector_1.pre_process_function": "connector.pre_process.openai.embedding",
+        "create_connector_1.post_process_function": "connector.post_process.openai.embedding",
+        "register_remote_model_1.name": "test-description"
+      }
+    }
+  ]
+}

--- a/src/main/resources/substitutionTemplates/deploy-model-semantic-search-template-v1.json
+++ b/src/main/resources/substitutionTemplates/deploy-model-semantic-search-template-v1.json
@@ -1,0 +1,124 @@
+{
+  "name": "${{template.name}}",
+  "description": "${{template.description}}",
+  "use_case": "DEPLOY_MODEL",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": [
+      "2.12.0",
+      "3.0.0"
+    ]
+  },
+  "workflows": {
+    "provision": {
+      "nodes": [
+        {
+          "id": "create_connector",
+          "type": "create_connector",
+          "user_inputs": {
+            "name": "${{create_connector_1}}",
+            "description": "${{create_connector_1.description}}",
+            "version": "1",
+            "protocol": "${{create_connector_1.protocol}}",
+            "parameters": {
+              "endpoint": "${{create_connector_1.endpoint}}",
+              "model": "${{create_connector_1.model}}",
+              "input_type": "search_document",
+              "truncate": "END"
+            },
+            "credential": {
+              "key": "${{create_connector_1.credential.key}}"
+            },
+            "actions": [
+              {
+                "action_type": "predict",
+                "method": "POST",
+                "url": "${{create_connector.actions.url}}",
+                "headers": {
+                  "Authorization": "Bearer ${credential.key}",
+                  "Request-Source": "unspecified:opensearch"
+                },
+                "request_body": "${{create_connector.actions.request_body}}",
+                "pre_process_function": "${{create_connector.actions.pre_process_function}}",
+                "post_process_function": "${{create_connector.actions.post_process_function}}"
+              }
+            ]
+          }
+        },
+        {
+          "id": "register_model",
+          "type": "register_remote_model",
+          "previous_node_inputs": {
+            "create_connector_step_1": "parameters"
+          },
+          "user_inputs": {
+            "name": "${register_remote_model.name}",
+            "function_name": "remote",
+            "description": "${register_remote_model.description}"
+          }
+        },
+        {
+          "id": "deploy_model",
+          "type": "deploy_model",
+          "previous_node_inputs": {
+            "register_model_1": "model_id"
+          }
+        },
+        {
+          "id": "create_ingest_pipeline",
+          "type": "create_ingest_pipeline",
+          "previous_node_inputs": {
+            "deploy_openai_model": "model_id"
+          },
+          "user_inputs": {
+            "pipeline_id": "${{create_ingest_pipeline.pipeline_id}}",
+            "configurations": {
+              "description": "${{create_ingest_pipeline.description}}",
+              "processors": [
+                {
+                  "text_embedding": {
+                    "model_id": "${{deploy_openai_model.model_id}}",
+                    "field_map": {
+                      "${{text_embedding.field_map.input}}": "${{text_embedding.field_map.input}}"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "id": "create_index",
+          "type": "create_index",
+          "previous_node_inputs": {
+            "create_ingest_pipeline": "pipeline_id"
+          },
+          "user_inputs": {
+            "index_name": "${{create_index.name}}",
+            "configurations": {
+              "settings": {
+                "index": {
+                  "number_of_shards": 2,
+                  "number_of_replicas": 1,
+                  "search.default_pipeline" : "${{create_ingest_pipeline.pipeline_id}}"
+                }
+              },
+              "mappings": {
+                "_doc": {
+                  "properties": {
+                    "age": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "aliases": {
+                "sample-alias1": {}
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/substitutionTemplates/deploy-remote-model-template-extra-params.json
+++ b/src/main/resources/substitutionTemplates/deploy-remote-model-template-extra-params.json
@@ -1,0 +1,80 @@
+{
+  "name": "${{template.name}}",
+  "description": "${{template.description}}",
+  "use_case": "",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": [
+      "2.12.0",
+      "3.0.0"
+    ]
+  },
+  "workflows": {
+    "provision": {
+      "nodes": [
+        {
+          "id": "create_connector",
+          "type": "create_connector",
+          "user_inputs": {
+            "name": "${{create_connector.name}}",
+            "description": "${{create_connector.description}}",
+            "version": "1",
+            "protocol": "${{create_connector.protocol}}",
+            "parameters": {
+              "endpoint": "${{create_connector.endpoint}}",
+              "model": "${{create_connector.model}}",
+              "input_type": "search_document",
+              "truncate": "END"
+            },
+            "credential": {
+              "key": "${{create_connector.credential.key}}"
+            },
+            "actions": [
+              {
+                "action_type": "predict",
+                "method": "POST",
+                "url": "${{create_connector.actions.url}}",
+                "headers": {
+                  "Authorization": "Bearer ${credential.key}",
+                  "Request-Source": "unspecified:opensearch"
+                },
+                "request_body": "${{create_connector.actions.request_body}}",
+                "pre_process_function": "${{create_connector.actions.pre_process_function}}",
+                "post_process_function": "${{create_connector.actions.post_process_function}}"
+              }
+            ]
+          }
+        },
+        {
+          "id": "register_model",
+          "type": "register_remote_model",
+          "previous_node_inputs": {
+            "create_connector": "parameters"
+          },
+          "user_inputs": {
+            "name": "${{register_remote_model.name}}",
+            "function_name": "remote",
+            "description": "${{register_remote_model.description}}"
+          }
+        },
+        {
+          "id": "deploy_model",
+          "type": "deploy_model",
+          "previous_node_inputs": {
+            "register_model": "model_id"
+          }
+        }
+      ],
+      "edges": [
+        {
+          "source": "create_connector",
+          "dest": "register_model"
+        },
+        {
+          "source": "register_model",
+          "dest": "deploy_model"
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/substitutionTemplates/deploy-remote-model-template.json
+++ b/src/main/resources/substitutionTemplates/deploy-remote-model-template.json
@@ -1,0 +1,77 @@
+{
+  "name": "${{template.name}}",
+  "description": "${{template.description}}",
+  "use_case": "",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": [
+      "2.12.0",
+      "3.0.0"
+    ]
+  },
+  "workflows": {
+    "provision": {
+      "nodes": [
+        {
+          "id": "create_connector",
+          "type": "create_connector",
+          "user_inputs": {
+            "name": "${{create_connector}}",
+            "description": "${{create_connector.description}}",
+            "version": "1",
+            "protocol": "${{create_connector.protocol}}",
+            "parameters": {
+              "endpoint": "${{create_connector.endpoint}}",
+              "model": "${{create_connector.model}}"
+            },
+            "credential": {
+              "key": "${{create_connector.credential.key}}"
+            },
+            "actions": [
+              {
+                "action_type": "predict",
+                "method": "POST",
+                "url": "${{create_connector.actions.url}}",
+                "headers": {
+                  "Authorization": "Bearer ${credential.key}"
+                },
+                "request_body": "${{create_connector.actions.request_body}}",
+                "pre_process_function": "${{create_connector.actions.pre_process_function}}",
+                "post_process_function": "${{create_connector.actions.post_process_function}}"
+              }
+            ]
+          }
+        },
+        {
+          "id": "register_model",
+          "type": "register_remote_model",
+          "previous_node_inputs": {
+            "create_connector_step_1": "parameters"
+          },
+          "user_inputs": {
+            "name": "${{register_remote_model.name}}",
+            "function_name": "remote",
+            "description": "${{register_remote_model.description}}"
+          }
+        },
+        {
+          "id": "deploy_model",
+          "type": "deploy_model",
+          "previous_node_inputs": {
+            "register_model_1": "model_id"
+          }
+        }
+      ],
+      "edges": [
+        {
+          "source": "create_connector",
+          "dest": "register_model"
+        },
+        {
+          "source": "register_model",
+          "dest": "deploy_model"
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/substitutionTemplates/neural-sparse-local-template.json
+++ b/src/main/resources/substitutionTemplates/neural-sparse-local-template.json
@@ -1,0 +1,86 @@
+{
+  "name": "${{template.name}}",
+  "description": "${{template.description}}",
+  "use_case": "",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": [
+      "2.12.0",
+      "3.0.0"
+    ]
+  },
+  "workflows": {
+    "provision": {
+      "nodes": [
+        {
+          "id": "register_local_sparse_encoding_model",
+          "type": "register_local_sparse_encoding_model",
+          "user_inputs": {
+            "node_timeout": "60s",
+            "name": "neural-sparse/opensearch-neural-sparse-tokenizer-v1-v2",
+            "version": "1.0.0",
+            "description": "This is a neural sparse tokenizer model: It tokenize input sentence into tokens and assign pre-defined weight from IDF to each. It serves only in query.",
+            "model_format": "TORCH_SCRIPT",
+            "function_name": "SPARSE_TOKENIZE",
+            "model_content_hash_value": "b3487da9c58ac90541b720f3b367084f271d280c7f3bdc3e6d9c9a269fb31950",
+            "url": "https://artifacts.opensearch.org/models/ml-models/amazon/neural-sparse/opensearch-neural-sparse-tokenizer-v1/1.0.0/torch_script/opensearch-neural-sparse-tokenizer-v1-1.0.0.zip",
+            "deploy": true
+          }
+        },
+        {
+          "id": "create_ingest_pipeline",
+          "type": "create_ingest_pipeline",
+          "previous_node_inputs": {
+            "register_local_sparse_encoding_model": "model_id"
+          },
+          "user_inputs": {
+            "pipeline_id": "${{create_ingest_pipeline.pipeline_id}}",
+            "configurations": {
+              "description": "${{create_ingest_pipeline.description}}",
+              "processors": [
+                {
+                  "sparse_encoding": {
+                    "model_id": "${{register_local_sparse_encoding_model.model_id}}",
+                    "field_map": {
+                      "${{create_ingest_pipeline.text_embedding.field_map.input}}": "${{create_ingest_pipeline.text_embedding.field_map.output}}"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "id": "create_index",
+          "type": "create_index",
+          "previous_node_inputs": {
+            "create_ingest_pipeline": "pipeline_id"
+          },
+          "user_inputs": {
+            "index_name": "${{create_index.name}}",
+            "configurations": {
+              "settings": {
+                "default_pipeline": "${{create_ingest_pipeline.pipeline_id}}"
+              },
+              "mappings": {
+                "_doc": {
+                  "properties": {
+                    "id": {
+                      "type": "text"
+                    },
+                    "${{create_ingest_pipeline.text_embedding.field_map.output}}": {
+                      "type": "rank_features"
+                    },
+                    "${{create_ingest_pipeline.text_embedding.field_map.input}}": {
+                      "type": "text"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -340,6 +340,24 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
     }
 
     /**
+     * Helper method to invoke the Create Workflow Rest Action without validation
+     * @param client the rest client
+     * @param useCase the usecase to create
+     * @throws Exception if the request fails
+     * @return a rest response
+     */
+    protected Response createWorkflowWithUseCase(RestClient client, String useCase) throws Exception {
+        return TestHelpers.makeRequest(
+            client,
+            "POST",
+            WORKFLOW_URI + "?validation=off&use_case=" + useCase,
+            Collections.emptyMap(),
+            "{}",
+            null
+        );
+    }
+
+    /**
      * Helper method to invoke the Create Workflow Rest Action with provision
      * @param client the rest client
      * @param template the template to create

--- a/src/test/java/org/opensearch/flowframework/common/DefaultUseCasesTests.java
+++ b/src/test/java/org/opensearch/flowframework/common/DefaultUseCasesTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.common;
+
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class DefaultUseCasesTests extends OpenSearchTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testGetDefaultsFileByValidUseCaseName() throws FlowFrameworkException {
+        String defaultsFile = DefaultUseCases.getDefaultsFileByUseCaseName("open_ai_embedding_model_deploy");
+        assertEquals("defaults/open-ai-embedding-defaults.json", defaultsFile);
+    }
+
+    public void testGetDefaultsFileByInvalidUseCaseName() throws FlowFrameworkException {
+        FlowFrameworkException e = assertThrows(
+            FlowFrameworkException.class,
+            () -> DefaultUseCases.getDefaultsFileByUseCaseName("invalid_use_case")
+        );
+    }
+
+    public void testGetSubstitutionTemplateByValidUseCaseName() throws FlowFrameworkException {
+        String templateFile = DefaultUseCases.getSubstitutionReadyFileByUseCaseName("open_ai_embedding_model_deploy");
+        assertEquals("substitutionTemplates/deploy-remote-model-template.json", templateFile);
+    }
+
+    public void testGetSubstitutionTemplateByInvalidUseCaseName() throws FlowFrameworkException {
+        FlowFrameworkException e = assertThrows(
+            FlowFrameworkException.class,
+            () -> DefaultUseCases.getSubstitutionReadyFileByUseCaseName("invalid_use_case")
+        );
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
@@ -211,7 +211,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
 
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap());
+        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap(), null, Collections.emptyMap());
 
         doAnswer(invocation -> {
             ActionListener<SearchResponse> searchListener = invocation.getArgument(1);
@@ -248,7 +248,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
     public void testFailedToCreateNewWorkflow() {
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap());
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            null,
+            template,
+            new String[] { "off" },
+            false,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap()
+        );
 
         // Bypass checkMaxWorkflows and force onResponse
         doAnswer(invocation -> {
@@ -279,7 +287,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
     public void testCreateNewWorkflow() {
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap());
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            null,
+            template,
+            new String[] { "off" },
+            false,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap()
+        );
 
         // Bypass checkMaxWorkflows and force onResponse
         doAnswer(invocation -> {
@@ -410,7 +426,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
 
         doNothing().when(workflowProcessSorter).validate(any(), any());
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, validTemplate, new String[] { "all" }, true, Collections.emptyMap());
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            null,
+            validTemplate,
+            new String[] { "all" },
+            true,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap()
+        );
 
         // Bypass checkMaxWorkflows and force onResponse
         doAnswer(invocation -> {
@@ -463,7 +487,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
         doNothing().when(workflowProcessSorter).validate(any(), any());
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, validTemplate, new String[] { "all" }, true, Collections.emptyMap());
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            null,
+            validTemplate,
+            new String[] { "all" },
+            true,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap()
+        );
 
         // Bypass checkMaxWorkflows and force onResponse
         doAnswer(invocation -> {

--- a/src/test/java/org/opensearch/flowframework/transport/WorkflowRequestResponseTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/WorkflowRequestResponseTests.java
@@ -143,6 +143,51 @@ public class WorkflowRequestResponseTests extends OpenSearchTestCase {
         assertEquals("bar", workflowRequest.getParams().get("foo"));
     }
 
+    public void testWorkflowRequestWithUseCase() throws IOException {
+        WorkflowRequest workflowRequest = new WorkflowRequest("123", template, "cohere-embedding_model_deploy", Collections.emptyMap());
+        assertNotNull(workflowRequest.getWorkflowId());
+        assertEquals(template, workflowRequest.getTemplate());
+        assertNull(workflowRequest.validate());
+        assertFalse(workflowRequest.isProvision());
+        assertTrue(workflowRequest.getDefaultParams().isEmpty());
+        assertEquals(workflowRequest.getUseCase(), "cohere-embedding_model_deploy");
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        workflowRequest.writeTo(out);
+        BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()));
+
+        WorkflowRequest streamInputRequest = new WorkflowRequest(in);
+
+        assertEquals(workflowRequest.getWorkflowId(), streamInputRequest.getWorkflowId());
+        assertEquals(workflowRequest.getTemplate().toString(), streamInputRequest.getTemplate().toString());
+        assertNull(workflowRequest.validate());
+        assertFalse(workflowRequest.isProvision());
+        assertTrue(workflowRequest.getDefaultParams().isEmpty());
+        assertEquals(workflowRequest.getUseCase(), "cohere-embedding_model_deploy");
+    }
+
+    public void testWorkflowRequestWithUseCaseAndParamsInBody() throws IOException {
+        WorkflowRequest workflowRequest = new WorkflowRequest("123", template, "cohere-embedding_model_deploy", Map.of("step", "model"));
+        assertNotNull(workflowRequest.getWorkflowId());
+        assertEquals(template, workflowRequest.getTemplate());
+        assertNull(workflowRequest.validate());
+        assertFalse(workflowRequest.isProvision());
+        assertEquals(workflowRequest.getDefaultParams().get("step"), "model");
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        workflowRequest.writeTo(out);
+        BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()));
+
+        WorkflowRequest streamInputRequest = new WorkflowRequest(in);
+
+        assertEquals(workflowRequest.getWorkflowId(), streamInputRequest.getWorkflowId());
+        assertEquals(workflowRequest.getTemplate().toString(), streamInputRequest.getTemplate().toString());
+        assertNull(workflowRequest.validate());
+        assertFalse(workflowRequest.isProvision());
+        assertEquals(workflowRequest.getDefaultParams().get("step"), "model");
+
+    }
+
     public void testWorkflowRequestWithParamsNoProvision() throws IOException {
         IllegalArgumentException ex = assertThrows(
             IllegalArgumentException.class,

--- a/src/test/java/org/opensearch/flowframework/transport/WorkflowRequestResponseTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/WorkflowRequestResponseTests.java
@@ -146,7 +146,7 @@ public class WorkflowRequestResponseTests extends OpenSearchTestCase {
     public void testWorkflowRequestWithParamsNoProvision() throws IOException {
         IllegalArgumentException ex = assertThrows(
             IllegalArgumentException.class,
-            () -> new WorkflowRequest("123", template, new String[] { "all" }, false, Map.of("foo", "bar"))
+            () -> new WorkflowRequest("123", template, new String[] { "all" }, false, Map.of("foo", "bar"), null, Collections.emptyMap())
         );
         assertEquals("Params may only be included when provisioning.", ex.getMessage());
     }

--- a/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
@@ -97,7 +97,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
 
         Object result = ParseUtils.conditionallySubstitute(input, outputs, params);
 
-        assertEquals("This string has no placeholders", result, "String should remain unchanged");
+        assertEquals("This string has no placeholders", result);
     }
 
     public void testConditionallySubstituteWithUnmatchedPlaceholders() {
@@ -107,7 +107,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
 
         Object result = ParseUtils.conditionallySubstitute(input, outputs, params);
 
-        assertEquals("This string has unmatched ${{placeholder}}", result, "String should remain unchanged due to unmatched placeholders");
+        assertEquals("This string has unmatched ${{placeholder}}", result);
     }
 
     public void testConditionallySubstituteWithOutputsSubstitution() {


### PR DESCRIPTION
### Description

The reason I went with a separate defaults file for now is so we don't make breaking changes on our template if customers gives us feedback for how to this differently. 

Some concerns I have:

1. Customers might have a hard time knowing what to substitute, for example if they want to change connector post functions they need to know this key:
`"create_connector.actions.pre_process_function": "<content>"`
or for sparse search: `"register_local_sparse_encoding_model.function_name"`

2. If we want to make these more flexibly its going to be hard to do substitution on things like the index mapping unless user gives a whole string version of there mapping, settings and alias and we make the entire configuration a substitution.

3. Currently you can see I have two versions of create connector - deploy - register. This is due that some connectors have more optional parameters then the others. One solution is having many files for each variation, another is to potentially have the connectors made with empty fields (for example `truncate` is only needed in cohere default so if we have that for an OpenAI connector it will just be there and unused).

I only added 3 fully working defaults here for now, will have lots more to add if this approach seems fine. I want to also add a good amount of local models so that at least for fast POC or demo users can have a one click set up of an entire use case with 0 additional input like:
```
POST /_plugins/_flow_framework/workflow?use_case=local_neural_sparse_search
{}
or
POST /_plugins/_flow_framework/workflow?use_case=local_neural_sparse_search
```

another example with current use cases in PR:

```
POST /_plugins/_flow_framework/workflow?use_case=cohere-embedding_model_deploy
{
    "create_connector.credential.key" : "123"
}
```


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
