### PR TITLE
Add model interface support for remote and local custom models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add guardrails to default use case params ([#658](https://github.com/opensearch-project/flow-framework/pull/658))
 - Allow strings for boolean workflow step parameters ([#671](https://github.com/opensearch-project/flow-framework/pull/671))
 - Add optional delay parameter to no-op step ([#674](https://github.com/opensearch-project/flow-framework/pull/674))
+- Add model interface support for remote and local custom models ([#701](https://github.com/opensearch-project/flow-framework/pull/701))
 
 ### Bug Fixes
 - Reset workflow state to initial state after successful deprovision ([#635](https://github.com/opensearch-project/flow-framework/pull/635))

--- a/release-notes/opensearch-flow-framework.release-notes-2.14.0.0.md
+++ b/release-notes/opensearch-flow-framework.release-notes-2.14.0.0.md
@@ -6,6 +6,7 @@ Compatible with OpenSearch 2.14.0
 - Add guardrails to default use case params ([#658](https://github.com/opensearch-project/flow-framework/pull/658))
 - Allow strings for boolean workflow step parameters ([#671](https://github.com/opensearch-project/flow-framework/pull/671))
 - Add optional delay parameter to no-op step ([#674](https://github.com/opensearch-project/flow-framework/pull/674))
+- Add model interface support for remote and local custom models ([#701](https://github.com/opensearch-project/flow-framework/pull/701))
 
 ### Bug Fixes
 - Reset workflow state to initial state after successful deprovision ([#635](https://github.com/opensearch-project/flow-framework/pull/635))

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -173,7 +173,7 @@ public class CommonValue {
     /** Delay field */
     public static final String DELAY_FIELD = "delay";
     /** Model Interface Field */
-    public static final String MODEL_INTERFACE = "interface";
+    public static final String INTERFACE_FIELD = "interface";
 
     /*
      * Constants associated with resource provisioning / state

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -172,6 +172,8 @@ public class CommonValue {
     public static final String GUARDRAILS_FIELD = "guardrails";
     /** Delay field */
     public static final String DELAY_FIELD = "delay";
+    /** Model Interface Field */
+    public static final String MODEL_INTERFACE = "interface";
 
     /*
      * Constants associated with resource provisioning / state

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
@@ -34,7 +34,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.flowframework.common.CommonValue.CONFIGURATIONS;
 import static org.opensearch.flowframework.common.CommonValue.GUARDRAILS_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_INTERFACE;
+import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_ORDER_FIELD;
 import static org.opensearch.flowframework.util.ParseUtils.buildStringToObjectMap;
 import static org.opensearch.flowframework.util.ParseUtils.buildStringToStringMap;
@@ -165,7 +165,7 @@ public class WorkflowNode implements ToXContentObject {
                                 if (GUARDRAILS_FIELD.equals(inputFieldName)) {
                                     userInputs.put(inputFieldName, Guardrails.parse(parser));
                                     break;
-                                } else if (CONFIGURATIONS.equals(inputFieldName) || MODEL_INTERFACE.equals(inputFieldName)) {
+                                } else if (CONFIGURATIONS.equals(inputFieldName) || INTERFACE_FIELD.equals(inputFieldName)) {
                                     Map<String, Object> configurationsMap = parser.map();
                                     try {
                                         String configurationsString = ParseUtils.parseArbitraryStringToObjectMapToString(configurationsMap);

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
@@ -34,6 +34,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.flowframework.common.CommonValue.CONFIGURATIONS;
 import static org.opensearch.flowframework.common.CommonValue.GUARDRAILS_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_INTERFACE;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_ORDER_FIELD;
 import static org.opensearch.flowframework.util.ParseUtils.buildStringToObjectMap;
 import static org.opensearch.flowframework.util.ParseUtils.buildStringToStringMap;
@@ -164,7 +165,7 @@ public class WorkflowNode implements ToXContentObject {
                                 if (GUARDRAILS_FIELD.equals(inputFieldName)) {
                                     userInputs.put(inputFieldName, Guardrails.parse(parser));
                                     break;
-                                } else if (CONFIGURATIONS.equals(inputFieldName)) {
+                                } else if (CONFIGURATIONS.equals(inputFieldName) || MODEL_INTERFACE.equals(inputFieldName)) {
                                     Map<String, Object> configurationsMap = parser.map();
                                     try {
                                         String configurationsString = ParseUtils.parseArbitraryStringToObjectMapToString(configurationsMap);

--- a/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
@@ -451,4 +451,19 @@ public class ParseUtils {
         matcher.appendTail(result);
         return result.toString();
     }
+
+    public static Map<String, String> convertStringToObjectMapToStringToStringMap(Map<String, Object> stringToObjectMap) throws Exception {
+        try (Jsonb jsonb = JsonbBuilder.create()) {
+            Map<String, String> stringToStringMap = new HashMap<>();
+            for (Map.Entry<String, Object> entry : stringToObjectMap.entrySet()) {
+                Object value = entry.getValue();
+                if (value instanceof String) {
+                    stringToStringMap.put(entry.getKey(), (String) value);
+                } else {
+                    stringToStringMap.put(entry.getKey(), jsonb.toJson(value));
+                }
+            }
+            return stringToStringMap;
+        }
+    }
 }

--- a/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
@@ -452,6 +452,12 @@ public class ParseUtils {
         return result.toString();
     }
 
+    /**
+     * Takes a String to json object map and converts this to a String to String map
+     * @param stringToObjectMap The string to object map to be transformed
+     * @return the transformed map
+     * @throws Exception for issues processing map
+     */
     public static Map<String, String> convertStringToObjectMapToStringToStringMap(Map<String, Object> stringToObjectMap) throws Exception {
         try (Jsonb jsonb = JsonbBuilder.create()) {
             Map<String, String> stringToStringMap = new HashMap<>();

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
@@ -13,8 +13,12 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.Booleans;
+import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.exception.WorkflowStepException;
@@ -30,6 +34,7 @@ import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -42,6 +47,7 @@ import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_INTERFACE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
@@ -116,6 +122,7 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
             String description = (String) inputs.get(DESCRIPTION_FIELD);
             String modelGroupId = (String) inputs.get(MODEL_GROUP_ID);
             String allConfig = (String) inputs.get(ALL_CONFIG);
+            String modelInterface = (String) inputs.get(MODEL_INTERFACE);
             final Boolean deploy = inputs.containsKey(DEPLOY_FIELD) ? Booleans.parseBoolean(inputs.get(DEPLOY_FIELD).toString()) : null;
 
             // Build register model input
@@ -148,6 +155,27 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
             }
             if (modelGroupId != null) {
                 mlInputBuilder.modelGroupId(modelGroupId);
+            }
+            if (modelInterface != null) {
+                try {
+                    // Convert model interface string to map
+                    BytesReference modelInterfaceBytes = new BytesArray(modelInterface.getBytes(StandardCharsets.UTF_8));
+                    Map<String, Object> modelInterfaceAsMap = XContentHelper.convertToMap(
+                        modelInterfaceBytes,
+                        false,
+                        MediaTypeRegistry.JSON
+                    ).v2();
+
+                    // Convert to string to string map
+                    Map<String, String> parameters = ParseUtils.convertStringToObjectMapToStringToStringMap(modelInterfaceAsMap);
+                    mlInputBuilder.modelInterface(parameters);
+
+                } catch (Exception ex) {
+                    String errorMessage = "Failed to create model interface";
+                    logger.error(errorMessage, ex);
+                    registerLocalModelFuture.onFailure(new WorkflowStepException(errorMessage, RestStatus.BAD_REQUEST));
+                }
+
             }
             if (deploy != null) {
                 mlInputBuilder.deployModel(deploy);

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
@@ -45,9 +45,9 @@ import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.EMBEDDING_DIMENSION;
 import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
+import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_INTERFACE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
@@ -122,7 +122,7 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
             String description = (String) inputs.get(DESCRIPTION_FIELD);
             String modelGroupId = (String) inputs.get(MODEL_GROUP_ID);
             String allConfig = (String) inputs.get(ALL_CONFIG);
-            String modelInterface = (String) inputs.get(MODEL_INTERFACE);
+            String modelInterface = (String) inputs.get(INTERFACE_FIELD);
             final Boolean deploy = inputs.containsKey(DEPLOY_FIELD) ? Booleans.parseBoolean(inputs.get(DEPLOY_FIELD).toString()) : null;
 
             // Build register model input

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStep.java
@@ -24,6 +24,7 @@ import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_INTERFACE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.URL;
@@ -71,7 +72,7 @@ public class RegisterLocalCustomModelStep extends AbstractRegisterLocalModelStep
 
     @Override
     protected Set<String> getOptionalKeys() {
-        return Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, ALL_CONFIG, DEPLOY_FIELD);
+        return Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, ALL_CONFIG, DEPLOY_FIELD, MODEL_INTERFACE);
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStep.java
@@ -22,9 +22,9 @@ import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.EMBEDDING_DIMENSION;
 import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
+import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_INTERFACE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.URL;
@@ -72,7 +72,7 @@ public class RegisterLocalCustomModelStep extends AbstractRegisterLocalModelStep
 
     @Override
     protected Set<String> getOptionalKeys() {
-        return Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, ALL_CONFIG, DEPLOY_FIELD, MODEL_INTERFACE);
+        return Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, ALL_CONFIG, DEPLOY_FIELD, INTERFACE_FIELD);
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -14,8 +14,12 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.Booleans;
+import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
@@ -27,12 +31,14 @@ import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.GUARDRAILS_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_INTERFACE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
@@ -76,7 +82,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
         PlainActionFuture<WorkflowData> registerRemoteModelFuture = PlainActionFuture.newFuture();
 
         Set<String> requiredKeys = Set.of(NAME_FIELD, CONNECTOR_ID);
-        Set<String> optionalKeys = Set.of(MODEL_GROUP_ID, DESCRIPTION_FIELD, DEPLOY_FIELD, GUARDRAILS_FIELD);
+        Set<String> optionalKeys = Set.of(MODEL_GROUP_ID, DESCRIPTION_FIELD, DEPLOY_FIELD, GUARDRAILS_FIELD, MODEL_INTERFACE);
 
         try {
             Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
@@ -93,6 +99,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
             String description = (String) inputs.get(DESCRIPTION_FIELD);
             String connectorId = (String) inputs.get(CONNECTOR_ID);
             Guardrails guardRails = (Guardrails) inputs.get(GUARDRAILS_FIELD);
+            String modelInterface = (String) inputs.get(MODEL_INTERFACE);
             final Boolean deploy = inputs.containsKey(DEPLOY_FIELD) ? Booleans.parseBoolean(inputs.get(DEPLOY_FIELD).toString()) : null;
 
             MLRegisterModelInputBuilder builder = MLRegisterModelInput.builder()
@@ -111,6 +118,27 @@ public class RegisterRemoteModelStep implements WorkflowStep {
             }
             if (guardRails != null) {
                 builder.guardrails(guardRails);
+            }
+            if (modelInterface != null) {
+                try {
+                    // Convert model interface string to map
+                    BytesReference modelInterfaceBytes = new BytesArray(modelInterface.getBytes(StandardCharsets.UTF_8));
+                    Map<String, Object> modelInterfaceAsMap = XContentHelper.convertToMap(
+                        modelInterfaceBytes,
+                        false,
+                        MediaTypeRegistry.JSON
+                    ).v2();
+
+                    // Convert to string to string map
+                    Map<String, String> parameters = ParseUtils.convertStringToObjectMapToStringToStringMap(modelInterfaceAsMap);
+                    builder.modelInterface(parameters);
+
+                } catch (Exception ex) {
+                    String errorMessage = "Failed to create model interface";
+                    logger.error(errorMessage, ex);
+                    registerRemoteModelFuture.onFailure(new WorkflowStepException(errorMessage, RestStatus.BAD_REQUEST));
+                }
+
             }
 
             MLRegisterModelInput mlInput = builder.build();

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -38,7 +38,7 @@ import java.util.Set;
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.GUARDRAILS_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_INTERFACE;
+import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
@@ -82,7 +82,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
         PlainActionFuture<WorkflowData> registerRemoteModelFuture = PlainActionFuture.newFuture();
 
         Set<String> requiredKeys = Set.of(NAME_FIELD, CONNECTOR_ID);
-        Set<String> optionalKeys = Set.of(MODEL_GROUP_ID, DESCRIPTION_FIELD, DEPLOY_FIELD, GUARDRAILS_FIELD, MODEL_INTERFACE);
+        Set<String> optionalKeys = Set.of(MODEL_GROUP_ID, DESCRIPTION_FIELD, DEPLOY_FIELD, GUARDRAILS_FIELD, INTERFACE_FIELD);
 
         try {
             Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
@@ -99,7 +99,7 @@ public class RegisterRemoteModelStep implements WorkflowStep {
             String description = (String) inputs.get(DESCRIPTION_FIELD);
             String connectorId = (String) inputs.get(CONNECTOR_ID);
             Guardrails guardRails = (Guardrails) inputs.get(GUARDRAILS_FIELD);
-            String modelInterface = (String) inputs.get(MODEL_INTERFACE);
+            String modelInterface = (String) inputs.get(INTERFACE_FIELD);
             final Boolean deploy = inputs.containsKey(DEPLOY_FIELD) ? Booleans.parseBoolean(inputs.get(DEPLOY_FIELD).toString()) : null;
 
             MLRegisterModelInputBuilder builder = MLRegisterModelInput.builder()

--- a/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
@@ -90,6 +90,12 @@ public class ParseUtilsTests extends OpenSearchTestCase {
         assertEquals("{\"test-1\":{\"test-1\":\"test-1\"}}", parsedMap);
     }
 
+    public void testConvertStringToObjectMapToStringToStringMap() throws Exception {
+        Map<String, Object> map = Map.ofEntries(Map.entry("test", Map.of("test-1", "{'test-2', 'test-3'}")));
+        Map<String, String> convertedMap = ParseUtils.convertStringToObjectMapToStringToStringMap(map);
+        assertEquals("{test={\"test-1\":\"{'test-2', 'test-3'}\"}}", convertedMap.toString());
+    }
+
     public void testConditionallySubstituteWithNoPlaceholders() {
         String input = "This string has no placeholders";
         Map<String, WorkflowData> outputs = new HashMap<>();


### PR DESCRIPTION
### Description
Adds support for the `interface` field of model registration. Currently only adding support for the `register_remote_model` and `register_local_custom_model` since pretrained/ local sparse encoding models do not currently work with the model interface. 

Registering and deploying remote model with model interface : 
```
curl -i -XPOST "localhost:9200/_plugins/_flow_framework/workflow?provision=true" -H "Content-Type:application/json" --data '{"name":"createconnector-registerremotemodel-deploymodel","description":"test case","use_case":"TEST_CASE","version":{"template":"1.0.0","compatibility":["2.12.0","3.0.0"]},"workflows":{"provision":{"nodes":[{"id":"workflow_step_1","type":"create_connector","user_inputs":{"name":"OpenAI Chat Connector","description":"The connector to public OpenAI model service for GPT 3.5","version":"1","protocol":"http","parameters":{"endpoint":"api.openai.com","model":"gpt-3.5-turbo"},"credential":{"openAI_key":"12345"},"actions":[{"action_type":"predict","method":"POST","url":"https://${parameters.endpoint}/v1/chat/completions"}]}},{"id":"workflow_step_2","type":"register_remote_model","previous_node_inputs":{"workflow_step_1":"connector_id"},"user_inputs":{"name":"openAI-gpt-3.5-turbo","description":"test model","interface":{"input":{"properties":{"parameters":{"properties":{"messages":{"type":"string","description":"This is a test description field"}}}}},"output":{"properties":{"inference_results":{"type":"array","items":{"type":"object","properties":{"output":{"type":"array","items":{"properties":{"name":{"type":"string","description":"This is a test description field"},"dataAsMap":{"type":"object","description":"This is a test description field"}}},"description":"This is a test description field"},"status_code":{"type":"integer","description":"This is a test description field"}}},"description":"This is a test description field"}}}},"deploy":true,"node_timeout":"15s"}}]}}}'
HTTP/1.1 201 Created
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 38

{"workflow_id":"gNg7O48BaP6uKfWC1aKh"}

curl -i -XGET "http://localhost:9200/_plugins/_ml/models/hNg7O48BaP6uKfWC2qJv?pretty"
HTTP/1.1 200 OK
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 1318

{
  "name" : "openAI-gpt-3.5-turbo",
  "model_group_id" : "gtg7O48BaP6uKfWC2aJg",
  "algorithm" : "REMOTE",
  "model_version" : "1",
  "description" : "test model",
  "model_state" : "DEPLOYED",
  "created_time" : 1714685729273,
  "last_updated_time" : 1714685729735,
  "last_deployed_time" : 1714685729734,
  "auto_redeploy_retry_times" : 0,
  "planning_worker_node_count" : 1,
  "current_worker_node_count" : 1,
  "planning_worker_nodes" : [
    "TpCVBoolSOCJOR4dkq66ng"
  ],
  "deploy_to_all_nodes" : true,
  "is_hidden" : false,
  "connector_id" : "gdg7O48BaP6uKfWC2KIR",
  "interface" : {
    "output" : "{\"properties\":{\"inference_results\":{\"description\":\"This is a test description field\",\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"output\":{\"description\":\"This is a test description field\",\"type\":\"array\",\"items\":{\"properties\":{\"name\":{\"description\":\"This is a test description field\",\"type\":\"string\"},\"dataAsMap\":{\"description\":\"This is a test description field\",\"type\":\"object\"}}}},\"status_code\":{\"description\":\"This is a test description field\",\"type\":\"integer\"}}}}}}",
    "input" : "{\"properties\":{\"parameters\":{\"properties\":{\"messages\":{\"description\":\"This is a test description field\",\"type\":\"string\"}}}}}"
  }
}
```

For registering and deploying local custom model :
```
curl -i -XPOST "localhost:9200/_plugins/_flow_framework/workflow?provision=true" -H "Content-Type:application/json" --data '{"name":"registermodelgroup-registerlocalmodel-deploymodel","description":"test case","use_case":"TEST_CASE","version":{"template":"1.0.0","compatibility":["2.12.0","3.0.0"]},"workflows":{"provision":{"nodes":[{"id":"workflow_step_1","type":"register_local_custom_model","user_inputs":{"node_timeout":"60s","name":"all-MiniLM-L6-v2","version":"1.0.0","description":"test model","model_format":"TORCH_SCRIPT","function_name":"SPARSE_TOKENIZE","model_content_hash_value":"c15f0d2e62d872be5b5bc6c84d2e0f4921541e29fefbef51d59cc10a8ae30e0f","model_type":"bert","embedding_dimension":"384","framework_type":"sentence_transformers","all_config":"{\"_name_or_path\":\"nreimers/MiniLM-L6-H384-uncased\",\"architectures\":[\"BertModel\"],\"attention_probs_dropout_prob\":0.1,\"gradient_checkpointing\":false,\"hidden_act\":\"gelu\",\"hidden_dropout_prob\":0.1,\"hidden_size\":384,\"initializer_range\":0.02,\"intermediate_size\":1536,\"layer_norm_eps\":1e-12,\"max_position_embeddings\":512,\"model_type\":\"bert\",\"num_attention_heads\":12,\"num_hidden_layers\":6,\"pad_token_id\":0,\"position_embedding_type\":\"absolute\",\"transformers_version\":\"4.8.2\",\"type_vocab_size\":2,\"use_cache\":true,\"vocab_size\":30522}","url":"https://artifacts.opensearch.org/models/ml-models/huggingface/sentence-transformers/all-MiniLM-L6-v2/1.0.1/torch_script/sentence-transformers_all-MiniLM-L6-v2-1.0.1-torch_script.zip","interface":{"input":{"properties":{"text_docs":{"type":"array"},"return_number":{"type":"boolean"},"target_response":{"type":"array"}}}}}},{"id":"workflow_step_2","type":"deploy_model","previous_node_inputs":{"workflow_step_1":"model_id"}}],"edges":[{"source":"workflow_step_1","dest":"workflow_step_2"}]}}}'
HTTP/1.1 201 Created
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 38

{"workflow_id":"lch-O48BUXkJrbtALpC3"}

curl -i -XGET "http://localhost:9200/_plugins/_ml/models/mMh-O48BUXkJrbtAMZCk?pretty"
HTTP/1.1 200 OK
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 1687

{
  "name" : "all-MiniLM-L6-v2",
  "model_group_id" : "lsh-O48BUXkJrbtAMJCA",
  "algorithm" : "SPARSE_TOKENIZE",
  "model_version" : "1",
  "description" : "test model",
  "model_format" : "TORCH_SCRIPT",
  "model_state" : "DEPLOYED",
  "model_content_size_in_bytes" : 91790008,
  "model_content_hash_value" : "c15f0d2e62d872be5b5bc6c84d2e0f4921541e29fefbef51d59cc10a8ae30e0f",
  "model_config" : {
    "model_type" : "bert",
    "embedding_dimension" : 384,
    "framework_type" : "SENTENCE_TRANSFORMERS",
    "all_config" : "{\"_name_or_path\":\"nreimers/MiniLM-L6-H384-uncased\",\"architectures\":[\"BertModel\"],\"attention_probs_dropout_prob\":0.1,\"gradient_checkpointing\":false,\"hidden_act\":\"gelu\",\"hidden_dropout_prob\":0.1,\"hidden_size\":384,\"initializer_range\":0.02,\"intermediate_size\":1536,\"layer_norm_eps\":1e-12,\"max_position_embeddings\":512,\"model_type\":\"bert\",\"num_attention_heads\":12,\"num_hidden_layers\":6,\"pad_token_id\":0,\"position_embedding_type\":\"absolute\",\"transformers_version\":\"4.8.2\",\"type_vocab_size\":2,\"use_cache\":true,\"vocab_size\":30522}"
  },
  "created_time" : 1714690076965,
  "last_updated_time" : 1714690083895,
  "last_registered_time" : 1714690081144,
  "last_deployed_time" : 1714690083894,
  "auto_redeploy_retry_times" : 0,
  "total_chunks" : 10,
  "planning_worker_node_count" : 1,
  "current_worker_node_count" : 1,
  "planning_worker_nodes" : [
    "zTtalEMSTRGrYfx29Gh4sQ"
  ],
  "deploy_to_all_nodes" : true,
  "is_hidden" : false,
  "interface" : {
    "input" : "{\"properties\":{\"target_response\":{\"type\":\"array\"},\"return_number\":{\"type\":\"boolean\"},\"text_docs\":{\"type\":\"array\"}}}"
  }
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
