### PR TITLE
Silently ignore content on APIs that don't require it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
+### Bug Fixes
+- Silently ignore content on APIs that don't require it ([#639](https://github.com/opensearch-project/flow-framework/pull/639))
+
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
@@ -69,11 +69,11 @@ public class RestDeleteWorkflowAction extends BaseRestHandler {
                     RestStatus.FORBIDDEN
                 );
             }
-            // Validate content
-            if (request.hasContent()) {
-                // BaseRestHandler will give appropriate error message
-                return channel -> channel.sendResponse(null);
-            }
+
+            // Always consume content to silently ignore it
+            // https://github.com/opensearch-project/flow-framework/issues/578
+            request.content();
+
             // Validate params
             if (workflowId == null) {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
@@ -64,10 +64,11 @@ public class RestDeprovisionWorkflowAction extends BaseRestHandler {
                     RestStatus.FORBIDDEN
                 );
             }
-            // Validate content
-            if (request.hasContent()) {
-                throw new FlowFrameworkException("deprovision request should have no payload", RestStatus.BAD_REQUEST);
-            }
+
+            // Always consume content to silently ignore it
+            // https://github.com/opensearch-project/flow-framework/issues/578
+            request.content();
+
             // Validate params
             if (workflowId == null) {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowAction.java
@@ -69,11 +69,11 @@ public class RestGetWorkflowAction extends BaseRestHandler {
                     RestStatus.FORBIDDEN
                 );
             }
-            // Validate content
-            if (request.hasContent()) {
-                // BaseRestHandler will give appropriate error message
-                return channel -> channel.sendResponse(null);
-            }
+
+            // Always consume content to silently ignore it
+            // https://github.com/opensearch-project/flow-framework/issues/578
+            request.content();
+
             // Validate params
             if (workflowId == null) {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
@@ -66,11 +66,10 @@ public class RestGetWorkflowStateAction extends BaseRestHandler {
                 );
             }
 
-            // Validate content
-            if (request.hasContent()) {
-                // BaseRestHandler will give appropriate error message
-                return channel -> channel.sendResponse(null);
-            }
+            // Always consume content to silently ignore it
+            // https://github.com/opensearch-project/flow-framework/issues/578
+            request.content();
+
             // Validate params
             if (workflowId == null) {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStepAction.java
@@ -71,6 +71,10 @@ public class RestGetWorkflowStepAction extends BaseRestHandler {
                 );
             }
 
+            // Always consume content to silently ignore it
+            // https://github.com/opensearch-project/flow-framework/issues/578
+            request.content();
+
             Map<String, String> params = request.hasParam(WORKFLOW_STEP)
                 ? Map.of(WORKFLOW_STEP, request.param(WORKFLOW_STEP))
                 : Collections.emptyMap();

--- a/src/test/java/org/opensearch/flowframework/rest/RestDeleteWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestDeleteWorkflowActionTests.java
@@ -9,9 +9,7 @@
 package org.opensearch.flowframework.rest;
 
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
@@ -53,19 +51,6 @@ public class RestDeleteWorkflowActionTests extends OpenSearchTestCase {
         assertEquals(1, routes.size());
         assertEquals(RestRequest.Method.DELETE, routes.get(0).getMethod());
         assertEquals(this.getPath, routes.get(0).getPath());
-    }
-
-    public void testInvalidRequestWithContent() {
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.DELETE)
-            .withPath(this.getPath)
-            .withContent(new BytesArray("request body"), MediaTypeRegistry.JSON)
-            .build();
-
-        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
-            restDeleteWorkflowAction.handleRequest(request, channel, nodeClient);
-        });
-        assertEquals("request [DELETE /_plugins/_flow_framework/workflow/{workflow_id}] does not support having a body", ex.getMessage());
     }
 
     public void testNullWorkflowId() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowActionTests.java
