### PR TITLE
Delete workflow state when template is deleted and no resources exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Silently ignore content on APIs that don't require it ([#639](https://github.com/opensearch-project/flow-framework/pull/639))
 - Hide user and credential field from search response ([#680](https://github.com/opensearch-project/flow-framework/pull/680))
 - Throw the correct error message in status API for WorkflowSteps ([#676](https://github.com/opensearch-project/flow-framework/pull/676))
+- Delete workflow state when template is deleted and no resources exist ([#689](https://github.com/opensearch-project/flow-framework/pull/689))
 
 ### Infrastructure
 - Switch macos runner to macos-13 from macos-latest since macos-latest is now arm64 ([#686](https://github.com/opensearch-project/flow-framework/pull/686))

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -15,6 +15,8 @@ import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
@@ -531,7 +533,7 @@ public class FlowFrameworkIndicesHandler {
         ActionListener<UpdateResponse> listener
     ) {
         if (!doesIndexExist(WORKFLOW_STATE_INDEX)) {
-            String errorMessage = "Failed to update document for given workflow due to missing " + WORKFLOW_STATE_INDEX + " index";
+            String errorMessage = "Failed to update document " + documentId + " due to missing " + WORKFLOW_STATE_INDEX + " index";
             logger.error(errorMessage);
             listener.onFailure(new FlowFrameworkException(errorMessage, RestStatus.BAD_REQUEST));
         } else {
@@ -545,6 +547,24 @@ public class FlowFrameworkIndicesHandler {
                 client.update(updateRequest, ActionListener.runBefore(listener, context::restore));
             } catch (Exception e) {
                 String errorMessage = "Failed to update " + WORKFLOW_STATE_INDEX + " entry : " + documentId;
+                logger.error(errorMessage, e);
+                listener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+            }
+        }
+    }
+
+    public void deleteFlowFrameworkSystemIndexDoc(String documentId, ActionListener<DeleteResponse> listener) {
+        if (!doesIndexExist(WORKFLOW_STATE_INDEX)) {
+            String errorMessage = "Failed to delete document " + documentId + " due to missing " + WORKFLOW_STATE_INDEX + " index";
+            logger.error(errorMessage);
+            listener.onFailure(new FlowFrameworkException(errorMessage, RestStatus.BAD_REQUEST));
+        } else {
+            try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+                DeleteRequest deleteRequest = new DeleteRequest(WORKFLOW_STATE_INDEX, documentId);
+                deleteRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                client.delete(deleteRequest, ActionListener.runBefore(listener, context::restore));
+            } catch (Exception e) {
+                String errorMessage = "Failed to delete " + WORKFLOW_STATE_INDEX + " entry : " + documentId;
                 logger.error(errorMessage, e);
                 listener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
             }

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -522,6 +522,51 @@ public class FlowFrameworkIndicesHandler {
     }
 
     /**
+     * Check workflow provisioning state and resources to see if state can be deleted with template
+     *
+     * @param documentId document id
+     * @param canDeleteStateConsumer consumer function which will be true if NOT_STARTED or COMPLETED and no resources
+     * @param listener action listener
+     * @param <T> action listener response type
+     */
+    public <T> void canDeleteState(String documentId, Consumer<Boolean> canDeleteStateConsumer, ActionListener<T> listener) {
+        GetRequest getRequest = new GetRequest(WORKFLOW_STATE_INDEX, documentId);
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            client.get(getRequest, ActionListener.wrap(response -> {
+                context.restore();
+                if (!response.isExists()) {
+                    // no need to delete if it's not there to start with
+                    canDeleteStateConsumer.accept(Boolean.FALSE);
+                    return;
+                }
+                try (
+                    XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())
+                ) {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                    WorkflowState workflowState = WorkflowState.parse(parser);
+                    canDeleteStateConsumer.accept(
+                        workflowState.resourcesCreated().isEmpty()
+                            && !ProvisioningProgress.IN_PROGRESS.equals(
+                                ProvisioningProgress.valueOf(workflowState.getProvisioningProgress())
+                            )
+                    );
+                } catch (Exception e) {
+                    String errorMessage = "Failed to parse workflow state " + documentId;
+                    logger.error(errorMessage, e);
+                    listener.onFailure(new FlowFrameworkException(errorMessage, RestStatus.INTERNAL_SERVER_ERROR));
+                }
+            }, exception -> {
+                logger.error("Failed to get workflow state for {} ", documentId);
+                canDeleteStateConsumer.accept(Boolean.FALSE);
+            }));
+        } catch (Exception e) {
+            String errorMessage = "Failed to retrieve workflow state to check provisioning status";
+            logger.error(errorMessage, e);
+            listener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+        }
+    }
+
+    /**
      * Updates a document in the workflow state index
      * @param documentId the document ID
      * @param updatedFields the fields to update the global state index with

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -526,10 +526,10 @@ public class FlowFrameworkIndicesHandler {
      *
      * @param documentId document id
      * @param canDeleteStateConsumer consumer function which will be true if NOT_STARTED or COMPLETED and no resources
-     * @param listener action listener
+     * @param listener action listener from caller to fail on error
      * @param <T> action listener response type
      */
-    public <T> void canDeleteState(String documentId, Consumer<Boolean> canDeleteStateConsumer, ActionListener<T> listener) {
+    public <T> void canDeleteWorkflowStateDoc(String documentId, Consumer<Boolean> canDeleteStateConsumer, ActionListener<T> listener) {
         GetRequest getRequest = new GetRequest(WORKFLOW_STATE_INDEX, documentId);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             client.get(getRequest, ActionListener.wrap(response -> {

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -598,6 +598,11 @@ public class FlowFrameworkIndicesHandler {
         }
     }
 
+    /**
+     * Deletes a document in the workflow state index
+     * @param documentId the document ID
+     * @param listener action listener
+     */
     public void deleteFlowFrameworkSystemIndexDoc(String documentId, ActionListener<DeleteResponse> listener) {
         if (!doesIndexExist(WORKFLOW_STATE_INDEX)) {
             String errorMessage = "Failed to delete document " + documentId + " due to missing " + WORKFLOW_STATE_INDEX + " index";

--- a/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
@@ -68,7 +68,7 @@ public class DeleteWorkflowTransportAction extends HandledTransportAction<Workfl
             ActionListener<DeleteResponse> stateListener = ActionListener.wrap(response -> {
                 logger.info("Deleted workflow state doc: {}", workflowId);
             }, exception -> { logger.info("Failed to delet workflow state doc: {}", workflowId, exception); });
-            flowFrameworkIndicesHandler.canDeleteState(workflowId, canDelete -> {
+            flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(workflowId, canDelete -> {
                 if (Boolean.TRUE.equals(canDelete)) {
                     flowFrameworkIndicesHandler.deleteFlowFrameworkSystemIndexDoc(workflowId, stateListener);
                 }

--- a/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
@@ -67,7 +67,7 @@ public class DeleteWorkflowTransportAction extends HandledTransportAction<Workfl
 
             ActionListener<DeleteResponse> stateListener = ActionListener.wrap(response -> {
                 logger.info("Deleted workflow state doc: {}", workflowId);
-            }, exception -> { logger.info("Failed to delet workflow state doc: {}", workflowId, exception); });
+            }, exception -> { logger.info("Failed to delete workflow state doc: {}", workflowId, exception); });
             flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(workflowId, canDelete -> {
                 if (Boolean.TRUE.equals(canDelete)) {
                     flowFrameworkIndicesHandler.deleteFlowFrameworkSystemIndexDoc(workflowId, stateListener);

--- a/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
@@ -64,6 +64,15 @@ public class DeleteWorkflowTransportAction extends HandledTransportAction<Workfl
             ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext();
             logger.info("Deleting workflow doc: {}", workflowId);
             client.delete(deleteRequest, ActionListener.runBefore(listener, context::restore));
+
+            ActionListener<DeleteResponse> stateListener = ActionListener.wrap(response -> {
+                logger.info("Deleted workflow state doc: {}", workflowId);
+            }, exception -> { logger.info("Failed to delet workflow state doc: {}", workflowId, exception); });
+            flowFrameworkIndicesHandler.canDeleteState(workflowId, canDelete -> {
+                if (Boolean.TRUE.equals(canDelete)) {
+                    flowFrameworkIndicesHandler.deleteFlowFrameworkSystemIndexDoc(workflowId, stateListener);
+                }
+            }, stateListener);
         } else {
             String errorMessage = "There are no templates in the global context";
             logger.error(errorMessage);

--- a/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
+++ b/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
@@ -292,7 +292,7 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
         assertTrue(exceptionCaptor.getValue().getMessage().contains("Failed to parse workflow state"));
     }
 
-    public void testCanDeleteState() {
+    public void testCanDeleteWorkflowStateDoc() {
         String documentId = randomAlphaOfLength(5);
         @SuppressWarnings("unchecked")
         ActionListener<GetResponse> listener = mock(ActionListener.class);
@@ -318,10 +318,10 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
             return null;
         }).when(client).get(any(GetRequest.class), any());
 
-        flowFrameworkIndicesHandler.canDeleteState(documentId, canDelete -> { assertTrue(canDelete); }, listener);
+        flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(documentId, canDelete -> { assertTrue(canDelete); }, listener);
     }
 
-    public void testCanNotDeleteStateInProgress() {
+    public void testCanNotDeleteWorkflowStateDocInProgress() {
         String documentId = randomAlphaOfLength(5);
         @SuppressWarnings("unchecked")
         ActionListener<GetResponse> listener = mock(ActionListener.class);
@@ -347,10 +347,10 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
             return null;
         }).when(client).get(any(GetRequest.class), any());
 
-        flowFrameworkIndicesHandler.canDeleteState(documentId, canDelete -> { assertFalse(canDelete); }, listener);
+        flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(documentId, canDelete -> { assertFalse(canDelete); }, listener);
     }
 
-    public void testCanNotDeleteStateResourcesExist() {
+    public void testCanNotDeleteWorkflowStateDocResourcesExist() {
         String documentId = randomAlphaOfLength(5);
         @SuppressWarnings("unchecked")
         ActionListener<GetResponse> listener = mock(ActionListener.class);
@@ -376,7 +376,7 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
             return null;
         }).when(client).get(any(GetRequest.class), any());
 
-        flowFrameworkIndicesHandler.canDeleteState(documentId, canDelete -> { assertFalse(canDelete); }, listener);
+        flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(documentId, canDelete -> { assertFalse(canDelete); }, listener);
     }
 
     public void testDoesTemplateExist() {

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkSecureRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkSecureRestApiIT.java
@@ -142,8 +142,8 @@ public class FlowFrameworkSecureRestApiIT extends FlowFrameworkRestTestCase {
         assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
 
         // Invoke status API with failure
-        response = getWorkflowStatus(fullAccessClient(), workflowId, false);
-        assertEquals(RestStatus.NOT_FOUND, TestHelpers.restStatus(response));
+        ResponseException exception = expectThrows(ResponseException.class, () -> getWorkflowStatus(fullAccessClient(), workflowId, false));
+        assertEquals(RestStatus.NOT_FOUND.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
 
         // Recreate the template
         response = createWorkflow(fullAccessClient(), template);
@@ -158,8 +158,8 @@ public class FlowFrameworkSecureRestApiIT extends FlowFrameworkRestTestCase {
         assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
 
         // Invoke status API with failure
-        response = getWorkflowStatus(fullAccessClient(), workflowId, false);
-        assertEquals(RestStatus.NOT_FOUND, TestHelpers.restStatus(response));
+        exception = expectThrows(ResponseException.class, () -> getWorkflowStatus(fullAccessClient(), workflowId, false));
+        assertEquals(RestStatus.NOT_FOUND.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
     }
 
     public void testGetWorkflowStepWithFullAccess() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkSecureRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkSecureRestApiIT.java
@@ -149,8 +149,12 @@ public class FlowFrameworkSecureRestApiIT extends FlowFrameworkRestTestCase {
         response = createWorkflow(fullAccessClient(), template);
         assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
 
+        // Retrieve workflow ID
+        responseMap = entityAsMap(response);
+        String newWorkflowId = (String) responseMap.get(WORKFLOW_ID);
+
         // Invoke status API
-        response = getWorkflowStatus(fullAccessClient(), workflowId, false);
+        response = getWorkflowStatus(fullAccessClient(), newWorkflowId, false);
         assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
 
         // Invoke delete API while state is NOT_STARTED
@@ -158,7 +162,7 @@ public class FlowFrameworkSecureRestApiIT extends FlowFrameworkRestTestCase {
         assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
 
         // Invoke status API with failure
-        exception = expectThrows(ResponseException.class, () -> getWorkflowStatus(fullAccessClient(), workflowId, false));
+        exception = expectThrows(ResponseException.class, () -> getWorkflowStatus(fullAccessClient(), newWorkflowId, false));
         assertEquals(RestStatus.NOT_FOUND.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
     }
 

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkSecureRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkSecureRestApiIT.java
@@ -144,26 +144,6 @@ public class FlowFrameworkSecureRestApiIT extends FlowFrameworkRestTestCase {
         // Invoke status API with failure
         ResponseException exception = expectThrows(ResponseException.class, () -> getWorkflowStatus(fullAccessClient(), workflowId, false));
         assertEquals(RestStatus.NOT_FOUND.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
-
-        // Recreate the template
-        response = createWorkflow(fullAccessClient(), template);
-        assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
-
-        // Retrieve workflow ID
-        responseMap = entityAsMap(response);
-        String newWorkflowId = (String) responseMap.get(WORKFLOW_ID);
-
-        // Invoke status API
-        response = getWorkflowStatus(fullAccessClient(), newWorkflowId, false);
-        assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
-
-        // Invoke delete API while state is NOT_STARTED
-        response = deleteWorkflow(fullAccessClient(), workflowId);
-        assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
-
-        // Invoke status API with failure
-        exception = expectThrows(ResponseException.class, () -> getWorkflowStatus(fullAccessClient(), newWorkflowId, false));
-        assertEquals(RestStatus.NOT_FOUND.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
     }
 
     public void testGetWorkflowStepWithFullAccess() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkSecureRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkSecureRestApiIT.java
@@ -129,13 +129,37 @@ public class FlowFrameworkSecureRestApiIT extends FlowFrameworkRestTestCase {
         response = getWorkflowStatus(fullAccessClient(), workflowId, false);
         assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
 
+        // Invoke delete API while state still exists
+        response = deleteWorkflow(fullAccessClient(), workflowId);
+        assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
+
+        // Invoke status API
+        response = getWorkflowStatus(fullAccessClient(), workflowId, false);
+        assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
+
         // Invoke deprovision API
         response = deprovisionWorkflow(fullAccessClient(), workflowId);
         assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
 
-        // Invoke delete API
+        // Invoke status API with failure
+        response = getWorkflowStatus(fullAccessClient(), workflowId, false);
+        assertEquals(RestStatus.NOT_FOUND, TestHelpers.restStatus(response));
+
+        // Recreate the template
+        response = createWorkflow(fullAccessClient(), template);
+        assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
+
+        // Invoke status API
+        response = getWorkflowStatus(fullAccessClient(), workflowId, false);
+        assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
+
+        // Invoke delete API while state is NOT_STARTED
         response = deleteWorkflow(fullAccessClient(), workflowId);
         assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
+
+        // Invoke status API with failure
+        response = getWorkflowStatus(fullAccessClient(), workflowId, false);
+        assertEquals(RestStatus.NOT_FOUND, TestHelpers.restStatus(response));
     }
 
     public void testGetWorkflowStepWithFullAccess() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
@@ -35,6 +35,7 @@ import org.junit.AfterClass;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import org.mockito.ArgumentCaptor;
 
@@ -121,6 +122,12 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
             responseListener.onResponse(new GetWorkflowStateResponse(state, true));
             return null;
         }).when(client).execute(any(GetWorkflowStateAction.class), any(GetWorkflowStateRequest.class), any());
+
+        doAnswer(invocation -> {
+            Consumer<Boolean> booleanConsumer = invocation.getArgument(1);
+            booleanConsumer.accept(Boolean.TRUE);
+            return null;
+        }).when(flowFrameworkIndicesHandler).doesTemplateExist(anyString(), any(), any());
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onResponse(WorkflowData.EMPTY);


### PR DESCRIPTION
### Description

Deletes workflow state when:
 - template is deleted and no resources exist
 - workflow is deprovisioned and template was already deleted

### Issues Resolved

Fixes #688 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
