### PR TITLE
Name changes to use cases

### DIFF
--- a/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
+++ b/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
@@ -26,31 +26,31 @@ public enum DefaultUseCases {
     ),
     /** defaults file and substitution ready template for Cohere embedding model */
     COHERE_EMBEDDING_MODEL_DEPLOY(
-        "cohere-embedding_model_deploy",
+        "cohere_embedding_model_deploy",
         "defaults/cohere-embedding-defaults.json",
         "substitutionTemplates/deploy-remote-model-extra-params-template.json"
     ),
     /** defaults file and substitution ready template for Bedrock Titan embedding model */
     BEDROCK_TITAN_EMBEDDING_MODEL_DEPLOY(
-        "bedrock-titan-embedding_model_deploy",
+        "bedrock_titan_embedding_model_deploy",
         "defaults/bedrock-titan-embedding-defaults.json",
         "substitutionTemplates/deploy-remote-bedrock-model-template.json"
     ),
     /** defaults file and substitution ready template for Bedrock Titan multimodal embedding model */
     BEDROCK_TITAN_MULTIMODAL_MODEL_DEPLOY(
-        "bedrock-titan-multimodal_model_deploy",
+        "bedrock_titan_multimodal_model_deploy",
         "defaults/bedrock-titan-multimodal-defaults.json",
         "substitutionTemplates/deploy-remote-bedrock-model-template.json"
     ),
     /** defaults file and substitution ready template for Cohere chat model */
     COHERE_CHAT_MODEL_DEPLOY(
-        "cohere-chat_model_deploy",
+        "cohere_chat_model_deploy",
         "defaults/cohere-chat-defaults.json",
         "substitutionTemplates/deploy-remote-model-chat-template.json"
     ),
     /** defaults file and substitution ready template for OpenAI chat model */
     OPENAI_CHAT_MODEL_DEPLOY(
-        "openai-chat_model_deploy",
+        "openai_chat_model_deploy",
         "defaults/openai-chat-defaults.json",
         "substitutionTemplates/deploy-remote-model-chat-template.json"
     ),
