### PR TITLE
Allow strings for boolean workflow step parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 - Add guardrails to default use case params ([#658](https://github.com/opensearch-project/flow-framework/pull/658))
+- Allow strings for boolean workflow step parameters ([#671](https://github.com/opensearch-project/flow-framework/pull/671))
+
 ### Bug Fixes
 - Reset workflow state to initial state after successful deprovision ([#635](https://github.com/opensearch-project/flow-framework/pull/635))
 - Silently ignore content on APIs that don't require it ([#639](https://github.com/opensearch-project/flow-framework/pull/639))

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -17,8 +17,10 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTask;
@@ -31,6 +33,7 @@ import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.AfterClass;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -40,6 +43,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
 import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
@@ -282,5 +286,119 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             assertTrue(ex.getCause().getMessage().contains(s));
         }
         assertTrue(ex.getCause().getMessage().endsWith("] in workflow [test-id] node [test-node-id]"));
+    }
+
+    public void testBoolParse() throws IOException, ExecutionException, InterruptedException {
+        String taskId = "abcd";
+        String modelId = "model-id";
+        String status = MLTaskState.COMPLETED.name();
+
+        // Stub register for success case
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterModelResponse> actionListener = invocation.getArgument(1);
+            MLRegisterModelResponse output = new MLRegisterModelResponse(taskId, status, null);
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
+
+        // Stub getTask for success case
+        doAnswer(invocation -> {
+            ActionListener<MLTask> actionListener = invocation.getArgument(1);
+            MLTask output = new MLTask(
+                taskId,
+                modelId,
+                null,
+                null,
+                MLTaskState.COMPLETED,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false
+            );
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).getTask(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateResponseListener = invocation.getArgument(4);
+            updateResponseListener.onResponse(new UpdateResponse(new ShardId(WORKFLOW_STATE_INDEX, "", 1), "id", -2, 0, 0, UPDATED));
+            return null;
+        }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
+
+        WorkflowData boolStringWorkflowData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "xyz"),
+                Map.entry("version", "1.0.0"),
+                Map.entry("description", "description"),
+                Map.entry("function_name", "SPARSE_TOKENIZE"),
+                Map.entry("model_format", "TORCH_SCRIPT"),
+                Map.entry(MODEL_GROUP_ID, "abcdefg"),
+                Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
+                Map.entry("model_type", "bert"),
+                Map.entry("embedding_dimension", "384"),
+                Map.entry("framework_type", "sentence_transformers"),
+                Map.entry("url", "something.com"),
+                Map.entry(DEPLOY_FIELD, "false")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        PlainActionFuture<WorkflowData> future = registerLocalModelStep.execute(
+            boolStringWorkflowData.getNodeId(),
+            boolStringWorkflowData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        future.actionGet();
+
+        verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
+        verify(machineLearningNodeClient, times(1)).getTask(any(), any());
+
+        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
+        assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
+    }
+
+    public void testBoolParseFail() throws IOException, ExecutionException, InterruptedException {
+        WorkflowData boolStringWorkflowData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "xyz"),
+                Map.entry("version", "1.0.0"),
+                Map.entry("description", "description"),
+                Map.entry("function_name", "SPARSE_TOKENIZE"),
+                Map.entry("model_format", "TORCH_SCRIPT"),
+                Map.entry(MODEL_GROUP_ID, "abcdefg"),
+                Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
+                Map.entry("model_type", "bert"),
+                Map.entry("embedding_dimension", "384"),
+                Map.entry("framework_type", "sentence_transformers"),
+                Map.entry("url", "something.com"),
+                Map.entry(DEPLOY_FIELD, "no")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        PlainActionFuture<WorkflowData> future = registerLocalModelStep.execute(
+            boolStringWorkflowData.getNodeId(),
+            boolStringWorkflowData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        assertTrue(future.isDone());
+        ExecutionException e = assertThrows(ExecutionException.class, () -> future.get());
+        assertEquals(WorkflowStepException.class, e.getCause().getClass());
+        WorkflowStepException w = (WorkflowStepException) e.getCause();
+        assertEquals("Failed to parse value [no] as only [true] or [false] are allowed.", w.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, w.getRestStatus());
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
@@ -182,6 +182,35 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
 
         assertEquals(modelId, future.get().getContent().get(MODEL_ID));
         assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
+
+        WorkflowData boolStringWorkflowData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "xyz"),
+                Map.entry("version", "1.0.0"),
+                Map.entry("model_format", "TORCH_SCRIPT"),
+                Map.entry(MODEL_GROUP_ID, "abcdefg"),
+                Map.entry("description", "aiwoeifjoaijeofiwe"),
+                Map.entry(DEPLOY_FIELD, "false")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        future = registerLocalPretrainedModelStep.execute(
+            boolStringWorkflowData.getNodeId(),
+            boolStringWorkflowData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        future.actionGet();
+
+        verify(machineLearningNodeClient, times(2)).register(any(MLRegisterModelInput.class), any());
+        verify(machineLearningNodeClient, times(2)).getTask(any(), any());
+
+        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
+        assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
     }
 
     public void testRegisterLocalPretrainedModelFailure() {
@@ -271,78 +300,6 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             assertTrue(ex.getCause().getMessage().contains(s));
         }
         assertTrue(ex.getCause().getMessage().endsWith("] in workflow [test-id] node [test-node-id]"));
-    }
-
-    public void testBoolParse() throws IOException, ExecutionException, InterruptedException {
-        String taskId = "abcd";
-        String modelId = "model-id";
-        String status = MLTaskState.COMPLETED.name();
-
-        // Stub register for success case
-        doAnswer(invocation -> {
-            ActionListener<MLRegisterModelResponse> actionListener = invocation.getArgument(1);
-            MLRegisterModelResponse output = new MLRegisterModelResponse(taskId, status, null);
-            actionListener.onResponse(output);
-            return null;
-        }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
-
-        // Stub getTask for success case
-        doAnswer(invocation -> {
-            ActionListener<MLTask> actionListener = invocation.getArgument(1);
-            MLTask output = new MLTask(
-                taskId,
-                modelId,
-                null,
-                null,
-                MLTaskState.COMPLETED,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                false
-            );
-            actionListener.onResponse(output);
-            return null;
-        }).when(machineLearningNodeClient).getTask(any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<UpdateResponse> updateResponseListener = invocation.getArgument(4);
-            updateResponseListener.onResponse(new UpdateResponse(new ShardId(WORKFLOW_STATE_INDEX, "", 1), "id", -2, 0, 0, UPDATED));
-            return null;
-        }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
-
-        WorkflowData boolStringWorkflowData = new WorkflowData(
-            Map.ofEntries(
-                Map.entry("name", "xyz"),
-                Map.entry("version", "1.0.0"),
-                Map.entry("model_format", "TORCH_SCRIPT"),
-                Map.entry(MODEL_GROUP_ID, "abcdefg"),
-                Map.entry("description", "aiwoeifjoaijeofiwe"),
-                Map.entry(DEPLOY_FIELD, "false")
-            ),
-            "test-id",
-            "test-node-id"
-        );
-
-        PlainActionFuture<WorkflowData> future = registerLocalPretrainedModelStep.execute(
-            boolStringWorkflowData.getNodeId(),
-            boolStringWorkflowData,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap()
-        );
-
-        future.actionGet();
-
-        verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
-        verify(machineLearningNodeClient, times(1)).getTask(any(), any());
-
-        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
-        assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
     }
 
     public void testBoolParseFail() throws IOException, ExecutionException, InterruptedException {

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
@@ -185,6 +185,37 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
 
         assertEquals(modelId, future.get().getContent().get(MODEL_ID));
         assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
+
+        WorkflowData boolStringWorkflowData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "xyz"),
+                Map.entry("version", "1.0.0"),
+                Map.entry("description", "description"),
+                Map.entry("function_name", "SPARSE_TOKENIZE"),
+                Map.entry("model_format", "TORCH_SCRIPT"),
+                Map.entry(MODEL_GROUP_ID, "abcdefg"),
+                Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
+                Map.entry("url", "something.com"),
+                Map.entry(DEPLOY_FIELD, "false")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+        future = registerLocalSparseEncodingModelStep.execute(
+            boolStringWorkflowData.getNodeId(),
+            boolStringWorkflowData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        future.actionGet();
+
+        verify(machineLearningNodeClient, times(2)).register(any(MLRegisterModelInput.class), any());
+        verify(machineLearningNodeClient, times(2)).getTask(any(), any());
+
+        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
+        assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
     }
 
     public void testRegisterLocalSparseEncodingModelFailure() {
@@ -274,80 +305,6 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             assertTrue(ex.getCause().getMessage().contains(s));
         }
         assertTrue(ex.getCause().getMessage().endsWith("] in workflow [test-id] node [test-node-id]"));
-    }
-
-    public void testBoolParse() throws IOException, ExecutionException, InterruptedException {
-        String taskId = "abcd";
-        String modelId = "model-id";
-        String status = MLTaskState.COMPLETED.name();
-
-        // Stub register for success case
-        doAnswer(invocation -> {
-            ActionListener<MLRegisterModelResponse> actionListener = invocation.getArgument(1);
-            MLRegisterModelResponse output = new MLRegisterModelResponse(taskId, status, null);
-            actionListener.onResponse(output);
-            return null;
-        }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
-
-        // Stub getTask for success case
-        doAnswer(invocation -> {
-            ActionListener<MLTask> actionListener = invocation.getArgument(1);
-            MLTask output = new MLTask(
-                taskId,
-                modelId,
-                null,
-                null,
-                MLTaskState.COMPLETED,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                false
-            );
-            actionListener.onResponse(output);
-            return null;
-        }).when(machineLearningNodeClient).getTask(any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<UpdateResponse> updateResponseListener = invocation.getArgument(4);
-            updateResponseListener.onResponse(new UpdateResponse(new ShardId(WORKFLOW_STATE_INDEX, "", 1), "id", -2, 0, 0, UPDATED));
-            return null;
-        }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
-
-        WorkflowData boolStringWorkflowData = new WorkflowData(
-            Map.ofEntries(
-                Map.entry("name", "xyz"),
-                Map.entry("version", "1.0.0"),
-                Map.entry("description", "description"),
-                Map.entry("function_name", "SPARSE_TOKENIZE"),
-                Map.entry("model_format", "TORCH_SCRIPT"),
-                Map.entry(MODEL_GROUP_ID, "abcdefg"),
-                Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
-                Map.entry("url", "something.com"),
-                Map.entry(DEPLOY_FIELD, "false")
-            ),
-            "test-id",
-            "test-node-id"
-        );
-        PlainActionFuture<WorkflowData> future = registerLocalSparseEncodingModelStep.execute(
-            boolStringWorkflowData.getNodeId(),
-            boolStringWorkflowData,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap()
-        );
-
-        future.actionGet();
-
-        verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
-        verify(machineLearningNodeClient, times(1)).getTask(any(), any());
-
-        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
-        assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
     }
 
     public void testBoolParseFail() throws IOException, ExecutionException, InterruptedException {

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
@@ -17,8 +17,10 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTask;
@@ -31,6 +33,7 @@ import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.AfterClass;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -40,6 +43,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
 import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
@@ -270,5 +274,111 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             assertTrue(ex.getCause().getMessage().contains(s));
         }
         assertTrue(ex.getCause().getMessage().endsWith("] in workflow [test-id] node [test-node-id]"));
+    }
+
+    public void testBoolParse() throws IOException, ExecutionException, InterruptedException {
+        String taskId = "abcd";
+        String modelId = "model-id";
+        String status = MLTaskState.COMPLETED.name();
+
+        // Stub register for success case
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterModelResponse> actionListener = invocation.getArgument(1);
+            MLRegisterModelResponse output = new MLRegisterModelResponse(taskId, status, null);
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
+
+        // Stub getTask for success case
+        doAnswer(invocation -> {
+            ActionListener<MLTask> actionListener = invocation.getArgument(1);
+            MLTask output = new MLTask(
+                taskId,
+                modelId,
+                null,
+                null,
+                MLTaskState.COMPLETED,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false
+            );
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).getTask(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateResponseListener = invocation.getArgument(4);
+            updateResponseListener.onResponse(new UpdateResponse(new ShardId(WORKFLOW_STATE_INDEX, "", 1), "id", -2, 0, 0, UPDATED));
+            return null;
+        }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
+
+        WorkflowData boolStringWorkflowData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "xyz"),
+                Map.entry("version", "1.0.0"),
+                Map.entry("description", "description"),
+                Map.entry("function_name", "SPARSE_TOKENIZE"),
+                Map.entry("model_format", "TORCH_SCRIPT"),
+                Map.entry(MODEL_GROUP_ID, "abcdefg"),
+                Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
+                Map.entry("url", "something.com"),
+                Map.entry(DEPLOY_FIELD, "false")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+        PlainActionFuture<WorkflowData> future = registerLocalSparseEncodingModelStep.execute(
+            boolStringWorkflowData.getNodeId(),
+            boolStringWorkflowData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        future.actionGet();
+
+        verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
+        verify(machineLearningNodeClient, times(1)).getTask(any(), any());
+
+        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
+        assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
+    }
+
+    public void testBoolParseFail() throws IOException, ExecutionException, InterruptedException {
+        WorkflowData boolStringWorkflowData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "xyz"),
+                Map.entry("version", "1.0.0"),
+                Map.entry("description", "description"),
+                Map.entry("function_name", "SPARSE_TOKENIZE"),
+                Map.entry("model_format", "TORCH_SCRIPT"),
+                Map.entry(MODEL_GROUP_ID, "abcdefg"),
+                Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
+                Map.entry("url", "something.com"),
+                Map.entry(DEPLOY_FIELD, "no")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+        PlainActionFuture<WorkflowData> future = registerLocalSparseEncodingModelStep.execute(
+            boolStringWorkflowData.getNodeId(),
+            boolStringWorkflowData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        assertTrue(future.isDone());
+        ExecutionException e = assertThrows(ExecutionException.class, () -> future.get());
+        assertEquals(WorkflowStepException.class, e.getCause().getClass());
+        WorkflowStepException w = (WorkflowStepException) e.getCause();
+        assertEquals("Failed to parse value [no] as only [true] or [false] are allowed.", w.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, w.getRestStatus());
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterModelGroupStepTests.java
@@ -14,6 +14,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.AccessMode;
@@ -41,9 +42,14 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class ModelGroupStepTests extends OpenSearchTestCase {
+public class RegisterModelGroupStepTests extends OpenSearchTestCase {
     private WorkflowData inputData;
     private WorkflowData inputDataWithNoName;
+    private WorkflowData boolStringInputData;
+    private WorkflowData badBoolInputData;
+
+    private String modelGroupId = MODEL_GROUP_ID;
+    private String status = MLTaskState.CREATED.name();
 
     @Mock
     MachineLearningNodeClient machineLearningNodeClient;
@@ -67,12 +73,31 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
             "test-node-id"
         );
         inputDataWithNoName = new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id");
+        boolStringInputData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "test"),
+                Map.entry("description", "description"),
+                Map.entry("backend_roles", List.of("role-1")),
+                Map.entry("access_mode", AccessMode.PUBLIC),
+                Map.entry("add_all_backend_roles", "false")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+        badBoolInputData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "test"),
+                Map.entry("description", "description"),
+                Map.entry("backend_roles", List.of("role-1")),
+                Map.entry("access_mode", AccessMode.PUBLIC),
+                Map.entry("add_all_backend_roles", "no")
+            ),
+            "test-id",
+            "test-node-id"
+        );
     }
 
     public void testRegisterModelGroup() throws ExecutionException, InterruptedException, IOException {
-        String modelGroupId = MODEL_GROUP_ID;
-        String status = MLTaskState.CREATED.name();
-
         RegisterModelGroupStep modelGroupStep = new RegisterModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
         @SuppressWarnings("unchecked")
@@ -153,4 +178,54 @@ public class ModelGroupStepTests extends OpenSearchTestCase {
         assertEquals("Missing required inputs [name] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
     }
 
+    public void testBoolParse() throws IOException, ExecutionException, InterruptedException {
+        RegisterModelGroupStep modelGroupStep = new RegisterModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ActionListener<MLRegisterModelGroupResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterModelGroupResponse> actionListener = invocation.getArgument(1);
+            MLRegisterModelGroupResponse output = new MLRegisterModelGroupResponse(modelGroupId, status);
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateResponseListener = invocation.getArgument(4);
+            updateResponseListener.onResponse(new UpdateResponse(new ShardId(WORKFLOW_STATE_INDEX, "", 1), "id", -2, 0, 0, UPDATED));
+            return null;
+        }).when(flowFrameworkIndicesHandler).updateResourceInStateIndex(anyString(), anyString(), anyString(), anyString(), any());
+
+        PlainActionFuture<WorkflowData> future = modelGroupStep.execute(
+            boolStringInputData.getNodeId(),
+            boolStringInputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        assertTrue(future.isDone());
+        assertEquals(modelGroupId, future.get().getContent().get(MODEL_GROUP_ID));
+        assertEquals(status, future.get().getContent().get("model_group_status"));
+    }
+
+    public void testBoolParseFail() throws IOException, ExecutionException, InterruptedException {
+        RegisterModelGroupStep modelGroupStep = new RegisterModelGroupStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+
+        PlainActionFuture<WorkflowData> future = modelGroupStep.execute(
+            badBoolInputData.getNodeId(),
+            badBoolInputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        assertTrue(future.isDone());
+        ExecutionException e = assertThrows(ExecutionException.class, () -> future.get());
+        assertEquals(WorkflowStepException.class, e.getCause().getClass());
+        WorkflowStepException w = (WorkflowStepException) e.getCause();
+        assertEquals("Failed to parse value [no] as only [true] or [false] are allowed.", w.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, w.getRestStatus());
+    }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
@@ -9,6 +9,8 @@
 package org.opensearch.flowframework.workflow;
 
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.ml.common.agent.MLToolSpec;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -18,7 +20,9 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 public class ToolStepTests extends OpenSearchTestCase {
-    private WorkflowData inputData = WorkflowData.EMPTY;
+    private WorkflowData inputData;
+    private WorkflowData boolStringInputData;
+    private WorkflowData badBoolInputData;
 
     @Override
     public void setUp() throws Exception {
@@ -31,6 +35,28 @@ public class ToolStepTests extends OpenSearchTestCase {
                 Map.entry("description", "description"),
                 Map.entry("parameters", Collections.emptyMap()),
                 Map.entry("include_output_in_agent_response", false)
+            ),
+            "test-id",
+            "test-node-id"
+        );
+        boolStringInputData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("type", "type"),
+                Map.entry("name", "name"),
+                Map.entry("description", "description"),
+                Map.entry("parameters", Collections.emptyMap()),
+                Map.entry("include_output_in_agent_response", "false")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+        badBoolInputData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("type", "type"),
+                Map.entry("name", "name"),
+                Map.entry("description", "description"),
+                Map.entry("parameters", Collections.emptyMap()),
+                Map.entry("include_output_in_agent_response", "yes")
             ),
             "test-id",
             "test-node-id"
@@ -50,5 +76,39 @@ public class ToolStepTests extends OpenSearchTestCase {
 
         assertTrue(future.isDone());
         assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
+    }
+
+    public void testBoolParse() throws IOException, ExecutionException, InterruptedException {
+        ToolStep toolStep = new ToolStep();
+
+        PlainActionFuture<WorkflowData> future = toolStep.execute(
+            boolStringInputData.getNodeId(),
+            boolStringInputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        assertTrue(future.isDone());
+        assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
+    }
+
+    public void testBoolParseFail() throws IOException, ExecutionException, InterruptedException {
+        ToolStep toolStep = new ToolStep();
+
+        PlainActionFuture<WorkflowData> future = toolStep.execute(
+            badBoolInputData.getNodeId(),
+            badBoolInputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        assertTrue(future.isDone());
+        ExecutionException e = assertThrows(ExecutionException.class, () -> future.get());
+        assertEquals(WorkflowStepException.class, e.getCause().getClass());
+        WorkflowStepException w = (WorkflowStepException) e.getCause();
+        assertEquals("Failed to parse value [yes] as only [true] or [false] are allowed.", w.getMessage());
+        assertEquals(RestStatus.BAD_REQUEST, w.getRestStatus());
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
@@ -73,22 +73,17 @@ public class ToolStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap()
         );
-
         assertTrue(future.isDone());
         assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
-    }
 
-    public void testBoolParse() throws IOException, ExecutionException, InterruptedException {
-        ToolStep toolStep = new ToolStep();
-
-        PlainActionFuture<WorkflowData> future = toolStep.execute(
+        toolStep = new ToolStep();
+        future = toolStep.execute(
             boolStringInputData.getNodeId(),
             boolStringInputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap()
         );
-
         assertTrue(future.isDone());
         assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
     }


### PR DESCRIPTION
### Description
Allows `"true"` or `"false"` strings when boolean parameters are expected.

### Issues Resolved

Fixes #669 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
