### PR TITLE
Fixing neural search name check for default use case integ test

### DIFF
--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -458,7 +458,7 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
 
         // Distribution build contains all plugins, checking if plugins are part of the integration test cluster
         List<String> plugins = catPlugins();
-        if (plugins.contains("opensearch-knn") && plugins.contains("neural-search")) {
+        if (plugins.contains("opensearch-knn") && plugins.contains("opensearch-neural-search")) {
             getAndAssertWorkflowStatus(client(), workflowId, State.PROVISIONING, ProvisioningProgress.IN_PROGRESS);
         } else {
             // expecting a failure since there is no neural-search plugin in cluster to provide text-embedding processor


### PR DESCRIPTION
### Description
Fixes neural search name check in integration tests. Neural Search plugin has the name `neural-search` in their [settings.gradle](https://github.com/opensearch-project/neural-search/blob/50a6dcf3f71df9abd6aa496e4e340126b3d44b31/settings.gradle#L11), however the plugin name shows up as `opensearch-neural-search`

### Issues Resolved
https://github.com/opensearch-project/flow-framework/issues/599

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
