### PR TITLE
Use jsonB instead of jackson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,10 +175,9 @@ dependencies {
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
     api "org.apache.httpcomponents.core5:httpcore5:5.2.2"
-    implementation "jakarta.json:jakarta.json-api:2.0.1"
-    implementation "jakarta.json.bind:jakarta.json.bind-api:2.0.0"
-    implementation ("org.eclipse:yasson:2.0.2")
-
+    implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.0"
+    implementation "org.glassfish:jakarta.json:2.0.1"
+    implementation "org.eclipse:yasson:3.0.3"
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"

--- a/build.gradle
+++ b/build.gradle
@@ -175,8 +175,10 @@ dependencies {
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
     api "org.apache.httpcomponents.core5:httpcore5:5.2.2"
-    implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
-    implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
+    implementation "jakarta.json:jakarta.json-api:2.0.1"
+    implementation "jakarta.json.bind:jakarta.json.bind-api:2.0.0"
+    implementation ("org.eclipse:yasson:2.0.2")
+
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"

--- a/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
@@ -9,7 +9,9 @@
 package org.opensearch.flowframework.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -416,10 +418,16 @@ public class ParseUtils {
      * @return instance of the string
      * @throws JsonProcessingException JsonProcessingException from Jackson for issues processing map
      */
-    public static String parseArbitraryStringToObjectMapToString(Map<String, Object> map) throws JsonProcessingException {
-        // Convert the map to a JSON string
-        String mappedString = mapper.writeValueAsString(map);
-        return mappedString;
+    public static String parseArbitraryStringToObjectMapToString(Map<String, Object> map) throws Exception {
+        Jsonb jsonb = JsonbBuilder.create();
+        try {
+            // Convert the map to a JSON string
+            String jsonString = jsonb.toJson(map);
+            return jsonString;
+        } finally {
+            // Close the Jsonb instance
+            jsonb.close();
+        }
     }
 
     /**

--- a/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
@@ -84,7 +84,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
         assertEquals(stringMap.get("one"), parsedMap.get("one"));
     }
 
-    public void testParseArbitraryStringToObjectMapToString() throws IOException {
+    public void testParseArbitraryStringToObjectMapToString() throws Exception {
         Map<String, Object> map = Map.ofEntries(Map.entry("test-1", Map.of("test-1", "test-1")));
         String parsedMap = ParseUtils.parseArbitraryStringToObjectMapToString(map);
         assertEquals("{\"test-1\":{\"test-1\":\"test-1\"}}", parsedMap);


### PR DESCRIPTION
### Description
Based on the discussion on https://github.com/opensearch-project/flow-framework/issues/566. Tried to use `jsonB` from `jakarta` but it's failing with the below upon running the test

```
 ./gradlew ':test' --tests "org.opensearch.flowframework.util.ParseUtilsTests.testParseArbitraryStringToObjectMapToString" -Dtests.seed=D5F664F8F9319CA -Dtests.security.manager=false -Dtests.locale=el-GR -Dtests.timezone=America/Argentina/Ushuaia -Druntime.java=17

```

```
 2> jakarta.json.JsonException: Provider org.glassfish.json.JsonProviderImpl not found
        at __randomizedtesting.SeedInfo.seed([D5F664F8F9319CA:2C7491821F916CBA]:0)
        at app//jakarta.json.spi.JsonProvider.provider(JsonProvider.java:75)
        at java.base@17.0.2/java.util.Optional.orElseGet(Optional.java:364)
        at app//org.eclipse.yasson.internal.JsonBinding.<init>(JsonBinding.java:49)
        at app//org.eclipse.yasson.internal.JsonBindingBuilder.build(JsonBindingBuilder.java:61)
        at app//jakarta.json.bind.JsonbBuilder.create(JsonbBuilder.java:86)
        at app//org.opensearch.flowframework.util.ParseUtils.parseArbitraryStringToObjectMapToString(ParseUtils.java:385)
        at app//org.opensearch.flowframework.util.ParseUtilsTests.testParseArbitraryStringToObjectMapToString(ParseUtilsTests.java:87)

        Caused by:
        java.lang.ClassNotFoundException: org.glassfish.json.JsonProviderImpl
            at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
            at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
            at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
            at java.base/java.lang.Class.forName0(Native Method)
            at java.base/java.lang.Class.forName(Class.java:375)
            at jakarta.json.spi.JsonProvider.provider(JsonProvider.java:72)

```

After including the `glassfish` dependency
```
implementation 'org.glassfish:javax.json:1.1.4'
```

it failed with jar hell!!

```
org.opensearch.flowframework.util.ParseUtilsTests > classMethod FAILED
    java.lang.RuntimeException: found jar hell in test classpath
        at org.opensearch.bootstrap.BootstrapForTesting.<clinit>(BootstrapForTesting.java:120)
        at org.opensearch.test.OpenSearchTestCase.<clinit>(OpenSearchTestCase.java:271)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:467)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$2.run(RandomizedRunner.java:623)

        Caused by:
        java.lang.IllegalStateException: jar hell!
        class: jakarta.json.EmptyArray
        jar1: /Users/kazabdu/.gradle/caches/modules-2/files-2.1/jakarta.json/jakarta.json-api/2.0.1/f118a476a74a435e89bb8e36578b65a2be6c191e/jakarta.json-api-2.0.1.jar
        jar2: /Users/kazabdu/.gradle/caches/modules-2/files-2.1/org.glassfish/jakarta.json/2.0.0/4c4a7c5cdcc038c2da2901f35fd8b27c27ffea20/jakarta.json-2.0.0.jar
            at org.opensearch.bootstrap.JarHell.checkClass(JarHell.java:316)
            at org.opensearch.bootstrap.JarHell.checkJarHell(JarHell.java:215)
            at org.opensearch.bootstrap.JarHell.checkJarHell(JarHell.java:102)
            at org.opensearch.bootstrap.BootstrapForTesting.<clinit>(BootstrapForTesting.java:118)
            ... 4 more


Suite: Test class org.opensearch.flowframework.util.ParseUtilsTests
  2> java.lang.RuntimeException: found jar hell in test classpath
        at org.opensearch.bootstrap.BootstrapForTesting.<clinit>(BootstrapForTesting.java:120)
        at org.opensearch.test.OpenSearchTestCase.<clinit>(OpenSearchTestCase.java:271)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:467)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$2.run(RandomizedRunner.java:623)

        Caused by:
        java.lang.IllegalStateException: jar hell!
        class: jakarta.json.EmptyArray
        jar1: /Users/kazabdu/.gradle/caches/modules-2/files-2.1/jakarta.json/jakarta.json-api/2.0.1/f118a476a74a435e89bb8e36578b65a2be6c191e/jakarta.json-api-2.0.1.jar
        jar2: /Users/kazabdu/.gradle/caches/modules-2/files-2.1/org.glassfish/jakarta.json/2.0.0/4c4a7c5cdcc038c2da2901f35fd8b27c27ffea20/jakarta.json-2.0.0.jar
            at org.opensearch.bootstrap.JarHell.checkClass(JarHell.java:316)
            at org.opensearch.bootstrap.JarHell.checkJarHell(JarHell.java:215)
            at org.opensearch.bootstrap.JarHell.checkJarHell(JarHell.java:102)
            at org.opensearch.bootstrap.BootstrapForTesting.<clinit>(BootstrapForTesting.java:118)
            ... 4 more

```

Looking for some idea here.

### Issues Resolved
Part of https://github.com/opensearch-project/flow-framework/issues/566

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
