### PR TITLE
Switch diffCoverage plugin to deltaCoverage

### DIFF
--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-- [Contributing to OpenSearch AI Flow Framework](#contributing-to-flow-framework)
+- [Contributing to OpenSearch Flow Framework](#contributing-to-opensearch-flow-framework)
   - [First Things First](#first-things-first)
   - [Ways to Contribute](#ways-to-contribute)
     - [Bug Reports](#bug-reports)
@@ -100,7 +100,7 @@ Adding in the change is two step process -
 
 Any new functionality requires testing. Your PR will trigger an automatic assessment of the code coverage of the lines you've added. You should add unit and/or integration tests to exercise as much of your new code as possible.
 
-If you'd like to preview your coverage before submitting your PR, to identify lines of code which are not tested, you may run `./gradlew diffCoverage` and review the report available in the project build directory at `build/reports/jacoco/diffCoverage/html/index.html`.
+If you'd like to preview your coverage before submitting your PR, to identify lines of code which are not tested, you may run `./gradlew test deltaCoverage` and review the report available in the project build directory at `build/reports/coverage-reports/delta-coverage/html/index.html`.
 
 ## Review Process
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,13 +47,13 @@ buildscript {
     dependencies {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
-        classpath "com.github.form-com.diff-coverage-gradle:diff-coverage:0.9.5"
     }
 }
 
 plugins {
     id "de.undercouch.download" version "5.6.0"
     id "org.gradle.test-retry" version "1.5.9" apply false
+    id "io.github.surpsg.delta-coverage" version "2.1.0"
 }
 
 apply plugin: 'java'
@@ -66,9 +66,6 @@ apply plugin: 'com.diffplug.spotless'
 apply from: 'formatter/formatting.gradle'
 // for javadocs and checks spotless doesn't do
 apply plugin: 'checkstyle'
-// for coverage and diff
-apply plugin: 'jacoco'
-apply plugin: 'com.form.diff-coverage'
 
 def pluginName = 'opensearch-flow-framework'
 def pluginDescription = 'OpenSearch plugin that enables builders to innovate AI apps on OpenSearch'
@@ -684,37 +681,25 @@ task updateVersion {
     }
 }
 
-diffCoverageReport {
-    afterEvaluate {
-        // Get uncommitted files via git diff
-        // https://github.com/form-com/diff-coverage-gradle/issues/73
-        def file = Files.createTempFile(URLEncoder.encode(project.name, 'UTF-8'), '.diff').toFile()
-        def diffBase = 'refs/remotes/origin/main'
-        // Only run locally
-        if (!System.getenv('CI')) {
-            file.withOutputStream { out ->
-                exec {
-                    ignoreExitValue true
-                    commandLine 'git', 'diff', '--no-color', '--minimal', diffBase
-                    standardOutput = out
-                }
-            }
-        }
-        diffSource.file = file
-    }
-
-    // View report at build/reports/jacoco/diffCoverage/html/index.html
-    reports {
-        html = true
+deltaCoverageReport {
+    diffSource {
+        git.compareWith("refs/remotes/origin/main")
     }
 
     violationRules {
-        minBranches = 0.60
-        minLines = 0.75
-        failOnViolation = true
+        failOnViolation.set(true)
+        rule(io.github.surpsg.deltacoverage.gradle.CoverageEntity.LINE) {
+            minCoverageRatio.set(0.75d)
+        }
+        rule(io.github.surpsg.deltacoverage.gradle.CoverageEntity.BRANCH) {
+            minCoverageRatio.set(0.6d)
+        }
+    }
+
+    reports {
+        html.set(true)
     }
 }
-
 
 tasks.withType(AbstractPublishToMaven) {
     def predicate = provider {


### PR DESCRIPTION
### Description

Removes the abandonware diffCoverage plugin and replaces it with deltaCoverage.

### Issues Resolved

Fixes #761 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
