### PR TITLE
Fix testDefaultSemanticSearchUseCaseWithFailureExpected

### DIFF
--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -471,21 +471,9 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         }
 
         assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
-
-        // Distribution build contains all plugins, checking if plugins are part of the integration test cluster
-        List<String> plugins = catPlugins();
-        if (plugins.contains("opensearch-knn") && plugins.contains("opensearch-neural-search")) {
-            getAndAssertWorkflowStatus(client(), workflowId, State.PROVISIONING, ProvisioningProgress.IN_PROGRESS);
-        } else {
-            // expecting a failure since there is no neural-search plugin in cluster to provide text-embedding processor
-            getAndAssertWorkflowStatus(client(), workflowId, State.FAILED, ProvisioningProgress.FAILED);
-            String error = getAndWorkflowStatusError(client(), workflowId);
-            assertTrue(
-                error.contains(
-                    "org.opensearch.flowframework.exception.WorkflowStepException during step create_ingest_pipeline, restStatus: BAD_REQUEST"
-                )
-            );
-        }
+        getAndAssertWorkflowStatus(client(), workflowId, State.FAILED, ProvisioningProgress.FAILED);
+        String error = getAndWorkflowStatusError(client(), workflowId);
+        assertTrue(error.contains("org.opensearch.flowframework.exception.WorkflowStepException during step create_ingest_pipeline"));
     }
 
     public void testAllDefaultUseCasesCreation() throws Exception {


### PR DESCRIPTION
### Description
Removes catPlugin check for neural and knn plugins since the request will fail due to an empty model ID being used for the default semantic search use case

### Issues Resolved
Resolves 2.14 build failure described by https://github.com/opensearch-project/flow-framework/issues/662#issuecomment-2058207810

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
