### PR TITLE
Set Java target compatibility to JDK 21

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,10 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # Spotless requires JDK 17+
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: Spotless Check
         run: ./gradlew spotlessCheck
@@ -26,6 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
       - name: Javadoc CheckStyle
         run: ./gradlew checkstyleMain
       - name: Javadoc Check
@@ -35,11 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        java: [11, 21]
-        include:
-          - os: ubuntu-latest
-            java: 17
-            codecov: yes
+        java: [21]
     name: Test JDK${{ matrix.java }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,7 +52,7 @@ jobs:
         run: |
           ./gradlew check -x integTest -x yamlRestTest -x spotlessJava
       - name: Upload Coverage Report
-        if: ${{ matrix.codecov }}
+        if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '21')
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -65,10 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        java: [11, 21]
-        include:
-          - os: ubuntu-latest
-            java: 17
+        java: [21]
     name: Integ Test JDK${{ matrix.java }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_bwc.yml
+++ b/.github/workflows/test_bwc.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ff-linux:
     strategy:
       matrix:
-        java: [11,17,21]
+        java: [21]
       fail-fast: false
 
     name: Test Flow Framework BWC

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -16,7 +16,7 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     name: Run Security Integration Tests on Linux
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
+- Set Java target compatibility to JDK 21 ([#730](https://github.com/opensearch-project/flow-framework/pull/730))
+
 ### Documentation
 ### Maintenance
 ### Refactoring
@@ -17,6 +19,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 - Add Workflow Step for Reindex from source index to destination ([#718](https://github.com/opensearch-project/flow-framework/pull/718))
 - Add param to delete workflow API to clear status even if resources exist ([#719](https://github.com/opensearch-project/flow-framework/pull/719))
+
 ### Bug Fixes
 - Add user mapping to Workflow State index ([#705](https://github.com/opensearch-project/flow-framework/pull/705))
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -24,12 +24,12 @@ See [OpenSearch requirements](https://github.com/opensearch-project/OpenSearch/b
 
 #### Java
 
-Flow Framework code currently maintains compatibility with JDK 11. Other plugins may require newer Java versions if used.
+The Flow Framework `main` branch targets JDK 21. To ease backporting to `2.x`, maintain compatibility with JDK 11 unless significant benefits can be gained. Other plugins may require newer Java versions if used.
 
 ### Setup
 
 1. Clone the repository (see [Forking and Cloning](#forking-and-cloning))
-2. Make sure `JAVA_HOME` is pointing to a Java 14 JDK (see [Install Prerequisites](#install-prerequisites))
+2. Make sure `JAVA_HOME` is pointing to a Java 21 or higher JDK (see [Install Prerequisites](#install-prerequisites))
 3. Launch Intellij IDEA, Choose Import Project and select the settings.gradle file in the root of this package.
 
 ### Build

--- a/build.gradle
+++ b/build.gradle
@@ -149,8 +149,8 @@ allprojects {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_11
-    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {


### PR DESCRIPTION
### Description

Sets source and target compatibility to JDK21.

### Issues Resolved

Resoves #729 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
