### PR TITLE
Add param to delete workflow API to clear status even if resources exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.14...2.x)
 ### Features
 ### Enhancements
+- Add param to delete workflow API to clear status even if resources exist ([#719](https://github.com/opensearch-project/flow-framework/pull/719))
+
 ### Bug Fixes
 - Add user mapping to Workflow State index ([#705](https://github.com/opensearch-project/flow-framework/pull/705))
 

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -196,6 +196,8 @@ public class CommonValue {
     public static final String USER_OUTPUTS_FIELD = "user_outputs";
     /** The template field name for template resources created */
     public static final String RESOURCES_CREATED_FIELD = "resources_created";
+    /** The parameter to clear workflow state when deleting template */
+    public static final String CLEAR_STATUS = "clear_status";
     /** The field name for the step name where a resource is created */
     public static final String WORKFLOW_STEP_NAME = "workflow_step_name";
     /** The field name for the step ID where a resource is created */

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowState.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowState.java
@@ -70,7 +70,7 @@ public class WorkflowState implements ToXContentObject, Writeable {
      * @param provisionEndTime Indicates the end time of the whole provisioning flow
      * @param user The user extracted from the thread context from the request
      * @param userOutputs A map of essential API responses for backend to use and lookup.
-     * @param resourcesCreated A map of all the resources created.
+     * @param resourcesCreated A list of all the resources created.
      */
     public WorkflowState(
         String workflowId,

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeleteWorkflowAction.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
+import static org.opensearch.flowframework.common.CommonValue.CLEAR_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
@@ -62,6 +63,7 @@ public class RestDeleteWorkflowAction extends BaseRestHandler {
     @Override
     protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String workflowId = request.param(WORKFLOW_ID);
+        request.param(CLEAR_STATUS); // consume and ignore, we will pass params to workflow
         try {
             if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {
                 throw new FlowFrameworkException(
@@ -78,7 +80,7 @@ public class RestDeleteWorkflowAction extends BaseRestHandler {
             if (workflowId == null) {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);
             }
-            WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null);
+            WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null, request.params());
             return channel -> client.execute(DeleteWorkflowAction.INSTANCE, workflowRequest, ActionListener.wrap(response -> {
                 XContentBuilder builder = response.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS);
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));

--- a/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestGetWorkflowStateAction.java
@@ -83,7 +83,7 @@ public class RestGetWorkflowStateAction extends BaseRestHandler {
                 try {
                     FlowFrameworkException ex = exception instanceof FlowFrameworkException
                         ? (FlowFrameworkException) exception
-                        : new FlowFrameworkException("Failed to get workflow.", ExceptionsHelper.status(exception));
+                        : new FlowFrameworkException("Failed to get workflow status.", ExceptionsHelper.status(exception));
                     XContentBuilder exceptionBuilder = ex.toXContent(channel.newErrorBuilder(), ToXContent.EMPTY_PARAMS);
                     channel.sendResponse(new BytesRestResponse(ex.getRestStatus(), exceptionBuilder));
                 } catch (IOException e) {

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportAction.java
@@ -83,11 +83,11 @@ public class GetWorkflowStateTransportAction extends HandledTransportAction<GetW
                         listener.onFailure(new FlowFrameworkException(errorMessage, RestStatus.BAD_REQUEST));
                     }
                 } else {
-                    listener.onFailure(new FlowFrameworkException("Fail to find workflow " + workflowId, RestStatus.NOT_FOUND));
+                    listener.onFailure(new FlowFrameworkException("Fail to find workflow status of " + workflowId, RestStatus.NOT_FOUND));
                 }
             }, e -> {
                 if (e instanceof IndexNotFoundException) {
-                    listener.onFailure(new FlowFrameworkException("Fail to find workflow " + workflowId, RestStatus.NOT_FOUND));
+                    listener.onFailure(new FlowFrameworkException("Fail to find workflow status of " + workflowId, RestStatus.NOT_FOUND));
                 } else {
                     String errorMessage = "Failed to get workflow status of: " + workflowId;
                     logger.error(errorMessage, e);

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -28,6 +28,7 @@ import org.opensearch.action.ingest.GetPipelineResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.common.settings.Settings;
@@ -454,10 +455,22 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
      * @throws Exception if the request fails
      */
     protected Response deleteWorkflow(RestClient client, String workflowId) throws Exception {
+        return deleteWorkflow(client, workflowId, "");
+    }
+
+    /**
+     * Helper method to invoke the Delete Workflow Rest Action
+     * @param client the rest client
+     * @param workflowId the workflow ID to delete
+     * @param params a string adding any rest path params
+     * @return a rest response
+     * @throws Exception if the request fails
+     */
+    protected Response deleteWorkflow(RestClient client, String workflowId, String params) throws Exception {
         return TestHelpers.makeRequest(
             client,
             "DELETE",
-            String.format(Locale.ROOT, "%s/%s", WORKFLOW_URI, workflowId),
+            String.format(Locale.ROOT, "%s/%s%s", WORKFLOW_URI, workflowId, params),
             Collections.emptyMap(),
             "",
             null
@@ -481,7 +494,6 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
             "",
             null
         );
-
     }
 
     /**
@@ -586,7 +598,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
     }
 
     /**
-     * Helper method to invoke the Get Workflow Rest Action and assert the provisioning and state status
+     * Helper method to invoke the Get Workflow Status Rest Action and assert the provisioning and state status
      * @param client the rest client
      * @param workflowId the workflow ID to get the status
      * @param stateStatus the state status name
@@ -605,6 +617,17 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
         Map<String, Object> responseMap = entityAsMap(response);
         assertEquals(stateStatus.name(), (String) responseMap.get(CommonValue.STATE_FIELD));
         assertEquals(provisioningStatus.name(), (String) responseMap.get(CommonValue.PROVISIONING_PROGRESS_FIELD));
+    }
+
+    /**
+     * Helper method to invoke the Get Workflow Status Rest Action and assert document is not found
+     * @param client the rest client
+     * @param workflowId the workflow ID to get the status
+     * @throws Exception if the request fails
+     */
+    protected void getAndAssertWorkflowStatusNotFound(RestClient client, String workflowId) throws Exception {
+        ResponseException ex = assertThrows(ResponseException.class, () -> getWorkflowStatus(client, workflowId, true));
+        assertEquals(RestStatus.NOT_FOUND.getStatus(), ex.getResponse().getStatusLine().getStatusCode());
     }
 
     /**

--- a/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
+++ b/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
@@ -72,6 +72,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("deprecation")
 public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
     @Mock
     private Client client;
@@ -262,19 +263,10 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
 
     public void testIsWorkflowProvisionedFailedParsing() {
         String documentId = randomAlphaOfLength(5);
+        @SuppressWarnings("unchecked")
         Consumer<Optional<ProvisioningProgress>> function = mock(Consumer.class);
+        @SuppressWarnings("unchecked")
         ActionListener<GetResponse> listener = mock(ActionListener.class);
-        WorkflowState workFlowState = new WorkflowState(
-            documentId,
-            "test",
-            "PROVISIONING",
-            "IN_PROGRESS",
-            Instant.now(),
-            Instant.now(),
-            TestHelpers.randomUser(),
-            Collections.emptyMap(),
-            Collections.emptyList()
-        );
         doAnswer(invocation -> {
             ActionListener<GetResponse> responseListener = invocation.getArgument(1);
 
@@ -318,7 +310,7 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
             return null;
         }).when(client).get(any(GetRequest.class), any());
 
-        flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(documentId, canDelete -> { assertTrue(canDelete); }, listener);
+        flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(documentId, false, canDelete -> { assertTrue(canDelete); }, listener);
     }
 
     public void testCanNotDeleteWorkflowStateDocInProgress() {
@@ -347,10 +339,10 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
             return null;
         }).when(client).get(any(GetRequest.class), any());
 
-        flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(documentId, canDelete -> { assertFalse(canDelete); }, listener);
+        flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(documentId, true, canDelete -> { assertFalse(canDelete); }, listener);
     }
 
-    public void testCanNotDeleteWorkflowStateDocResourcesExist() {
+    public void testDeleteWorkflowStateDocResourcesExist() {
         String documentId = randomAlphaOfLength(5);
         @SuppressWarnings("unchecked")
         ActionListener<GetResponse> listener = mock(ActionListener.class);
@@ -376,12 +368,18 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
             return null;
         }).when(client).get(any(GetRequest.class), any());
 
-        flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(documentId, canDelete -> { assertFalse(canDelete); }, listener);
+        // Can't delete because resources exist
+        flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(documentId, false, canDelete -> { assertFalse(canDelete); }, listener);
+
+        // But can delete if clearStatus set true
+        flowFrameworkIndicesHandler.canDeleteWorkflowStateDoc(documentId, true, canDelete -> { assertTrue(canDelete); }, listener);
     }
 
     public void testDoesTemplateExist() {
         String documentId = randomAlphaOfLength(5);
+        @SuppressWarnings("unchecked")
         Consumer<Boolean> function = mock(Consumer.class);
+        @SuppressWarnings("unchecked")
         ActionListener<GetResponse> listener = mock(ActionListener.class);
         doAnswer(invocation -> {
             ActionListener<GetResponse> responseListener = invocation.getArgument(1);

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -175,6 +175,17 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         assertNotNull(resourcesCreated.get(0).resourceId());
         assertEquals("deploy_model", resourcesCreated.get(1).workflowStepName());
         assertNotNull(resourcesCreated.get(1).resourceId());
+
+        // Delete the workflow without deleting the resources
+        Response deleteResponse = deleteWorkflow(client(), workflowId);
+        assertEquals(RestStatus.OK, TestHelpers.restStatus(deleteResponse));
+
+        // Verify state doc is not deleted
+        assertBusy(
+            () -> { getAndAssertWorkflowStatus(client(), workflowId, State.COMPLETED, ProvisioningProgress.DONE); },
+            30,
+            TimeUnit.SECONDS
+        );
     }
 
     public void testCreateAndProvisionCyclicalTemplate() throws Exception {
@@ -235,6 +246,13 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         assertNotNull(resourcesCreated.get(1).resourceId());
         assertEquals("deploy_model", resourcesCreated.get(2).workflowStepName());
         assertNotNull(resourcesCreated.get(2).resourceId());
+
+        // Delete the workflow without deleting the resources
+        Response deleteResponse = deleteWorkflow(client(), workflowId, "?clear_status=true");
+        assertEquals(RestStatus.OK, TestHelpers.restStatus(deleteResponse));
+
+        // Verify state doc is deleted
+        assertBusy(() -> { getAndAssertWorkflowStatusNotFound(client(), workflowId); }, 30, TimeUnit.SECONDS);
     }
 
     public void testCreateAndProvisionAgentFrameworkWorkflow() throws Exception {
@@ -305,6 +323,9 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         // Hit Delete API
         Response deleteResponse = deleteWorkflow(client(), workflowId);
         assertEquals(RestStatus.OK, TestHelpers.restStatus(deleteResponse));
+
+        // Verify state doc is deleted
+        assertBusy(() -> { getAndAssertWorkflowStatusNotFound(client(), workflowId); }, 30, TimeUnit.SECONDS);
     }
 
     public void testTimestamps() throws Exception {


### PR DESCRIPTION
### Description

Adds an optional `clear_status` param to the delete workflow API (defaulting `false`).

If present, overrides the "do resources exist" check and permits deleting the workflow state as long as provisioning is not `IN_PROGRESS`

Please also review Documentation PR: https://github.com/opensearch-project/documentation-website/pull/7268

### Issues Resolved

Resolves #692

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
