### PR TITLE
Warn about escaping quotes in curl command

### DIFF
--- a/sample-templates/README.md
+++ b/sample-templates/README.md
@@ -6,6 +6,8 @@ Each template is provided in both YAML and JSON format with identical functional
 The YAML templates include comments which give more insight into the template's usage.
 Use the corresponding `Content-Type` (`application/yaml` or `application/json`) when providing them as the body of a REST request.
 
+Note that several of the templates use both the single quote (`'`) and double quote (`"`) characters which may create issues if using the templates using `curl` on the command line with `--data`. Escaping the single quotes or reading the template from a file is needed to work around this.
+
 You will need to update the `credentials` field with appropriate API keys.
 
 To create a workflow and provision the resources:

--- a/sample-templates/README.md
+++ b/sample-templates/README.md
@@ -6,7 +6,7 @@ Each template is provided in both YAML and JSON format with identical functional
 The YAML templates include comments which give more insight into the template's usage.
 Use the corresponding `Content-Type` (`application/yaml` or `application/json`) when providing them as the body of a REST request.
 
-Note that several of the templates use both the single quote (`'`) and double quote (`"`) characters which may create issues if using the templates using `curl` on the command line with `--data`. Escaping the single quotes or reading the template from a file is needed to work around this.
+**Note:** Several of the templates use both the single quote (`'`) and double quote (`"`) characters which may create issues using the templates with `curl` on the command line and the template in `--data`. Escaping the single quotes or reading the template from a file is needed to work around this.
 
 You will need to update the `credentials` field with appropriate API keys.
 


### PR DESCRIPTION
### Description

Adds a line to the Sample Template README file warning users that `curl` commands may require special treatment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
