### PR TITLE
Reduce unnecessary duplication of changelog verifier GHA runs

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -6,7 +6,7 @@ on:
       - 'backport/**'
   pull_request:
     branches: main
-    types: [opened, edited, review_requested, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
   # Enforces the update of a changelog file on every pull request


### PR DESCRIPTION
### Description

Reduces the number of triggering events for the Changelog verifier action, primarily intended to reduce the email spam to submitters on omitted change log.

See OpenSearch PR: https://github.com/opensearch-project/OpenSearch/pull/13072/files

### Issues Resolved

Similar (but smaller scale) problem as https://github.com/opensearch-project/OpenSearch/issues/13013


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
