### PR TITLE
Add user mapping to Workflow State index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,27 +12,13 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Maintenance
 ### Refactoring
 
-## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.13...2.x)
+## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.14...2.x)
 ### Features
 ### Enhancements
-- Add guardrails to default use case params ([#658](https://github.com/opensearch-project/flow-framework/pull/658))
-- Allow strings for boolean workflow step parameters ([#671](https://github.com/opensearch-project/flow-framework/pull/671))
-- Add optional delay parameter to no-op step ([#674](https://github.com/opensearch-project/flow-framework/pull/674))
-- Add model interface support for remote and local custom models ([#701](https://github.com/opensearch-project/flow-framework/pull/701))
-
 ### Bug Fixes
-- Reset workflow state to initial state after successful deprovision ([#635](https://github.com/opensearch-project/flow-framework/pull/635))
-- Silently ignore content on APIs that don't require it ([#639](https://github.com/opensearch-project/flow-framework/pull/639))
-- Hide user and credential field from search response ([#680](https://github.com/opensearch-project/flow-framework/pull/680))
-- Throw the correct error message in status API for WorkflowSteps ([#676](https://github.com/opensearch-project/flow-framework/pull/676))
-- Delete workflow state when template is deleted and no resources exist ([#689](https://github.com/opensearch-project/flow-framework/pull/689))
-- Fixing model group parsing and restoring context ([#695] (https://github.com/opensearch-project/flow-framework/pull/695))
+- Add user mapping to Workflow State index ([#705](https://github.com/opensearch-project/flow-framework/pull/705))
 
 ### Infrastructure
-- Switch macos runner to macos-13 from macos-latest since macos-latest is now arm64 ([#686](https://github.com/opensearch-project/flow-framework/pull/686))
-
 ### Documentation
 ### Maintenance
 ### Refactoring
-- Improve error messages for workflow states other than NOT_STARTED ([#642](https://github.com/opensearch-project/flow-framework/pull/642))
-- Create a Config XContent model for Config index ([#679](https://github.com/opensearch-project/flow-framework/pull/679))

--- a/src/main/resources/mappings/workflow-state.json
+++ b/src/main/resources/mappings/workflow-state.json
@@ -30,6 +30,44 @@
     "user_outputs": {
       "type": "object"
     },
+    "user": {
+      "type": "nested",
+      "properties": {
+        "name": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "backend_roles": {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        "roles": {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        "custom_attribute_names": {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword"
+            }
+          }
+        }
+      }
+    },
     "resources_created": {
       "type": "nested",
       "properties": {

--- a/src/main/resources/mappings/workflow-state.json
+++ b/src/main/resources/mappings/workflow-state.json
@@ -1,7 +1,7 @@
 {
   "dynamic": false,
   "_meta": {
-    "schema_version": 2
+    "schema_version": 3
   },
   "properties": {
     "schema_version": {


### PR DESCRIPTION
### Description

Adds the missing mapping for the `user` field.  (Copy/paste from same field in the template mapping.)

### Issues Resolved

Fixes #700 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