@@ -64,20 +64,20 @@ public enum DefaultUseCases {
     SEMANTIC_SEARCH("semantic_search", "defaults/semantic-search-defaults.json", "substitutionTemplates/semantic-search-template.json"),
     /** defaults file and substitution ready template for multimodal search, no model creation*/
     MULTI_MODAL_SEARCH(
-        "multi_modal_search",
+        "multimodal_search",
         "defaults/multi-modal-search-defaults.json",
         "substitutionTemplates/multi-modal-search-template.json"
     ),
     /** defaults file and substitution ready template for multimodal search, no model creation*/
     MULTI_MODAL_SEARCH_WITH_BEDROCK_TITAN(
-        "multi_modal_search_with_bedrock_titan_multi_modal",
+        "multimodal_search_with_bedrock_titan",
         "defaults/multimodal-search-bedrock-titan-defaults.json",
         "substitutionTemplates/multi-modal-search-with-bedrock-titan-template.json"
     ),
     /** defaults file and substitution ready template for semantic search with query enricher processor attached, no model creation*/
     SEMANTIC_SEARCH_WITH_QUERY_ENRICHER(
         "semantic_search_with_query_enricher",
-        "defaults/semantic-search-defaults.json",
+        "defaults/semantic-search-query-enricher-defaults.json",
         "substitutionTemplates/semantic-search-with-query-enricher-template.json"
     ),
     /** defaults file and substitution ready template for semantic search with cohere embedding model*/
@@ -89,7 +89,7 @@ public enum DefaultUseCases {
     /** defaults file and substitution ready template for semantic search with query enricher processor attached and cohere embedding model*/
     SEMANTIC_SEARCH_WITH_COHERE_EMBEDDING_AND_QUERY_ENRICHER(
         "semantic_search_with_cohere_embedding_query_enricher",
-        "defaults/cohere-embedding-semantic-search-defaults.json",
+        "defaults/cohere-embedding-semantic-search-with-query-enricher-defaults.json",
         "substitutionTemplates/semantic-search-with-model-and-query-enricher-template.json"
     ),
     /** defaults file and substitution ready template for hybrid search, no model creation*/

--- a/src/main/resources/defaults/bedrock-titan-embedding-defaults.json
+++ b/src/main/resources/defaults/bedrock-titan-embedding-defaults.json
@@ -1,5 +1,5 @@
 {
-    "template.name": "deploy-bedrock-titan-embedding-model",
+    "template.name": "bedrock_titan_embedding_model_deploy",
     "template.description": "Deploying Amazon Bedrock Titan embedding model ",
     "create_connector.name": "Amazon Bedrock Connector: embedding",
     "create_connector.description": "The connector to bedrock Titan embedding model",

--- a/src/main/resources/defaults/bedrock-titan-multimodal-defaults.json
+++ b/src/main/resources/defaults/bedrock-titan-multimodal-defaults.json
@@ -1,5 +1,5 @@
 {
-    "template.name": "deploy-bedrock-titan-multimodal-embedding-model",
+    "template.name": "bedrock_titan_multimodal_model_deploy",
     "template.description": "Deploying Amazon Bedrock Titan multimodal embedding model ",
     "create_connector.name": "Amazon Bedrock Connector: multi-modal embedding",
     "create_connector.description": "The connector to bedrock Titan multi-modal embedding model",

--- a/src/main/resources/defaults/cohere-chat-defaults.json
+++ b/src/main/resources/defaults/cohere-chat-defaults.json
@@ -1,5 +1,5 @@
 {
-    "template.name": "deploy-cohere-chat-model",
+    "template.name": "cohere_chat_model_deploy",
     "template.description": "Deploying a Cohere chat model",
     "create_connector.name": "Cohere Chat Model",
     "create_connector.description": "The connector to Cohere's public chat API",

--- a/src/main/resources/defaults/cohere-embedding-semantic-search-with-query-enricher-defaults.json
+++ b/src/main/resources/defaults/cohere-embedding-semantic-search-with-query-enricher-defaults.json
@@ -1,6 +1,6 @@
 {
-    "template.name": "cohere_embedding_model_deploy",
-    "template.description": "Deploying a Cohere embedding model",
+    "template.name": "semantic search with cohere embedding",
+    "template.description": "Setting up semantic search, with a Cohere embedding model",
     "create_connector.name": "cohere-embedding-connector",
     "create_connector.description": "The connector to Cohere's public embed API",
     "create_connector.protocol": "http",
@@ -13,5 +13,16 @@
     "create_connector.actions.pre_process_function": "connector.pre_process.cohere.embedding",
     "create_connector.actions.post_process_function": "connector.post_process.cohere.embedding",
     "register_remote_model.name": "Cohere english embed model",
-    "register_remote_model.description": "cohere-embedding-model"
+    "register_remote_model.description": "cohere-embedding-model",
+    "create_ingest_pipeline.pipeline_id": "nlp-ingest-pipeline",
+    "create_ingest_pipeline.description": "A text embedding pipeline",
+    "text_embedding.field_map.input": "passage_text",
+    "text_embedding.field_map.output": "passage_embedding",
+    "create_index.name": "my-nlp-index",
+    "create_index.settings.number_of_shards": "2",
+    "create_index.mappings.method.engine": "lucene",
+    "create_index.mappings.method.space_type": "l2",
+    "create_index.mappings.method.name": "hnsw",
+    "text_embedding.field_map.output.dimension": "1024",
+    "create_search_pipeline.pipeline_id": "default_model_pipeline"
 }

--- a/src/main/resources/defaults/local-sparse-search-biencoder-defaults.json
+++ b/src/main/resources/defaults/local-sparse-search-biencoder-defaults.json
@@ -1,5 +1,5 @@
 {
-    "template.name": "local-model-neural-sparse-search",
+    "template.name": "local_neural_sparse_search_bi_encoder",
     "template.description": "Setting up neural sparse search with pretrained local model",
     "register_local_sparse_encoding_model.name": "amazon/neural-sparse/opensearch-neural-sparse-encoding-v1",
     "register_local_sparse_encoding_model.description": "This is a neural sparse encoding model",

--- a/src/main/resources/defaults/multi-modal-search-defaults.json
+++ b/src/main/resources/defaults/multi-modal-search-defaults.json
@@ -1,5 +1,5 @@
 {
-    "template.name": "multi-modal-search",
+    "template.name": "multimodal_search",
     "template.description": "Setting up multimodal search, ingest pipeline and index",
     "create_ingest_pipeline.pipeline_id": "nlp-multimodal-ingest-pipeline",
     "create_ingest_pipeline.description": "A text/image embedding pipeline",

--- a/src/main/resources/defaults/multimodal-search-bedrock-titan-defaults.json
+++ b/src/main/resources/defaults/multimodal-search-bedrock-titan-defaults.json
@@ -1,5 +1,5 @@
 {
-    "template.name": "multimodal-search-with-bedrock-titan-deployment",
+    "template.name": "multimodal_search_with_bedrock_titan",
     "template.description": "Setting up multimodal search with Amazon Bedrock Titan embedding model deployment",
     "create_connector.name": "Amazon Bedrock Connector: multi-modal embedding",
     "create_connector.description": "The connector to bedrock Titan multi-modal embedding model",

--- a/src/main/resources/defaults/openai-chat-defaults.json
+++ b/src/main/resources/defaults/openai-chat-defaults.json
@@ -1,5 +1,5 @@
 {
-      "template.name": "deploy-openai-chat-model",
+      "template.name": "openai_chat_model_deploy",
       "template.description": "Deploying an OpenAI chat model",
       "create_connector.name": "OpenAI Chat Connector",
       "create_connector.description": "Connector to public OpenAI model",

--- a/src/main/resources/defaults/openai-embedding-defaults.json
+++ b/src/main/resources/defaults/openai-embedding-defaults.json
@@ -1,5 +1,5 @@
 {
-    "template.name": "deploy-openai-model",
+    "template.name": "open_ai_embedding_model_deploy",
     "template.description": "Deploying an OpenAI embedding model",
     "create_connector.name": "OpenAI-embedding-connector",
     "create_connector.description": "Connector to public OpenAI model",

--- a/src/main/resources/defaults/semantic-search-defaults.json
+++ b/src/main/resources/defaults/semantic-search-defaults.json
@@ -1,5 +1,5 @@
 {
-    "template.name": "semantic-search",
+    "template.name": "semantic_search",
     "template.description": "Setting up semantic search, ingest pipeline and index",
     "create_ingest_pipeline.pipeline_id": "nlp-ingest-pipeline",
     "create_ingest_pipeline.description": "A text embedding pipeline",

--- a/src/main/resources/defaults/semantic-search-query-enricher-defaults.json
+++ b/src/main/resources/defaults/semantic-search-query-enricher-defaults.json
@@ -1,15 +1,16 @@
 {
-    "template.name": "semantic-search",
+    "template.name": "semantic_search",
     "template.description": "Setting up semantic search, ingest pipeline and index",
     "create_ingest_pipeline.pipeline_id": "nlp-ingest-pipeline",
     "create_ingest_pipeline.description": "A text embedding pipeline",
     "create_ingest_pipeline.model_id": "123",
     "text_embedding.field_map.input": "passage_text",
     "text_embedding.field_map.output": "passage_embedding",
-    "create_search_pipeline.pipeline_id": "default_model_pipeline",
     "create_index.name": "my-nlp-index",
     "create_index.settings.number_of_shards": "2",
     "create_index.mappings.method.engine": "lucene",
     "create_index.mappings.method.space_type": "l2",
-    "create_index.mappings.method.name": "hnsw"
+    "create_index.mappings.method.name": "hnsw",
+    "text_embedding.field_map.output.dimension": "1024",
+    "create_search_pipeline.pipeline_id": "default_model_pipeline"
 }

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -404,7 +404,7 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
     public void testDefaultCohereUseCase() throws Exception {
 
         // Hit Create Workflow API with original template
-        Response response = createWorkflowWithUseCase(client(), "cohere-embedding_model_deploy");
+        Response response = createWorkflowWithUseCase(client(), "cohere_embedding_model_deploy");
         assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
 
         Map<String, Object> responseMap = entityAsMap(response);


### PR DESCRIPTION
### Description
changing all use case names to have underscore and also adding distinct default file for semantic_search_with_cohere_embedding_query_enricher instead of using same one as without query_enricher based on tech writer suggestion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
