### PR TITLE
[Backport 2.x] Update dependency org.bouncycastle:bcprov-jdk18on to v1.78 (#654)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.78'
     implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
     implementation "org.glassfish:jakarta.json:2.0.1"
     implementation "org.eclipse:yasson:3.0.3"


### PR DESCRIPTION
Backport 3c67cff96e241a7101c7e5779a16a8b57d154f84 from #654.