### PR TITLE
Adding guardrails to default use case params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.13...2.x)
 ### Features
 ### Enhancements
+- Adding guardrails to default use case params ([#658](https://github.com/opensearch-project/flow-framework/pull/658))
 ### Bug Fixes
 - Reset workflow state to initial state after successful deprovision ([#635](https://github.com/opensearch-project/flow-framework/pull/635))
 - Silently ignore content on APIs that don't require it ([#639](https://github.com/opensearch-project/flow-framework/pull/639))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.13...2.x)
 ### Features
 ### Enhancements
-- Adding guardrails to default use case params ([#658](https://github.com/opensearch-project/flow-framework/pull/658))
+- Add guardrails to default use case params ([#658](https://github.com/opensearch-project/flow-framework/pull/658))
 ### Bug Fixes
 - Reset workflow state to initial state after successful deprovision ([#635](https://github.com/opensearch-project/flow-framework/pull/635))
 - Silently ignore content on APIs that don't require it ([#639](https://github.com/opensearch-project/flow-framework/pull/639))

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -202,4 +202,18 @@ public class CommonValue {
     public static final String RESOURCE_ID = "resource_id";
     /** The field name for the opensearch-ml plugin */
     public static final String OPENSEARCH_ML = "opensearch-ml";
+
+    /*
+     * Constants assoicated with substitution / default templates
+     */
+    /** The field name for connector credential key substitution */
+    public static final String CREATE_CONNECTOR_CREDENTIAL_KEY = "create_connector.credential.key";
+    /** The field name for connector credential access key substitution */
+    public static final String CREATE_CONNECTOR_CREDENTIAL_ACCESS_KEY = "create_connector.credential.access_key";
+    /** The field name for connector credential secret key substitution */
+    public static final String CREATE_CONNECTOR_CREDENTIAL_SECRET_KEY = "create_connector.credential.secret_key";
+    /** The field name for connector credential session token substitution */
+    public static final String CREATE_CONNECTOR_CREDENTIAL_SESSION_TOKEN = "create_connector.credential.session_token";
+    /** The field name for ingest pipeline model ID substitution */
+    public static final String CREATE_INGEST_PIPELINE_MODEL_ID = "create_ingest_pipeline.model_id";
 }

--- a/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
+++ b/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
@@ -219,9 +219,8 @@ public enum DefaultUseCases {
      * Gets the required parameters based on the given use case
      * @param useCaseName name of the given use case
      * @return the list of required params
-     * @throws FlowFrameworkException if the use case doesn't exist in enum
      */
-    public static List<String> getRequiredParamsByUseCaseName(String useCaseName) throws FlowFrameworkException {
+    public static List<String> getRequiredParamsByUseCaseName(String useCaseName) {
         if (useCaseName != null && !useCaseName.isEmpty()) {
             for (DefaultUseCases useCase : values()) {
                 if (useCase.getUseCaseName().equals(useCaseName)) {
@@ -229,7 +228,7 @@ public enum DefaultUseCases {
                 }
             }
         }
-        logger.error("Unable to find required parameters for use case: {}", useCaseName);
-        throw new FlowFrameworkException("Unable to find required parameters for use case: " + useCaseName, RestStatus.BAD_REQUEST);
+        logger.error("Default use case [" + useCaseName + "] does not exist");
+        throw new FlowFrameworkException("Default use case [" + useCaseName + "] does not exist", RestStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
+++ b/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
@@ -215,6 +215,12 @@ public enum DefaultUseCases {
         throw new FlowFrameworkException("Unable to find substitution ready file for use case: " + useCaseName, RestStatus.BAD_REQUEST);
     }
 
+    /**
+     * Gets the required parameters based on the given use case
+     * @param useCaseName name of the given use case
+     * @return the list of required params
+     * @throws FlowFrameworkException if the use case doesn't exist in enum
+     */
     public static List<String> getRequiredParamsByUseCaseName(String useCaseName) throws FlowFrameworkException {
         if (useCaseName != null && !useCaseName.isEmpty()) {
             for (DefaultUseCases useCase : values()) {

--- a/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
+++ b/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
@@ -13,6 +13,16 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.opensearch.flowframework.common.CommonValue.CREATE_CONNECTOR_CREDENTIAL_ACCESS_KEY;
+import static org.opensearch.flowframework.common.CommonValue.CREATE_CONNECTOR_CREDENTIAL_KEY;
+import static org.opensearch.flowframework.common.CommonValue.CREATE_CONNECTOR_CREDENTIAL_SECRET_KEY;
+import static org.opensearch.flowframework.common.CommonValue.CREATE_CONNECTOR_CREDENTIAL_SESSION_TOKEN;
+import static org.opensearch.flowframework.common.CommonValue.CREATE_INGEST_PIPELINE_MODEL_ID;
+
 /**
  * Enum encapsulating the different default use cases and templates we have stored
  */
@@ -22,94 +32,119 @@ public enum DefaultUseCases {
     OPEN_AI_EMBEDDING_MODEL_DEPLOY(
         "open_ai_embedding_model_deploy",
         "defaults/openai-embedding-defaults.json",
-        "substitutionTemplates/deploy-remote-model-template.json"
+        "substitutionTemplates/deploy-remote-model-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_KEY)
     ),
     /** defaults file and substitution ready template for Cohere embedding model */
     COHERE_EMBEDDING_MODEL_DEPLOY(
         "cohere_embedding_model_deploy",
         "defaults/cohere-embedding-defaults.json",
-        "substitutionTemplates/deploy-remote-model-extra-params-template.json"
+        "substitutionTemplates/deploy-remote-model-extra-params-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_KEY)
     ),
     /** defaults file and substitution ready template for Bedrock Titan embedding model */
     BEDROCK_TITAN_EMBEDDING_MODEL_DEPLOY(
         "bedrock_titan_embedding_model_deploy",
         "defaults/bedrock-titan-embedding-defaults.json",
-        "substitutionTemplates/deploy-remote-bedrock-model-template.json"
+        "substitutionTemplates/deploy-remote-bedrock-model-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_ACCESS_KEY, CREATE_CONNECTOR_CREDENTIAL_SECRET_KEY, CREATE_CONNECTOR_CREDENTIAL_SESSION_TOKEN)
     ),
     /** defaults file and substitution ready template for Bedrock Titan multimodal embedding model */
     BEDROCK_TITAN_MULTIMODAL_MODEL_DEPLOY(
         "bedrock_titan_multimodal_model_deploy",
         "defaults/bedrock-titan-multimodal-defaults.json",
-        "substitutionTemplates/deploy-remote-bedrock-model-template.json"
+        "substitutionTemplates/deploy-remote-bedrock-model-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_ACCESS_KEY, CREATE_CONNECTOR_CREDENTIAL_SECRET_KEY, CREATE_CONNECTOR_CREDENTIAL_SESSION_TOKEN)
     ),
     /** defaults file and substitution ready template for Cohere chat model */
     COHERE_CHAT_MODEL_DEPLOY(
         "cohere_chat_model_deploy",
         "defaults/cohere-chat-defaults.json",
-        "substitutionTemplates/deploy-remote-model-chat-template.json"
+        "substitutionTemplates/deploy-remote-model-chat-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_KEY)
     ),
     /** defaults file and substitution ready template for OpenAI chat model */
     OPENAI_CHAT_MODEL_DEPLOY(
         "openai_chat_model_deploy",
         "defaults/openai-chat-defaults.json",
-        "substitutionTemplates/deploy-remote-model-chat-template.json"
+        "substitutionTemplates/deploy-remote-model-chat-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_KEY)
     ),
     /** defaults file and substitution ready template for local neural sparse model and ingest pipeline*/
     LOCAL_NEURAL_SPARSE_SEARCH_BI_ENCODER(
         "local_neural_sparse_search_bi_encoder",
         "defaults/local-sparse-search-biencoder-defaults.json",
-        "substitutionTemplates/neural-sparse-local-biencoder-template.json"
+        "substitutionTemplates/neural-sparse-local-biencoder-template.json",
+        Collections.emptyList()
     ),
     /** defaults file and substitution ready template for semantic search, no model creation*/
-    SEMANTIC_SEARCH("semantic_search", "defaults/semantic-search-defaults.json", "substitutionTemplates/semantic-search-template.json"),
+    SEMANTIC_SEARCH(
+        "semantic_search",
+        "defaults/semantic-search-defaults.json",
+        "substitutionTemplates/semantic-search-template.json",
+        List.of(CREATE_INGEST_PIPELINE_MODEL_ID)
+    ),
     /** defaults file and substitution ready template for multimodal search, no model creation*/
     MULTI_MODAL_SEARCH(
         "multimodal_search",
         "defaults/multi-modal-search-defaults.json",
-        "substitutionTemplates/multi-modal-search-template.json"
+        "substitutionTemplates/multi-modal-search-template.json",
+        List.of(CREATE_INGEST_PIPELINE_MODEL_ID)
     ),
     /** defaults file and substitution ready template for multimodal search, no model creation*/
     MULTI_MODAL_SEARCH_WITH_BEDROCK_TITAN(
         "multimodal_search_with_bedrock_titan",
         "defaults/multimodal-search-bedrock-titan-defaults.json",
-        "substitutionTemplates/multi-modal-search-with-bedrock-titan-template.json"
+        "substitutionTemplates/multi-modal-search-with-bedrock-titan-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_ACCESS_KEY, CREATE_CONNECTOR_CREDENTIAL_SECRET_KEY, CREATE_CONNECTOR_CREDENTIAL_SESSION_TOKEN)
     ),
     /** defaults file and substitution ready template for semantic search with query enricher processor attached, no model creation*/
     SEMANTIC_SEARCH_WITH_QUERY_ENRICHER(
         "semantic_search_with_query_enricher",
         "defaults/semantic-search-query-enricher-defaults.json",
-        "substitutionTemplates/semantic-search-with-query-enricher-template.json"
+        "substitutionTemplates/semantic-search-with-query-enricher-template.json",
+        List.of(CREATE_INGEST_PIPELINE_MODEL_ID)
     ),
     /** defaults file and substitution ready template for semantic search with cohere embedding model*/
     SEMANTIC_SEARCH_WITH_COHERE_EMBEDDING(
         "semantic_search_with_cohere_embedding",
         "defaults/cohere-embedding-semantic-search-defaults.json",
-        "substitutionTemplates/semantic-search-with-model-template.json"
+        "substitutionTemplates/semantic-search-with-model-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_KEY)
     ),
     /** defaults file and substitution ready template for semantic search with query enricher processor attached and cohere embedding model*/
     SEMANTIC_SEARCH_WITH_COHERE_EMBEDDING_AND_QUERY_ENRICHER(
         "semantic_search_with_cohere_embedding_query_enricher",
         "defaults/cohere-embedding-semantic-search-with-query-enricher-defaults.json",
-        "substitutionTemplates/semantic-search-with-model-and-query-enricher-template.json"
+        "substitutionTemplates/semantic-search-with-model-and-query-enricher-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_KEY)
     ),
     /** defaults file and substitution ready template for hybrid search, no model creation*/
-    HYBRID_SEARCH("hybrid_search", "defaults/hybrid-search-defaults.json", "substitutionTemplates/hybrid-search-template.json"),
+    HYBRID_SEARCH(
+        "hybrid_search",
+        "defaults/hybrid-search-defaults.json",
+        "substitutionTemplates/hybrid-search-template.json",
+        List.of(CREATE_INGEST_PIPELINE_MODEL_ID)
+    ),
     /** defaults file and substitution ready template for conversational search with cohere chat model*/
     CONVERSATIONAL_SEARCH_WITH_COHERE_DEPLOY(
         "conversational_search_with_llm_deploy",
         "defaults/conversational-search-defaults.json",
-        "substitutionTemplates/conversational-search-with-cohere-model-template.json"
+        "substitutionTemplates/conversational-search-with-cohere-model-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_KEY)
     );
 
     private final String useCaseName;
     private final String defaultsFile;
     private final String substitutionReadyFile;
+    private final List<String> requiredParams;
     private static final Logger logger = LogManager.getLogger(DefaultUseCases.class);
 
-    DefaultUseCases(String useCaseName, String defaultsFile, String substitutionReadyFile) {
+    DefaultUseCases(String useCaseName, String defaultsFile, String substitutionReadyFile, List<String> requiredParams) {
         this.useCaseName = useCaseName;
         this.defaultsFile = defaultsFile;
         this.substitutionReadyFile = substitutionReadyFile;
+        this.requiredParams = requiredParams;
     }
 
     /**
@@ -134,6 +169,14 @@ public enum DefaultUseCases {
      */
     public String getSubstitutionReadyFile() {
         return substitutionReadyFile;
+    }
+
+    /**
+     * Returns the required params for the given enum Constant
+     * @return the required params of the given useCase
+     */
+    public List<String> getRequiredParams() {
+        return requiredParams;
     }
 
     /**
@@ -170,5 +213,17 @@ public enum DefaultUseCases {
         }
         logger.error("Unable to find substitution ready file for use case: {}", useCaseName);
         throw new FlowFrameworkException("Unable to find substitution ready file for use case: " + useCaseName, RestStatus.BAD_REQUEST);
+    }
+
+    public static List<String> getRequiredParamsByUseCaseName(String useCaseName) throws FlowFrameworkException {
+        if (useCaseName != null && !useCaseName.isEmpty()) {
+            for (DefaultUseCases useCase : values()) {
+                if (useCase.getUseCaseName().equals(useCaseName)) {
+                    return new ArrayList<String>(useCase.getRequiredParams());
+                }
+            }
+        }
+        logger.error("Unable to find required parameters for use case: {}", useCaseName);
+        throw new FlowFrameworkException("Unable to find required parameters for use case: " + useCaseName, RestStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -129,8 +129,8 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                 useCaseDefaultsMap = ParseUtils.parseJsonFileToStringToStringMap("/" + defaultsFilePath);
                 List<String> requiredParams = DefaultUseCases.getRequiredParamsByUseCaseName(useCase);
 
-                if (request.hasContent() == false) {
-                    if (requiredParams.size() != 0) {
+                if (!request.hasContent()) {
+                    if (!requiredParams.isEmpty()) {
                         throw new FlowFrameworkException(
                             "Missing the following required parameters for use case [" + useCase + "] : " + requiredParams.toString(),
                             RestStatus.BAD_REQUEST
@@ -162,7 +162,7 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                         }
                     } catch (Exception ex) {
                         if (ex instanceof FlowFrameworkException) {
-                            throw (FlowFrameworkException) ex;
+                            throw ex;
                         } else {
                             RestStatus status = ex instanceof IOException ? RestStatus.BAD_REQUEST : ExceptionsHelper.status(ex);
                             String errorMessage =

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -127,8 +127,14 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                 );
                 String defaultsFilePath = DefaultUseCases.getDefaultsFileByUseCaseName(useCase);
                 useCaseDefaultsMap = ParseUtils.parseJsonFileToStringToStringMap("/" + defaultsFilePath);
+                List<String> requiredParams = DefaultUseCases.getRequiredParamsByUseCaseName(useCase);
 
-                if (request.hasContent()) {
+                if (request.hasContent() == false && requiredParams.size() != 0) {
+                    throw new FlowFrameworkException(
+                        "Missing the following required parameters for use case [" + useCase + "] : " + requiredParams.toString(),
+                        RestStatus.BAD_REQUEST
+                    );
+                } else {
                     try {
                         XContentParser parser = request.contentParser();
                         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
@@ -136,7 +142,6 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
 
                         // Validate user defaults key set
                         Set<String> userDefaultKeys = userDefaults.keySet();
-                        List<String> requiredParams = DefaultUseCases.getRequiredParamsByUseCaseName(useCase);
                         if (!userDefaultKeys.containsAll(requiredParams)) {
                             requiredParams.removeAll(userDefaultKeys);
                             throw new FlowFrameworkException(

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -129,11 +129,13 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                 useCaseDefaultsMap = ParseUtils.parseJsonFileToStringToStringMap("/" + defaultsFilePath);
                 List<String> requiredParams = DefaultUseCases.getRequiredParamsByUseCaseName(useCase);
 
-                if (request.hasContent() == false && requiredParams.size() != 0) {
-                    throw new FlowFrameworkException(
-                        "Missing the following required parameters for use case [" + useCase + "] : " + requiredParams.toString(),
-                        RestStatus.BAD_REQUEST
-                    );
+                if (request.hasContent() == false) {
+                    if (requiredParams.size() != 0) {
+                        throw new FlowFrameworkException(
+                            "Missing the following required parameters for use case [" + useCase + "] : " + requiredParams.toString(),
+                            RestStatus.BAD_REQUEST
+                        );
+                    }
                 } else {
                     try {
                         XContentParser parser = request.contentParser();

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -132,6 +133,18 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                         XContentParser parser = request.contentParser();
                         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                         Map<String, Object> userDefaults = ParseUtils.parseStringToObjectMap(parser);
+
+                        // Validate user defaults key set
+                        Set<String> userDefaultKeys = userDefaults.keySet();
+                        List<String> requiredParams = DefaultUseCases.getRequiredParamsByUseCaseName(useCase);
+                        if (!userDefaultKeys.containsAll(requiredParams)) {
+                            requiredParams.removeAll(userDefaultKeys);
+                            throw new FlowFrameworkException(
+                                "Missing the following required parameters for use case [" + useCase + "] : " + requiredParams.toString(),
+                                RestStatus.BAD_REQUEST
+                            );
+                        }
+
                         // updates the default params with anything user has given that matches
                         for (Map.Entry<String, Object> userDefaultsEntry : userDefaults.entrySet()) {
                             String key = userDefaultsEntry.getKey();
@@ -141,13 +154,16 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                             }
                         }
                     } catch (Exception ex) {
-                        RestStatus status = ex instanceof IOException ? RestStatus.BAD_REQUEST : ExceptionsHelper.status(ex);
-                        String errorMessage =
-                            "failure parsing request body when a use case is given, make sure to provide a map with values that are either Strings, Arrays, or Map of Strings to Strings";
-                        logger.error(errorMessage, ex);
-                        throw new FlowFrameworkException(errorMessage, status);
+                        if (ex instanceof FlowFrameworkException) {
+                            throw (FlowFrameworkException) ex;
+                        } else {
+                            RestStatus status = ex instanceof IOException ? RestStatus.BAD_REQUEST : ExceptionsHelper.status(ex);
+                            String errorMessage =
+                                "failure parsing request body when a use case is given, make sure to provide a map with values that are either Strings, Arrays, or Map of Strings to Strings";
+                            logger.error(errorMessage, ex);
+                            throw new FlowFrameworkException(errorMessage, status);
+                        }
                     }
-
                 }
 
                 useCaseTemplateFileInStringFormat = (String) ParseUtils.conditionallySubstitute(

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -345,16 +345,24 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
      * Helper method to invoke the Create Workflow Rest Action without validation
      * @param client the rest client
      * @param useCase the usecase to create
+     * @param the required params
      * @throws Exception if the request fails
      * @return a rest response
      */
-    protected Response createWorkflowWithUseCase(RestClient client, String useCase) throws Exception {
+    protected Response createWorkflowWithUseCase(RestClient client, String useCase, List<String> params) throws Exception {
+
+        StringBuilder sb = new StringBuilder();
+        for (String param : params) {
+            sb.append("\"" + param + "\" : \"\"").append(",");
+        }
+        if (params.size() != 0) sb.deleteCharAt(sb.length() - 1);
+
         return TestHelpers.makeRequest(
             client,
             "POST",
             WORKFLOW_URI + "?validation=off&use_case=" + useCase,
             Collections.emptyMap(),
-            "{}",
+            "{" + sb.toString() + "}",
             null
         );
     }

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -355,7 +355,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
         for (String param : params) {
             sb.append('"').append(param).append("\" : \"\",");
         }
-        if (params.isEmpty()) {
+        if (!params.isEmpty()) {
             sb.deleteCharAt(sb.length() - 1);
         }
 

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -353,9 +353,11 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
 
         StringBuilder sb = new StringBuilder();
         for (String param : params) {
-            sb.append("\"" + param + "\" : \"\"").append(",");
+            sb.append('"').append(param).append("\" : \"\",");
         }
-        if (params.size() != 0) sb.deleteCharAt(sb.length() - 1);
+        if (params.isEmpty()) {
+            sb.deleteCharAt(sb.length() - 1);
+        }
 
         return TestHelpers.makeRequest(
             client,

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -43,6 +43,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import static org.opensearch.flowframework.common.CommonValue.CREATE_CONNECTOR_CREDENTIAL_KEY;
+import static org.opensearch.flowframework.common.CommonValue.CREATE_INGEST_PIPELINE_MODEL_ID;
 import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
 
@@ -406,7 +408,7 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
     public void testDefaultCohereUseCase() throws Exception {
 
         // Hit Create Workflow API with original template
-        Response response = createWorkflowWithUseCase(client(), "cohere_embedding_model_deploy");
+        Response response = createWorkflowWithUseCase(client(), "cohere_embedding_model_deploy", List.of(CREATE_CONNECTOR_CREDENTIAL_KEY));
         assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
 
         Map<String, Object> responseMap = entityAsMap(response);
@@ -442,8 +444,12 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
     }
 
     public void testDefaultSemanticSearchUseCaseWithFailureExpected() throws Exception {
-        // Hit Create Workflow API with original template
-        Response response = createWorkflowWithUseCase(client(), "semantic_search");
+        // Hit Create Workflow API with original template without required params
+        Response response = createWorkflowWithUseCase(client(), "semantic_search", Collections.emptyList());
+        assertEquals(RestStatus.BAD_REQUEST, TestHelpers.restStatus(response));
+
+        // Pass in required params
+        response = createWorkflowWithUseCase(client(), "semantic_search", List.of(CREATE_INGEST_PIPELINE_MODEL_ID));
         assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
 
         Map<String, Object> responseMap = entityAsMap(response);
@@ -483,7 +489,11 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
             .collect(Collectors.toSet());
 
         for (String useCaseName : allUseCaseNames) {
-            Response response = createWorkflowWithUseCase(client(), useCaseName);
+            Response response = createWorkflowWithUseCase(
+                client(),
+                useCaseName,
+                DefaultUseCases.getRequiredParamsByUseCaseName(useCaseName)
+            );
             assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
 
             Map<String, Object> responseMap = entityAsMap(response);

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -445,11 +445,17 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
 
     public void testDefaultSemanticSearchUseCaseWithFailureExpected() throws Exception {
         // Hit Create Workflow API with original template without required params
-        Response response = createWorkflowWithUseCase(client(), "semantic_search", Collections.emptyList());
-        assertEquals(RestStatus.BAD_REQUEST, TestHelpers.restStatus(response));
+        ResponseException exception = expectThrows(
+            ResponseException.class,
+            () -> createWorkflowWithUseCase(client(), "semantic_search", Collections.emptyList())
+        );
+        assertTrue(
+            exception.getMessage()
+                .contains("Missing the following required parameters for use case [semantic_search] : [create_ingest_pipeline.model_id]")
+        );
 
         // Pass in required params
-        response = createWorkflowWithUseCase(client(), "semantic_search", List.of(CREATE_INGEST_PIPELINE_MODEL_ID));
+        Response response = createWorkflowWithUseCase(client(), "semantic_search", List.of(CREATE_INGEST_PIPELINE_MODEL_ID));
         assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
 
         Map<String, Object> responseMap = entityAsMap(response);

--- a/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
@@ -141,7 +141,7 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
             .withPath(this.createWorkflowPath)
             .withParams(Map.of(USE_CASE, DefaultUseCases.COHERE_EMBEDDING_MODEL_DEPLOY.getUseCaseName()))
-            .withContent(new BytesArray(""), MediaTypeRegistry.JSON)
+            .withContent(new BytesArray("{\"" + CREATE_CONNECTOR_CREDENTIAL_KEY + "\":\"\"}"), MediaTypeRegistry.JSON)
             .build();
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
         doAnswer(invocation -> {

--- a/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.opensearch.flowframework.common.CommonValue.CREATE_CONNECTOR_CREDENTIAL_KEY;
 import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW;
 import static org.opensearch.flowframework.common.CommonValue.USE_CASE;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
@@ -157,7 +158,7 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
             .withPath(this.createWorkflowPath)
             .withParams(Map.of(USE_CASE, DefaultUseCases.COHERE_EMBEDDING_MODEL_DEPLOY.getUseCaseName()))
-            .withContent(new BytesArray("{\"key\":\"step\"}"), MediaTypeRegistry.JSON)
+            .withContent(new BytesArray("{\"" + CREATE_CONNECTOR_CREDENTIAL_KEY + "\":\"step\"}"), MediaTypeRegistry.JSON)
             .build();
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
         doAnswer(invocation -> {


### PR DESCRIPTION
### Description
Adds a requiredParams field to the DefaultUseCases enum which is used validate the given request body of default use case request

Examples :
```
curl -i -XPOST "http://localhost:9200/_plugins/_flow_framework/workflow?use_case=semantic_search_with_cohere_embedding_query_enricher&provision=true" -H "Content-Type:application/json" -d '{"test_value" : "QFaXLdVUFfk7XYxqSOtweCvVxXS2l3Jsw1DeKhuR"}'
HTTP/1.1 400 Bad Request
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 157

{"error":"Missing the following required parameters for use case [semantic_search_with_cohere_embedding_query_enricher] : [create_connector.credential.key]"}

curl -i -XPOST "http://localhost:9200/_plugins/_flow_framework/workflow?use_case=multimodal_search_with_bedrock_titan&provision=true&?pretty" -H "Content-Type:application/json" -d '{"test_value" : "QFaXLdVUFfk7XYxqSOtweCvVxXS2l3Jsw1DeKhuR"}'
HTTP/1.1 400 Bad Request
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 231

{"error":"Missing the following required parameters for use case [multimodal_search_with_bedrock_titan] : [create_connector.credential.access_key, create_connector.credential.secret_key, create_connector.credential.session_token]"}
```

### Issues Resolved
https://github.com/opensearch-project/flow-framework/issues/655

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
