### PR TITLE
Hides user and credential field from search response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 - Reset workflow state to initial state after successful deprovision ([#635](https://github.com/opensearch-project/flow-framework/pull/635))
 - Silently ignore content on APIs that don't require it ([#639](https://github.com/opensearch-project/flow-framework/pull/639))
-
+- Hide user and credential field from search response ([#680](https://github.com/opensearch-project/flow-framework/pull/680))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Reset workflow state to initial state after successful deprovision ([#635](https://github.com/opensearch-project/flow-framework/pull/635))
 - Silently ignore content on APIs that don't require it ([#639](https://github.com/opensearch-project/flow-framework/pull/639))
 - Hide user and credential field from search response ([#680](https://github.com/opensearch-project/flow-framework/pull/680))
+
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -48,8 +48,6 @@ public class CommonValue {
     public static final String CREATE_TIME = "create_time";
     /** The template field name for the user who created the workflow **/
     public static final String USER_FIELD = "user";
-    /** Path to credential field **/
-    public static final String PATH_TO_CREDENTIAL_FIELD = "workflows.provision.nodes.user_inputs.credential";
     /** The created time field */
     public static final String CREATED_TIME = "created_time";
     /** The last updated time field */

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -48,6 +48,8 @@ public class CommonValue {
     public static final String CREATE_TIME = "create_time";
     /** The template field name for the user who created the workflow **/
     public static final String USER_FIELD = "user";
+    /** Path to credential field **/
+    public static final String PATH_TO_CREDENTIAL_FIELD = "workflows.provision.nodes.user_inputs.credential";
     /** The created time field */
     public static final String CREATED_TIME = "created_time";
     /** The last updated time field */

--- a/src/main/java/org/opensearch/flowframework/rest/AbstractSearchWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/AbstractSearchWorkflowAction.java
@@ -31,7 +31,6 @@ import java.util.List;
 
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
-import static org.opensearch.flowframework.util.RestHandlerUtils.getSourceContext;
 
 /**
  * Abstract class to handle search request.
@@ -85,7 +84,6 @@ public abstract class AbstractSearchWorkflowAction<T extends ToXContentObject> e
         }
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.parseXContent(request.contentOrSourceParamParser());
-        searchSourceBuilder.fetchSource(getSourceContext(request, searchSourceBuilder));
         searchSourceBuilder.seqNoAndPrimaryTerm(true).version(true);
         searchSourceBuilder.timeout(flowFrameworkSettings.getRequestTimeout());
 

--- a/src/main/java/org/opensearch/flowframework/rest/AbstractSearchWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/AbstractSearchWorkflowAction.java
@@ -23,17 +23,13 @@ import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestResponse;
 import org.opensearch.rest.action.RestResponseListener;
-import org.opensearch.script.Script;
-import org.opensearch.script.ScriptType;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
-import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
 import static org.opensearch.flowframework.util.RestHandlerUtils.getSourceContext;
 
@@ -92,19 +88,6 @@ public abstract class AbstractSearchWorkflowAction<T extends ToXContentObject> e
         searchSourceBuilder.fetchSource(getSourceContext(request, searchSourceBuilder));
         searchSourceBuilder.seqNoAndPrimaryTerm(true).version(true);
         searchSourceBuilder.timeout(flowFrameworkSettings.getRequestTimeout());
-
-        // Apply credential filter when searching templates
-        if (index.equals(GLOBAL_CONTEXT_INDEX)) {
-            searchSourceBuilder.scriptField(
-                "filter",
-                new Script(
-                    ScriptType.INLINE,
-                    "painless",
-                    "def filteredSource = new HashMap(params._source); def workflows = filteredSource.get(\"workflows\"); if (workflows != null) { def provision = workflows.get(\"provision\"); if (provision != null) { def nodes = provision.get(\"nodes\"); if (nodes != null) { for (node in nodes) { def userInputs = node.get(\"user_inputs\"); if (userInputs != null) { userInputs.remove(\"credential\"); } } } } } return filteredSource;",
-                    Collections.emptyMap()
-                )
-            );
-        }
 
         SearchRequest searchRequest = new SearchRequest().source(searchSourceBuilder).indices(index);
         return channel -> client.execute(actionType, searchRequest, search(channel));

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowTransportAction.java
@@ -80,7 +80,7 @@ public class GetWorkflowTransportAction extends HandledTransportAction<WorkflowR
                         listener.onFailure(new FlowFrameworkException(errorMessage, RestStatus.NOT_FOUND));
                     } else {
                         // Remove any credential from response
-                        Template template = encryptorUtils.redactTemplateCredentials(Template.parse(response.getSourceAsString()));
+                        Template template = encryptorUtils.redactTemplateSecuredFields(Template.parse(response.getSourceAsString()));
                         listener.onResponse(new GetWorkflowResponse(template));
                     }
                 }, exception -> {

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowTransportAction.java
@@ -79,7 +79,7 @@ public class GetWorkflowTransportAction extends HandledTransportAction<WorkflowR
                         logger.error(errorMessage);
                         listener.onFailure(new FlowFrameworkException(errorMessage, RestStatus.NOT_FOUND));
                     } else {
-                        // Remove any credential from response
+                        // Remove any secured field from response
                         Template template = encryptorUtils.redactTemplateSecuredFields(Template.parse(response.getSourceAsString()));
                         listener.onResponse(new GetWorkflowResponse(template));
                     }

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowTransportAction.java
@@ -17,12 +17,14 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.util.EncryptorUtils;
+import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -80,7 +82,8 @@ public class GetWorkflowTransportAction extends HandledTransportAction<WorkflowR
                         listener.onFailure(new FlowFrameworkException(errorMessage, RestStatus.NOT_FOUND));
                     } else {
                         // Remove any secured field from response
-                        Template template = encryptorUtils.redactTemplateSecuredFields(Template.parse(response.getSourceAsString()));
+                        User user = ParseUtils.getUserContext(client);
+                        Template template = encryptorUtils.redactTemplateSecuredFields(user, Template.parse(response.getSourceAsString()));
                         listener.onResponse(new GetWorkflowResponse(template));
                     }
                 }, exception -> {

--- a/src/main/java/org/opensearch/flowframework/transport/SearchWorkflowStateTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/SearchWorkflowStateTransportAction.java
@@ -17,9 +17,14 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.util.ParseUtils;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
+
+import static org.opensearch.flowframework.util.RestHandlerUtils.getSourceContext;
 
 /**
  * Transport Action to search workflow states
@@ -45,8 +50,10 @@ public class SearchWorkflowStateTransportAction extends HandledTransportAction<S
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> actionListener) {
         // AccessController should take care of letting the user with right permission to view the workflow
+        User user = ParseUtils.getUserContext(client);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            logger.info("Searching workflow states in global context");
+            SearchSourceBuilder searchSourceBuilder = request.source();
+            searchSourceBuilder.fetchSource(getSourceContext(user, searchSourceBuilder));
             client.search(request, ActionListener.runBefore(actionListener, context::restore));
         } catch (Exception e) {
             logger.error("Failed to search workflow states in global context", e);

--- a/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
@@ -17,6 +17,7 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
@@ -201,10 +202,11 @@ public class EncryptorUtils {
     // TODO : Improve redactTemplateCredentials to redact different fields
     /**
      * Removes the credential fields from a template
+     * @param user User
      * @param template the template
      * @return the redacted template
      */
-    public Template redactTemplateSecuredFields(Template template) {
+    public Template redactTemplateSecuredFields(User user, Template template) {
         Map<String, Workflow> processedWorkflows = new HashMap<>();
 
         for (Map.Entry<String, Workflow> entry : template.workflows().entrySet()) {
@@ -226,6 +228,10 @@ public class EncryptorUtils {
 
             // Add processed workflow nodes to processed workflows
             processedWorkflows.put(entry.getKey(), new Workflow(entry.getValue().userParams(), processedNodes, entry.getValue().edges()));
+        }
+
+        if (ParseUtils.isAdmin(user)) {
+            return new Template.Builder(template).workflows(processedWorkflows).build();
         }
 
         return new Template.Builder(template).user(null).workflows(processedWorkflows).build();

--- a/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
@@ -122,7 +122,7 @@ public class EncryptorUtils {
     /**
      * Applies the given cipher function on template credentials
      * @param template the template to process
-     * @param cipher the encryption/decryption function to apply on credential values
+     * @param cipherFunction the encryption/decryption function to apply on credential values
      * @return template with encrypted credentials
      */
     private Template processTemplateCredentials(Template template, Function<String, String> cipherFunction) {
@@ -204,9 +204,29 @@ public class EncryptorUtils {
      * @param template the template
      * @return the redacted template
      */
-    public Template redactTemplateCredentials(Template template) {
+    public Template redactTemplateSecuredFields(Template template) {
+        Template updatedTemplate = null;
+
+        if (template.getUser() != null) {
+            updatedTemplate = new Template.Builder(template).name(template.name())
+                .description(template.description())
+                .useCase(template.useCase())
+                .templateVersion(template.templateVersion())
+                .user(null)
+                .uiMetadata(template.getUiMetadata())
+                .compatibilityVersion(template.compatibilityVersion())
+                .workflows(template.workflows())
+                .createdTime(template.createdTime())
+                .lastUpdatedTime(template.lastUpdatedTime())
+                .lastProvisionedTime(template.lastProvisionedTime())
+                .build();
+        } else {
+            updatedTemplate = template;
+        }
+
         Map<String, Workflow> processedWorkflows = new HashMap<>();
-        for (Map.Entry<String, Workflow> entry : template.workflows().entrySet()) {
+
+        for (Map.Entry<String, Workflow> entry : updatedTemplate.workflows().entrySet()) {
 
             List<WorkflowNode> processedNodes = new ArrayList<>();
             for (WorkflowNode node : entry.getValue().nodes()) {
@@ -227,7 +247,7 @@ public class EncryptorUtils {
             processedWorkflows.put(entry.getKey(), new Workflow(entry.getValue().userParams(), processedNodes, entry.getValue().edges()));
         }
 
-        return new Template.Builder(template).workflows(processedWorkflows).build();
+        return new Template.Builder(updatedTemplate).workflows(processedWorkflows).build();
     }
 
     /**

--- a/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/EncryptorUtils.java
@@ -205,28 +205,9 @@ public class EncryptorUtils {
      * @return the redacted template
      */
     public Template redactTemplateSecuredFields(Template template) {
-        Template updatedTemplate = null;
-
-        if (template.getUser() != null) {
-            updatedTemplate = new Template.Builder(template).name(template.name())
-                .description(template.description())
-                .useCase(template.useCase())
-                .templateVersion(template.templateVersion())
-                .user(null)
-                .uiMetadata(template.getUiMetadata())
-                .compatibilityVersion(template.compatibilityVersion())
-                .workflows(template.workflows())
-                .createdTime(template.createdTime())
-                .lastUpdatedTime(template.lastUpdatedTime())
-                .lastProvisionedTime(template.lastProvisionedTime())
-                .build();
-        } else {
-            updatedTemplate = template;
-        }
-
         Map<String, Workflow> processedWorkflows = new HashMap<>();
 
-        for (Map.Entry<String, Workflow> entry : updatedTemplate.workflows().entrySet()) {
+        for (Map.Entry<String, Workflow> entry : template.workflows().entrySet()) {
 
             List<WorkflowNode> processedNodes = new ArrayList<>();
             for (WorkflowNode node : entry.getValue().nodes()) {
@@ -247,7 +228,7 @@ public class EncryptorUtils {
             processedWorkflows.put(entry.getKey(), new Workflow(entry.getValue().userParams(), processedNodes, entry.getValue().edges()));
         }
 
-        return new Template.Builder(updatedTemplate).workflows(processedWorkflows).build();
+        return new Template.Builder(template).user(null).workflows(processedWorkflows).build();
     }
 
     /**

--- a/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
@@ -25,7 +25,6 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.workflow.WorkflowData;
-import org.opensearch.ml.common.agent.LLMSpec;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -47,8 +46,6 @@ import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
-import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 
 /**
  * Utility methods for Template parsing
@@ -114,6 +111,18 @@ public class ParseUtils {
     }
 
     /**
+     * 'all_access' role users are treated as admins.
+     * @param user of the current role
+     * @return boolean if the role is admin
+     */
+    public static boolean isAdmin(User user) {
+        if (user == null) {
+            return false;
+        }
+        return user.getRoles().contains("all_access");
+    }
+
+    /**
      * Builds an XContent object representing a map of String keys to Object values.
      *
      * @param xContentBuilder An XContent builder whose position is at the start of the map object to build
@@ -130,21 +139,6 @@ public class ParseUtils {
             }
         }
         xContentBuilder.endObject();
-    }
-
-    /**
-     * Builds an XContent object representing a LLMSpec.
-     *
-     * @param xContentBuilder An XContent builder whose position is at the start of the map object to build
-     * @param llm             LLMSpec
-     * @throws IOException on a build failure
-     */
-    public static void buildLLMMap(XContentBuilder xContentBuilder, LLMSpec llm) throws IOException {
-        String modelId = llm.getModelId();
-        Map<String, String> parameters = llm.getParameters();
-        xContentBuilder.field(MODEL_ID, modelId);
-        xContentBuilder.field(PARAMETERS_FIELD);
-        buildStringToStringMap(xContentBuilder, parameters);
     }
 
     /**

--- a/src/main/java/org/opensearch/flowframework/util/RestHandlerUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/RestHandlerUtils.java
@@ -9,9 +9,9 @@
 package org.opensearch.flowframework.util;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.opensearch.commons.authuser.User;
 import org.opensearch.core.common.Strings;
 import org.opensearch.flowframework.common.CommonValue;
-import org.opensearch.rest.RestRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 
@@ -36,18 +36,19 @@ public class RestHandlerUtils {
     /**
      * Creates a source context and include/exclude information to be shared based on the user
      *
-     * @param request the REST request
+     * @param user User
      * @param searchSourceBuilder the search request source builder
      * @return modified sources
      */
-    public static FetchSourceContext getSourceContext(RestRequest request, SearchSourceBuilder searchSourceBuilder) {
-        // TODO
-        // 1. check if the request came from dashboard and exclude UI_METADATA
+    public static FetchSourceContext getSourceContext(User user, SearchSourceBuilder searchSourceBuilder) {
         if (searchSourceBuilder.fetchSource() != null) {
             String[] newArray = (String[]) ArrayUtils.addAll(searchSourceBuilder.fetchSource().excludes(), DASHBOARD_EXCLUDES);
             return new FetchSourceContext(true, searchSourceBuilder.fetchSource().includes(), newArray);
         } else {
             // When user does not set the _source field in search api request, searchSourceBuilder.fetchSource becomes null
+            if (ParseUtils.isAdmin(user)) {
+                return new FetchSourceContext(true, Strings.EMPTY_ARRAY, new String[] { PATH_TO_CREDENTIAL_FIELD });
+            }
             return new FetchSourceContext(true, Strings.EMPTY_ARRAY, EXCLUDES);
         }
     }

--- a/src/main/java/org/opensearch/flowframework/util/RestHandlerUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/RestHandlerUtils.java
@@ -9,6 +9,7 @@
 package org.opensearch.flowframework.util;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.opensearch.core.common.Strings;
 import org.opensearch.flowframework.common.CommonValue;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -20,7 +21,12 @@ import org.opensearch.search.fetch.subphase.FetchSourceContext;
 public class RestHandlerUtils {
 
     /** Fields that need to be excluded from the Search Response*/
-    public static final String[] USER_EXCLUDE = new String[] { CommonValue.USER_FIELD, CommonValue.UI_METADATA_FIELD };
+    public static final String[] DASHBOARD_EXCLUDES = new String[] {
+        CommonValue.USER_FIELD,
+        CommonValue.UI_METADATA_FIELD,
+        CommonValue.PATH_TO_CREDENTIAL_FIELD };
+
+    public static final String[] EXCLUDES = new String[] { CommonValue.USER_FIELD, CommonValue.PATH_TO_CREDENTIAL_FIELD };
 
     private RestHandlerUtils() {}
 
@@ -35,10 +41,11 @@ public class RestHandlerUtils {
         // TODO
         // 1. check if the request came from dashboard and exclude UI_METADATA
         if (searchSourceBuilder.fetchSource() != null) {
-            String[] newArray = (String[]) ArrayUtils.addAll(searchSourceBuilder.fetchSource().excludes(), USER_EXCLUDE);
+            String[] newArray = (String[]) ArrayUtils.addAll(searchSourceBuilder.fetchSource().excludes(), DASHBOARD_EXCLUDES);
             return new FetchSourceContext(true, searchSourceBuilder.fetchSource().includes(), newArray);
         } else {
-            return null;
+            // When user does not set the _source field in search api request, searchSourceBuilder.fetchSource becomes null
+            return new FetchSourceContext(true, Strings.EMPTY_ARRAY, EXCLUDES);
         }
     }
 }

--- a/src/main/java/org/opensearch/flowframework/util/RestHandlerUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/RestHandlerUtils.java
@@ -20,13 +20,16 @@ import org.opensearch.search.fetch.subphase.FetchSourceContext;
  */
 public class RestHandlerUtils {
 
+    /** Path to credential field **/
+    private static final String PATH_TO_CREDENTIAL_FIELD = "workflows.provision.nodes.user_inputs.credential";
+
     /** Fields that need to be excluded from the Search Response*/
-    public static final String[] DASHBOARD_EXCLUDES = new String[] {
+    private static final String[] DASHBOARD_EXCLUDES = new String[] {
         CommonValue.USER_FIELD,
         CommonValue.UI_METADATA_FIELD,
-        CommonValue.PATH_TO_CREDENTIAL_FIELD };
+        PATH_TO_CREDENTIAL_FIELD };
 
-    public static final String[] EXCLUDES = new String[] { CommonValue.USER_FIELD, CommonValue.PATH_TO_CREDENTIAL_FIELD };
+    private static final String[] EXCLUDES = new String[] { CommonValue.USER_FIELD, PATH_TO_CREDENTIAL_FIELD };
 
     private RestHandlerUtils() {}
 

--- a/src/test/java/org/opensearch/flowframework/transport/SearchWorkflowStateTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/SearchWorkflowStateTransportActionTests.java
@@ -15,6 +15,7 @@ import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -71,6 +72,8 @@ public class SearchWorkflowStateTransportActionTests extends OpenSearchTestCase 
         @SuppressWarnings("unchecked")
         ActionListener<SearchResponse> listener = mock(ActionListener.class);
         SearchRequest searchRequest = new SearchRequest();
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchRequest.source(searchSourceBuilder);
 
         searchWorkflowStateTransportAction.doExecute(mock(Task.class), searchRequest, listener);
         verify(client, times(1)).search(any(SearchRequest.class), any());

--- a/src/test/java/org/opensearch/flowframework/transport/SearchWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/SearchWorkflowTransportActionTests.java
@@ -15,6 +15,7 @@ import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -34,12 +35,17 @@ public class SearchWorkflowTransportActionTests extends OpenSearchTestCase {
     private SearchWorkflowTransportAction searchWorkflowTransportAction;
     private Client client;
     private ThreadPool threadPool;
+    ThreadContext threadContext;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         this.client = mock(Client.class);
-
+        this.threadPool = mock(ThreadPool.class);
+        Settings settings = Settings.builder().build();
+        threadContext = new ThreadContext(settings);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
         this.searchWorkflowTransportAction = new SearchWorkflowTransportAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
@@ -73,6 +79,8 @@ public class SearchWorkflowTransportActionTests extends OpenSearchTestCase {
         @SuppressWarnings("unchecked")
         ActionListener<SearchResponse> listener = mock(ActionListener.class);
         SearchRequest searchRequest = new SearchRequest();
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchRequest.source(searchSourceBuilder);
 
         searchWorkflowTransportAction.doExecute(mock(Task.class), searchRequest, listener);
         verify(client, times(1)).search(any(SearchRequest.class), any());

--- a/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
@@ -17,6 +17,7 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.TestHelpers;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
@@ -26,6 +27,7 @@ import org.opensearch.flowframework.model.WorkflowNode;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -199,8 +201,10 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
         WorkflowNode node = testTemplate.workflows().get("provision").nodes().get(0);
         assertNotNull(node.userInputs().get(CREDENTIAL_FIELD));
 
+        User user = new User("user", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+
         // Redact template with credential field
-        Template redactedTemplate = encryptorUtils.redactTemplateSecuredFields(testTemplate);
+        Template redactedTemplate = encryptorUtils.redactTemplateSecuredFields(user, testTemplate);
 
         // Validate the credential field has been removed
         WorkflowNode redactedNode = redactedTemplate.workflows().get("provision").nodes().get(0);
@@ -211,10 +215,25 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
         // Confirm user is present in the non-redacted template
         assertNotNull(testTemplate.getUser());
 
+        User user = new User("user", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         // Redact template with user field
-        Template redactedTemplate = encryptorUtils.redactTemplateSecuredFields(testTemplate);
+        Template redactedTemplate = encryptorUtils.redactTemplateSecuredFields(user, testTemplate);
 
         // Validate the user field has been removed
         assertNull(redactedTemplate.getUser());
+    }
+
+    public void testAdminUserTemplate() {
+        // Confirm user is present in the non-redacted template
+        assertNotNull(testTemplate.getUser());
+
+        List<String> roles = new ArrayList<>();
+        roles.add("all_access");
+
+        User user = new User("admin", roles, roles, Collections.emptyList());
+
+        // Redact template with user field
+        Template redactedTemplate = encryptorUtils.redactTemplateSecuredFields(user, testTemplate);
+        assertNotNull(redactedTemplate.getUser());
     }
 }

--- a/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
@@ -200,10 +200,21 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
         assertNotNull(node.userInputs().get(CREDENTIAL_FIELD));
 
         // Redact template with credential field
-        Template redactedTemplate = encryptorUtils.redactTemplateCredentials(testTemplate);
+        Template redactedTemplate = encryptorUtils.redactTemplateSecuredFields(testTemplate);
 
         // Validate the credential field has been removed
         WorkflowNode redactedNode = redactedTemplate.workflows().get("provision").nodes().get(0);
         assertNull(redactedNode.userInputs().get(CREDENTIAL_FIELD));
+    }
+
+    public void testRedactTemplateUserField() {
+        // Confirm user is present in the non-redacted template
+        assertNotNull(testTemplate.getUser());
+
+        // Redact template with user field
+        Template redactedTemplate = encryptorUtils.redactTemplateSecuredFields(testTemplate);
+
+        // Validate the user field has been removed
+        assertNull(redactedTemplate.getUser());
     }
 }

--- a/src/test/java/org/opensearch/flowframework/util/RestHandlerUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/RestHandlerUtilsTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.util;
+
+import org.opensearch.commons.authuser.User;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.fetch.subphase.FetchSourceContext;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class RestHandlerUtilsTests extends OpenSearchTestCase {
+
+    public void testGetSourceContextFromClientWithDashboardExcludes() {
+        SearchSourceBuilder testSearchSourceBuilder = new SearchSourceBuilder();
+        testSearchSourceBuilder.fetchSource(new String[] { "a" }, new String[] { "b" });
+        User user = new User("user", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        FetchSourceContext sourceContext = RestHandlerUtils.getSourceContext(user, testSearchSourceBuilder);
+        assertEquals(sourceContext.excludes().length, 4);
+    }
+
+    public void testGetSourceContextFromClientWithExcludes() {
+        SearchSourceBuilder testSearchSourceBuilder = new SearchSourceBuilder();
+        User user = new User("user", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        FetchSourceContext sourceContext = RestHandlerUtils.getSourceContext(user, testSearchSourceBuilder);
+        assertEquals(sourceContext.excludes().length, 2);
+    }
+
+    public void testGetSourceContextAdminUser() {
+        SearchSourceBuilder testSearchSourceBuilder = new SearchSourceBuilder();
+        List<String> roles = new ArrayList<>();
+        roles.add("all_access");
+
+        User user = new User("admin", roles, roles, Collections.emptyList());
+        FetchSourceContext sourceContext = RestHandlerUtils.getSourceContext(user, testSearchSourceBuilder);
+        assertEquals(sourceContext.excludes().length, 1);
+    }
+
+}


### PR DESCRIPTION
### Description
- Hides user field from Search and Get APIs
- A painless script was added in https://github.com/opensearch-project/flow-framework/pull/504 to filter out the credential field when present and adds a `filter` field instead of `_source` causing more client side work. Handled the credential field filtering in a better way.


Testing

Request
```json
curl -XPOST --insecure -u 'admin:admin' --header 'Content-Type: application/json' "https://localhost:9200/_plugins/_flow_framework/workflow?provision=true" -d '{"name":"Deploy Claude Model","description":"Deploy a model using a connector to Claude","use_case":"PROVISION","version":{"template":"1.0.0","compatibility":["2.12.0","3.0.0"]},"workflows":{"provision":{"nodes":[{"id":"create_claude_connector","type":"create_connector","user_inputs":{"name":"Claude Instant Runtime Connector","version":"1","protocol":"aws_sigv4","description":"The connector to BedRock service for Claude model","actions":[{"headers":{"x-amz-content-sha256":"required","content-type":"application/json"},"method":"POST","request_body":"{ \"prompt\":\"${parameters.prompt}\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature},  \"anthropic_version\":\"${parameters.anthropic_version}\" }","action_type":"predict","url":"https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-instant-v1/invoke"}],"credential":{"access_key":"PUT_YOUR_ACCESS_KEY_HERE","secret_key":"PUT_YOUR_SECRET_KEY_HERE"},"parameters":{"endpoint":"bedrock-runtime.us-west-2.amazonaws.com","content_type":"application/json","auth":"Sig_V4","max_tokens_to_sample":"8000","service_name":"bedrock","temperature":"0.0001","response_filter":"$.completion","region":"us-west-2","anthropic_version":"bedrock-2023-05-31"}}}]}}}'
```

Response of Search API:
```
curl -XGET --insecure -u 'admin:admin' --header 'Content-Type: application/json' "https://localhost:9200/_plugins/_flow_framework/workflow/_search?pretty" -d '{"query":{"match_all":{}}}'
{
  "took" : 44,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : ".plugins-flow-framework-templates",
        "_id" : "YinyEo8B0L4I4ADcw5V9",
        "_version" : 2,
        "_seq_no" : 1,
        "_primary_term" : 1,
        "_score" : 1.0,
        "_source" : {
          "use_case" : "PROVISION",
          "created_time" : 1714009850537,
          "last_updated_time" : 1714009850537,
          "name" : "Deploy Claude Model",
          "description" : "Deploy a model using a connector to Claude",
          "workflows" : {
            "provision" : {
              "nodes" : [
                {
                  "user_inputs" : {
                    "protocol" : "aws_sigv4",
                    "name" : "Claude Instant Runtime Connector",
                    "description" : "The connector to BedRock service for Claude model",
                    "version" : "1",
                    "parameters" : {
                      "endpoint" : "bedrock-runtime.us-west-2.amazonaws.com",
                      "content_type" : "application/json",
                      "auth" : "Sig_V4",
                      "max_tokens_to_sample" : "8000",
                      "service_name" : "bedrock",
                      "temperature" : "0.0001",
                      "response_filter" : "$.completion",
                      "region" : "us-west-2",
                      "anthropic_version" : "bedrock-2023-05-31"
                    },
                    "actions" : [
                      {
                        "headers" : {
                          "x-amz-content-sha256" : "required",
                          "content-type" : "application/json"
                        },
                        "method" : "POST",
                        "request_body" : "{ \"prompt\":\"${parameters.prompt}\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature},  \"anthropic_version\":\"${parameters.anthropic_version}\" }",
                        "action_type" : "predict",
                        "url" : "https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-instant-v1/invoke"
                      }
                    ]
                  },
                  "id" : "create_claude_connector",
                  "type" : "create_connector",
                  "previous_node_inputs" : { }
                }
              ],
              "edges" : [ ],
              "user_params" : { }
            }
          },
          "version" : {
            "template" : "1.0.0",
            "compatibility" : [
              "2.12.0",
              "3.0.0"
            ]
          },
          "last_provisioned_time" : 1714009850887
        }
      }
    ]
  }
}
```

Response of GET API:

```
curl -XGET --insecure -u 'admin:admin' --header 'Content-Type: application/json' "https://localhost:9200/_plugins/_flow_framework/workflow/D0sjE48BLSYJV6YQCQ_K?pretty" 
{
  "name" : "test-1",
  "description" : "test-2",
  "use_case" : "SEMANTIC_SEARCH",
  "version" : {
    "template" : "1.0.0",
    "compatibility" : [
      "2.12.0",
      "3.0.0"
    ]
  },
  "workflows" : {
    "provision" : {
      "user_params" : { },
      "nodes" : [
        {
          "id" : "create_ingest_pipeline",
          "type" : "create_ingest_pipeline",
          "previous_node_inputs" : { },
          "user_inputs" : {
            "configurations" : "{\"description\":\"test-pipeline\",\"processors\":[{\"text_embedding\":{\"field_map\":{\"passage_text\":\"passage_embedding\"},\"model_id\":\"jyKh544B161srMZWwY93\"}}]}",
            "pipeline_id" : "nlp-pipeline"
          }
        }
      ],
      "edges" : [ ]
    }
  },
  "user" : {
    "name" : "admin",
    "backend_roles" : [
      "admin"
    ],
    "roles" : [
      "own_index",
      "all_access"
    ],
    "custom_attribute_names" : [ ],
    "user_requested_tenant" : null
  },
  "created_time" : 1714013014339,
  "last_updated_time" : 1714013014339,
  "last_provisioned_time" : 1714013014615
}
```

### Issues Resolved
Resolves https://github.com/opensearch-project/flow-framework/issues/546

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
