### PR TITLE
Fixing ingest pipeline integ test

### DIFF
--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -685,11 +685,11 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
         );
     }
 
-    protected GetPipelineResponse getPipelines() throws IOException {
+    protected GetPipelineResponse getPipelines(String pipelineId) throws IOException {
         Response getPipelinesResponse = TestHelpers.makeRequest(
             client(),
             "GET",
-            "_ingest/pipeline",
+            "_ingest/pipeline/" + pipelineId,
             null,
             "",
             ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -393,7 +393,7 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         assertEquals(5, resourcesCreated.size());
         String modelId = resourcesCreated.get(2).resourceId();
 
-        GetPipelineResponse getPipelinesResponse = getPipelines();
+        GetPipelineResponse getPipelinesResponse = getPipelines("append-1");
 
         assertTrue(getPipelinesResponse.pipelines().get(0).toString().contains(modelId));
 


### PR DESCRIPTION
### Description
Adds a pipeline ID to the `getPipelines()` helper method to return only the pipeline configuration of the given pipeline ID
More details can be found in the attached issue

### Issues Resolved
Addressing distribution build failure [here](https://github.com/opensearch-project/flow-framework/issues/599#issuecomment-2019273004)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
