### PR TITLE
Stop duplicate CI runs on branch push by bots

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,12 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'whitesource-remediate/**'
       - 'backport/**'
+      - 'create-pull-request/**'
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/test_bwc.yml
+++ b/.github/workflows/test_bwc.yml
@@ -1,11 +1,13 @@
 name: BWC
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - "**"
+    branches-ignore:
+      - 'whitesource-remediate/**'
+      - 'backport/**'
+      - 'create-pull-request/**'
   pull_request:
-    branches:
-      - "**"
+    types: [opened, synchronize, reopened]
 
 jobs:
   Build-ff-linux:

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -1,9 +1,11 @@
 name: Security test workflow for Flow Framework
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'whitesource-remediate/**'
       - 'backport/**'
+      - 'create-pull-request/**'
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
### Description

CI tests are running twice on version-bump PRs 
BWC tests are running twice on version-bump and dependency bump and backport PRs

These are caused because bots `push` to a branch on the repo in addition to the PRs.  

Unfortunately, `push` is the only way to run a workflow when it is rebased (without changing the PR commits):
 - For dependency version updates, there's a check-box in the PR description to rebase that will generate a new latest commit
 - For backport and version bump PRs, added the `workflow-dispatch` trigger to enable manually rerunning the workflows on the appropriate branch.  This is particularly useful when a version bump is past the 30-day retry window. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