@@ -9,9 +9,7 @@
 package org.opensearch.flowframework.rest;
 
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest;
@@ -69,22 +67,6 @@ public class RestDeprovisionWorkflowActionTests extends OpenSearchTestCase {
         assertEquals(1, channel.errors().get());
         assertEquals(RestStatus.BAD_REQUEST, channel.capturedResponse().status());
         assertTrue(channel.capturedResponse().content().utf8ToString().contains("workflow_id cannot be null"));
-    }
-
-    public void testInvalidRequestWithContent() {
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
-            .withPath(this.deprovisionWorkflowPath)
-            .withContent(new BytesArray("request body"), MediaTypeRegistry.JSON)
-            .build();
-
-        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
-            deprovisionWorkflowRestAction.handleRequest(request, channel, nodeClient);
-        });
-        assertEquals(
-            "request [POST /_plugins/_flow_framework/workflow/{workflow_id}/_deprovision] does not support having a body",
-            ex.getMessage()
-        );
     }
 
     public void testFeatureFlagNotEnabled() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowActionTests.java
@@ -9,9 +9,7 @@
 package org.opensearch.flowframework.rest;
 
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
@@ -53,19 +51,6 @@ public class RestGetWorkflowActionTests extends OpenSearchTestCase {
         assertEquals(1, routes.size());
         assertEquals(RestRequest.Method.GET, routes.get(0).getMethod());
         assertEquals(this.getPath, routes.get(0).getPath());
-    }
-
-    public void testInvalidRequestWithContent() {
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
-            .withPath(this.getPath)
-            .withContent(new BytesArray("request body"), MediaTypeRegistry.JSON)
-            .build();
-
-        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
-            restGetWorkflowAction.handleRequest(request, channel, nodeClient);
-        });
-        assertEquals("request [GET /_plugins/_flow_framework/workflow/{workflow_id}] does not support having a body", ex.getMessage());
     }
 
     public void testNullWorkflowId() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStateActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStateActionTests.java
@@ -9,9 +9,7 @@
 package org.opensearch.flowframework.rest;
 
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
@@ -73,22 +71,6 @@ public class RestGetWorkflowStateActionTests extends OpenSearchTestCase {
         assertEquals(1, channel.errors().get());
         assertEquals(RestStatus.BAD_REQUEST, channel.capturedResponse().status());
         assertTrue(channel.capturedResponse().content().utf8ToString().contains("workflow_id cannot be null"));
-    }
-
-    public void testInvalidRequestWithContent() {
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
-            .withPath(this.getPath)
-            .withContent(new BytesArray("request body"), MediaTypeRegistry.JSON)
-            .build();
-
-        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
-            restGetWorkflowStateAction.handleRequest(request, channel, nodeClient);
-        });
-        assertEquals(
-            "request [GET /_plugins/_flow_framework/workflow/{workflow_id}/_status] does not support having a body",
-            ex.getMessage()
-        );
     }
 
     public void testFeatureFlagNotEnabled() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStepActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestGetWorkflowStepActionTests.java
@@ -11,9 +11,7 @@ package org.opensearch.flowframework.rest;
 import org.opensearch.client.Client;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
@@ -83,19 +81,6 @@ public class RestGetWorkflowStepActionTests extends OpenSearchTestCase {
         assertEquals(1, routes.size());
         assertEquals(RestRequest.Method.GET, routes.get(0).getMethod());
         assertEquals(this.getPath, routes.get(0).getPath());
-    }
-
-    public void testInvalidRequestWithContent() {
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
-            .withPath(this.getPath)
-            .withContent(new BytesArray("request body"), MediaTypeRegistry.JSON)
-            .build();
-
-        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
-            restGetWorkflowStepAction.handleRequest(request, channel, nodeClient);
-        });
-        assertEquals("request [GET /_plugins/_flow_framework/workflow/_steps] does not support having a body", ex.getMessage());
     }
 
     public void testWorkflowSteps() throws Exception {


### PR DESCRIPTION
### Description

Despite code paths and unit tests showing otherwise, OpenSearch silently ignores the content (body) of a REST request that doesn't require it.  We should do the same.

### Issues Resolved

Fixes #638 (or at least doesn't give users a poor experience).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
