### PR TITLE
Add allow_delete parameter to Deprovision API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.14...2.x)
 ### Features
 - Support editing of certain workflow fields on a provisioned workflow ([#757](https://github.com/opensearch-project/flow-framework/pull/757))
-- Add allow_delete parameter to Deprovision API and add DeleteIndex, DeleteIngestPipeline, and DeleteSearchPipeline Workflow Steps ([#763](https://github.com/opensearch-project/flow-framework/pull/763))
+- Add allow_delete parameter to Deprovision API ([#763](https://github.com/opensearch-project/flow-framework/pull/763))
 
 ### Enhancements
 - Register system index descriptors through SystemIndexPlugin.getSystemIndexDescriptors ([#750](https://github.com/opensearch-project/flow-framework/pull/750))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.14...2.x)
 ### Features
 - Support editing of certain workflow fields on a provisioned workflow ([#757](https://github.com/opensearch-project/flow-framework/pull/757))
+- Add allow_delete parameter to Deprovision API and add DeleteIndex, DeleteIngestPipeline, and DeleteSearchPipeline Workflow Steps ([#763](https://github.com/opensearch-project/flow-framework/pull/763))
 
 ### Enhancements
 - Register system index descriptors through SystemIndexPlugin.getSystemIndexDescriptors ([#750](https://github.com/opensearch-project/flow-framework/pull/750))

--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -131,13 +131,7 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin, SystemI
             flowFrameworkSettings,
             client
         );
-        WorkflowProcessSorter workflowProcessSorter = new WorkflowProcessSorter(
-            workflowStepFactory,
-            threadPool,
-            clusterService,
-            client,
-            flowFrameworkSettings
-        );
+        WorkflowProcessSorter workflowProcessSorter = new WorkflowProcessSorter(workflowStepFactory, threadPool, flowFrameworkSettings);
 
         return List.of(workflowStepFactory, workflowProcessSorter, encryptorUtils, flowFrameworkIndicesHandler, flowFrameworkSettings);
     }

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -68,7 +68,9 @@ public class CommonValue {
     public static final String WORKFLOW_ID = "workflow_id";
     /** Field name for template validation, the flag to indicate if validation is necessary */
     public static final String VALIDATION = "validation";
-    /** The param name for provision workflow in create API */
+    /** Param name for allow deletion during deprovisioning */
+    public static final String ALLOW_DELETE = "allow_delete";
+    /** The field name for provision workflow within a use case template*/
     public static final String PROVISION_WORKFLOW = "provision";
     /** The param name for update workflow field in create API */
     public static final String UPDATE_WORKFLOW_FIELDS = "update_fields";

--- a/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
+++ b/src/main/java/org/opensearch/flowframework/common/WorkflowResources.java
@@ -18,7 +18,10 @@ import org.opensearch.flowframework.workflow.CreateIngestPipelineStep;
 import org.opensearch.flowframework.workflow.CreateSearchPipelineStep;
 import org.opensearch.flowframework.workflow.DeleteAgentStep;
 import org.opensearch.flowframework.workflow.DeleteConnectorStep;
+import org.opensearch.flowframework.workflow.DeleteIndexStep;
+import org.opensearch.flowframework.workflow.DeleteIngestPipelineStep;
 import org.opensearch.flowframework.workflow.DeleteModelStep;
+import org.opensearch.flowframework.workflow.DeleteSearchPipelineStep;
 import org.opensearch.flowframework.workflow.DeployModelStep;
 import org.opensearch.flowframework.workflow.NoOpStep;
 import org.opensearch.flowframework.workflow.RegisterAgentStep;
@@ -54,11 +57,11 @@ public enum WorkflowResources {
     /** Workflow steps for deploying/undeploying a model and associated created resource */
     DEPLOY_MODEL(DeployModelStep.NAME, WorkflowResources.MODEL_ID, UndeployModelStep.NAME),
     /** Workflow steps for creating an ingest-pipeline and associated created resource */
-    CREATE_INGEST_PIPELINE(CreateIngestPipelineStep.NAME, WorkflowResources.PIPELINE_ID, null), // TODO delete step
+    CREATE_INGEST_PIPELINE(CreateIngestPipelineStep.NAME, WorkflowResources.PIPELINE_ID, DeleteIngestPipelineStep.NAME),
     /** Workflow steps for creating an ingest-pipeline and associated created resource */
-    CREATE_SEARCH_PIPELINE(CreateSearchPipelineStep.NAME, WorkflowResources.PIPELINE_ID, null), // TODO delete step
+    CREATE_SEARCH_PIPELINE(CreateSearchPipelineStep.NAME, WorkflowResources.PIPELINE_ID, DeleteSearchPipelineStep.NAME),
     /** Workflow steps for creating an index and associated created resource */
-    CREATE_INDEX(CreateIndexStep.NAME, WorkflowResources.INDEX_NAME, NoOpStep.NAME),
+    CREATE_INDEX(CreateIndexStep.NAME, WorkflowResources.INDEX_NAME, DeleteIndexStep.NAME),
     /** Workflow steps for reindex a source index to destination index and associated created resource */
     REINDEX(ReindexStep.NAME, WorkflowResources.INDEX_NAME, NoOpStep.NAME),
     /** Workflow steps for registering/deleting an agent and the associated created resource */

--- a/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestDeprovisionWorkflowAction.java
@@ -25,9 +25,12 @@ import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
+import static org.opensearch.flowframework.common.CommonValue.ALLOW_DELETE;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
@@ -57,6 +60,7 @@ public class RestDeprovisionWorkflowAction extends BaseRestHandler {
     @Override
     protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String workflowId = request.param(WORKFLOW_ID);
+        String allowDelete = request.param(ALLOW_DELETE);
         try {
             if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {
                 throw new FlowFrameworkException(
@@ -73,7 +77,11 @@ public class RestDeprovisionWorkflowAction extends BaseRestHandler {
             if (workflowId == null) {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);
             }
-            WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null);
+            WorkflowRequest workflowRequest = new WorkflowRequest(
+                workflowId,
+                null,
+                allowDelete == null ? Collections.emptyMap() : Map.of(ALLOW_DELETE, allowDelete)
+            );
 
             return channel -> client.execute(DeprovisionWorkflowAction.INSTANCE, workflowRequest, ActionListener.wrap(response -> {
                 XContentBuilder builder = response.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS);

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteIndexStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteIndexStep.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.exception.WorkflowStepException;
+import org.opensearch.flowframework.util.ParseUtils;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.flowframework.common.WorkflowResources.INDEX_NAME;
+import static org.opensearch.flowframework.exception.WorkflowStepException.getSafeException;
+
+/**
+ * Step to delete an index
+ */
+public class DeleteIndexStep implements WorkflowStep {
+
+    private static final Logger logger = LogManager.getLogger(DeleteIndexStep.class);
+    private final Client client;
+
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "delete_index";
+    /** Required input keys */
+    public static final Set<String> REQUIRED_INPUTS = Set.of(INDEX_NAME);
+    /** Optional input keys */
+    public static final Set<String> OPTIONAL_INPUTS = Collections.emptySet();
+    /** Provided output keys */
+    public static final Set<String> PROVIDED_OUTPUTS = Set.of(INDEX_NAME);
+
+    /**
+     * Instantiate this class
+     *
+     * @param client Client to delete an index
+     */
+    public DeleteIndexStep(Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public PlainActionFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs,
+        Map<String, String> params
+    ) {
+        PlainActionFuture<WorkflowData> deleteIndexFuture = PlainActionFuture.newFuture();
+
+        try {
+            Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
+                REQUIRED_INPUTS,
+                OPTIONAL_INPUTS,
+                currentNodeInputs,
+                outputs,
+                previousNodeInputs,
+                params
+            );
+
+            String indexName = (String) inputs.get(INDEX_NAME);
+
+            DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indexName);
+
+            client.admin().indices().delete(deleteIndexRequest, ActionListener.wrap(acknowledgedResponse -> {
+                logger.info("Deleted index: {}", indexName);
+                deleteIndexFuture.onResponse(
+                    new WorkflowData(
+                        Map.ofEntries(Map.entry(INDEX_NAME, indexName)),
+                        currentNodeInputs.getWorkflowId(),
+                        currentNodeInputs.getNodeId()
+                    )
+                );
+            }, ex -> {
+                Exception e = getSafeException(ex);
+                String errorMessage = (e == null ? "Failed to delete the index " + indexName : e.getMessage());
+                logger.error(errorMessage, e);
+                deleteIndexFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
+            }));
+        } catch (Exception e) {
+            deleteIndexFuture.onFailure(e);
+        }
+        return deleteIndexFuture;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean allowDeleteRequired() {
+        return true;
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteIngestPipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteIngestPipelineStep.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.ingest.DeletePipelineRequest;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.exception.WorkflowStepException;
+import org.opensearch.flowframework.util.ParseUtils;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.flowframework.common.WorkflowResources.PIPELINE_ID;
+import static org.opensearch.flowframework.exception.WorkflowStepException.getSafeException;
+
+/**
+ * Step to delete an ingest pipeline
+ */
+public class DeleteIngestPipelineStep implements WorkflowStep {
+
+    private static final Logger logger = LogManager.getLogger(DeleteIngestPipelineStep.class);
+    private final Client client;
+
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "delete_ingest_pipeline";
+    /** Required input keys */
+    public static final Set<String> REQUIRED_INPUTS = Set.of(PIPELINE_ID);
+    /** Optional input keys */
+    public static final Set<String> OPTIONAL_INPUTS = Collections.emptySet();
+    /** Provided output keys */
+    public static final Set<String> PROVIDED_OUTPUTS = Set.of(PIPELINE_ID);
+
+    /**
+     * Instantiate this class
+     *
+     * @param client Client to delete an Ingest Pipeline
+     */
+    public DeleteIngestPipelineStep(Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public PlainActionFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs,
+        Map<String, String> params
+    ) {
+        PlainActionFuture<WorkflowData> deletePipelineFuture = PlainActionFuture.newFuture();
+
+        try {
+            Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
+                REQUIRED_INPUTS,
+                OPTIONAL_INPUTS,
+                currentNodeInputs,
+                outputs,
+                previousNodeInputs,
+                params
+            );
+
+            String pipelineId = (String) inputs.get(PIPELINE_ID);
+
+            DeletePipelineRequest deletePipelineRequest = new DeletePipelineRequest(pipelineId);
+
+            client.admin().cluster().deletePipeline(deletePipelineRequest, ActionListener.wrap(acknowledgedResponse -> {
+                logger.info("Deleted IngestPipeline: {}", pipelineId);
+                deletePipelineFuture.onResponse(
+                    new WorkflowData(
+                        Map.ofEntries(Map.entry(PIPELINE_ID, pipelineId)),
+                        currentNodeInputs.getWorkflowId(),
+                        currentNodeInputs.getNodeId()
+                    )
+                );
+            }, ex -> {
+                Exception e = getSafeException(ex);
+                String errorMessage = (e == null ? "Failed to delete the ingest pipeline " + pipelineId : e.getMessage());
+                logger.error(errorMessage, e);
+                deletePipelineFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
+            }));
+        } catch (Exception e) {
+            deletePipelineFuture.onFailure(e);
+        }
+        return deletePipelineFuture;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean allowDeleteRequired() {
+        return true;
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteSearchPipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteSearchPipelineStep.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.search.DeleteSearchPipelineRequest;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.exception.WorkflowStepException;
+import org.opensearch.flowframework.util.ParseUtils;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.flowframework.common.WorkflowResources.PIPELINE_ID;
+import static org.opensearch.flowframework.exception.WorkflowStepException.getSafeException;
+
+/**
+ * Step to delete a search pipeline
+ */
+public class DeleteSearchPipelineStep implements WorkflowStep {
+
+    private static final Logger logger = LogManager.getLogger(DeleteSearchPipelineStep.class);
+    private final Client client;
+
+    /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
+    public static final String NAME = "delete_search_pipeline";
+    /** Required input keys */
+    public static final Set<String> REQUIRED_INPUTS = Set.of(PIPELINE_ID);
+    /** Optional input keys */
+    public static final Set<String> OPTIONAL_INPUTS = Collections.emptySet();
+    /** Provided output keys */
+    public static final Set<String> PROVIDED_OUTPUTS = Set.of(PIPELINE_ID);
+
+    /**
+     * Instantiate this class
+     *
+     * @param client Client to delete a Search Pipeline
+     */
+    public DeleteSearchPipelineStep(Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public PlainActionFuture<WorkflowData> execute(
+        String currentNodeId,
+        WorkflowData currentNodeInputs,
+        Map<String, WorkflowData> outputs,
+        Map<String, String> previousNodeInputs,
+        Map<String, String> params
+    ) {
+        PlainActionFuture<WorkflowData> deleteSearchPipelineFuture = PlainActionFuture.newFuture();
+
+        try {
+            Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(
+                REQUIRED_INPUTS,
+                OPTIONAL_INPUTS,
+                currentNodeInputs,
+                outputs,
+                previousNodeInputs,
+                params
+            );
+
+            String pipelineId = (String) inputs.get(PIPELINE_ID);
+
+            DeleteSearchPipelineRequest deleteSearchPipelineRequest = new DeleteSearchPipelineRequest(pipelineId);
+
+            client.admin().cluster().deleteSearchPipeline(deleteSearchPipelineRequest, ActionListener.wrap(acknowledgedResponse -> {
+                logger.info("Deleted SearchPipeline: {}", pipelineId);
+                deleteSearchPipelineFuture.onResponse(
+                    new WorkflowData(
+                        Map.ofEntries(Map.entry(PIPELINE_ID, pipelineId)),
+                        currentNodeInputs.getWorkflowId(),
+                        currentNodeInputs.getNodeId()
+                    )
+                );
+            }, ex -> {
+                Exception e = getSafeException(ex);
+                String errorMessage = (e == null ? "Failed to delete the search pipeline " + pipelineId : e.getMessage());
+                logger.error(errorMessage, e);
+                deleteSearchPipelineFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
+            }));
+        } catch (Exception e) {
+            deleteSearchPipelineFuture.onFailure(e);
+        }
+        return deleteSearchPipelineFuture;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean allowDeleteRequired() {
+        return true;
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -68,8 +68,6 @@ public class WorkflowProcessSorter {
      *
      * @param workflowStepFactory The factory which matches template step types to instances.
      * @param threadPool The OpenSearch Thread pool to pass to process nodes.
-     * @param clusterService The OpenSearch cluster service.
-     * @param client The OpenSearch Client
      * @param flowFrameworkSettings settings of the plugin
      */
     public WorkflowProcessSorter(

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
@@ -39,4 +39,12 @@ public interface WorkflowStep {
      * @return the name of this workflow step.
      */
     String getName();
+
+    /**
+     * For steps which delete data, override this method to require the resource ID to be specified on the rest path to deprovision it
+     * @return true if the resource ID must be specified for deprovisioning
+     */
+    default boolean allowDeleteRequired() {
+        return false;
+    }
 }

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -22,6 +22,7 @@ import org.opensearch.flowframework.model.WorkflowValidator;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -86,6 +87,7 @@ public class WorkflowStepFactory {
     ) {
         stepMap.put(NoOpStep.NAME, NoOpStep::new);
         stepMap.put(CreateIndexStep.NAME, () -> new CreateIndexStep(client, flowFrameworkIndicesHandler));
+        stepMap.put(DeleteIndexStep.NAME, () -> new DeleteIndexStep(client));
         stepMap.put(ReindexStep.NAME, () -> new ReindexStep(client, flowFrameworkIndicesHandler));
         stepMap.put(
             RegisterLocalCustomModelStep.NAME,
@@ -113,20 +115,30 @@ public class WorkflowStepFactory {
         stepMap.put(RegisterAgentStep.NAME, () -> new RegisterAgentStep(mlClient, flowFrameworkIndicesHandler));
         stepMap.put(DeleteAgentStep.NAME, () -> new DeleteAgentStep(mlClient));
         stepMap.put(CreateIngestPipelineStep.NAME, () -> new CreateIngestPipelineStep(client, flowFrameworkIndicesHandler));
+        stepMap.put(DeleteIngestPipelineStep.NAME, () -> new DeleteIngestPipelineStep(client));
         stepMap.put(CreateSearchPipelineStep.NAME, () -> new CreateSearchPipelineStep(client, flowFrameworkIndicesHandler));
+        stepMap.put(DeleteSearchPipelineStep.NAME, () -> new DeleteSearchPipelineStep(client));
     }
 
     /**
      * Enum encapsulating the different step names, their inputs, outputs, required plugin and timeout of the step
      */
-
     public enum WorkflowSteps {
 
         /** Noop Step */
-        NOOP("noop", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), null),
+        NOOP(NoOpStep.NAME, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), null),
 
         /** Create Index Step */
         CREATE_INDEX(CreateIndexStep.NAME, List.of(INDEX_NAME, CONFIGURATIONS), List.of(INDEX_NAME), Collections.emptyList(), null),
+
+        /** Delete Index Step */
+        DELETE_INDEX(
+            DeleteIndexStep.NAME,
+            DeleteIndexStep.REQUIRED_INPUTS, // TODO: Copy this pattern to other steps, see
+            DeleteIndexStep.PROVIDED_OUTPUTS, // https://github.com/opensearch-project/flow-framework/issues/535
+            Collections.emptyList(),
+            null
+        ),
 
         /** Create ReIndex Step */
         REINDEX(ReindexStep.NAME, List.of(SOURCE_INDEX, DESTINATION_INDEX), List.of(ReindexStep.NAME), Collections.emptyList(), null),
@@ -225,11 +237,29 @@ public class WorkflowStepFactory {
             null
         ),
 
+        /** Delete Ingest Pipeline Step */
+        DELETE_INGEST_PIPELINE(
+            DeleteIngestPipelineStep.NAME,
+            DeleteIngestPipelineStep.REQUIRED_INPUTS,
+            DeleteIngestPipelineStep.PROVIDED_OUTPUTS,
+            Collections.emptyList(),
+            null
+        ),
+
         /** Create Search Pipeline Step */
         CREATE_SEARCH_PIPELINE(
             CreateSearchPipelineStep.NAME,
             List.of(PIPELINE_ID, CONFIGURATIONS),
             List.of(PIPELINE_ID),
+            Collections.emptyList(),
+            null
+        ),
+
+        /** Delete Search Pipeline Step */
+        DELETE_SEARCH_PIPELINE(
+            DeleteSearchPipelineStep.NAME,
+            DeleteSearchPipelineStep.REQUIRED_INPUTS,
+            DeleteSearchPipelineStep.PROVIDED_OUTPUTS,
             Collections.emptyList(),
             null
         );
@@ -240,7 +270,13 @@ public class WorkflowStepFactory {
         private final List<String> requiredPlugins;
         private final TimeValue timeout;
 
-        WorkflowSteps(String workflowStepName, List<String> inputs, List<String> outputs, List<String> requiredPlugins, TimeValue timeout) {
+        WorkflowSteps(
+            String workflowStepName,
+            Collection<String> inputs,
+            Collection<String> outputs,
+            List<String> requiredPlugins,
+            TimeValue timeout
+        ) {
             this.workflowStepName = workflowStepName;
             this.inputs = List.copyOf(inputs);
             this.outputs = List.copyOf(outputs);

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -490,6 +490,24 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
     }
 
     /**
+     * Helper method to invoke the Deprovision Workflow Rest Action
+     * @param client the rest client
+     * @param workflowId the workflow ID to deprovision
+     * @return a rest response
+     * @throws Exception if the request fails
+     */
+    protected Response deprovisionWorkflowWithAllowDelete(RestClient client, String workflowId, String allowedResource) throws Exception {
+        return TestHelpers.makeRequest(
+            client,
+            "POST",
+            String.format(Locale.ROOT, "%s/%s/%s%s", WORKFLOW_URI, workflowId, "_deprovision?allow_delete=", allowedResource),
+            Collections.emptyMap(),
+            "",
+            null
+        );
+    }
+
+    /**
      * Helper method to invoke the Delete Workflow Rest Action
      * @param client the rest client
      * @param workflowId the workflow ID to delete

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowValidatorTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowValidatorTests.java
@@ -11,6 +11,7 @@ package org.opensearch.flowframework.model;
 import org.opensearch.client.Client;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory.WorkflowSteps;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -70,6 +71,7 @@ public class WorkflowValidatorTests extends OpenSearchTestCase {
 
         // Get all registered workflow step types in the workflow step factory
         List<String> registeredWorkflowStepTypes = new ArrayList<String>(workflowStepFactory.getStepMap().keySet());
+        registeredWorkflowStepTypes.removeAll(WorkflowProcessSorter.WORKFLOW_STEP_DENYLIST);
 
         // Check if each registered step has a corresponding validator definition
         assertTrue(registeredWorkflowStepTypes.containsAll(registeredWorkflowValidatorTypes));

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowValidatorTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowValidatorTests.java
@@ -46,63 +46,7 @@ public class WorkflowValidatorTests extends OpenSearchTestCase {
 
         WorkflowValidator validator = new WorkflowValidator(workflowStepValidators);
 
-        assertEquals(18, validator.getWorkflowStepValidators().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("create_connector"));
-        assertEquals(7, validator.getWorkflowStepValidators().get("create_connector").getInputs().size());
-        assertEquals(1, validator.getWorkflowStepValidators().get("create_connector").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("delete_model"));
-        assertEquals(1, validator.getWorkflowStepValidators().get("delete_model").getInputs().size());
-        assertEquals(1, validator.getWorkflowStepValidators().get("delete_model").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("deploy_model"));
-        assertEquals(1, validator.getWorkflowStepValidators().get("deploy_model").getInputs().size());
-        assertEquals(1, validator.getWorkflowStepValidators().get("deploy_model").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("register_remote_model"));
-        assertEquals(2, validator.getWorkflowStepValidators().get("register_remote_model").getInputs().size());
-        assertEquals(2, validator.getWorkflowStepValidators().get("register_remote_model").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("register_model_group"));
-        assertEquals(1, validator.getWorkflowStepValidators().get("register_model_group").getInputs().size());
-        assertEquals(2, validator.getWorkflowStepValidators().get("register_model_group").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("register_local_custom_model"));
-        assertEquals(9, validator.getWorkflowStepValidators().get("register_local_custom_model").getInputs().size());
-        assertEquals(2, validator.getWorkflowStepValidators().get("register_local_custom_model").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("register_local_sparse_encoding_model"));
-        assertEquals(3, validator.getWorkflowStepValidators().get("register_local_sparse_encoding_model").getInputs().size());
-        assertEquals(5, validator.getWorkflowStepValidators().get("register_local_sparse_encoding_model").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("register_local_pretrained_model"));
-        assertEquals(3, validator.getWorkflowStepValidators().get("register_local_pretrained_model").getInputs().size());
-        assertEquals(2, validator.getWorkflowStepValidators().get("register_local_pretrained_model").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("undeploy_model"));
-        assertEquals(1, validator.getWorkflowStepValidators().get("undeploy_model").getInputs().size());
-        assertEquals(1, validator.getWorkflowStepValidators().get("undeploy_model").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("delete_connector"));
-        assertEquals(1, validator.getWorkflowStepValidators().get("delete_connector").getInputs().size());
-        assertEquals(1, validator.getWorkflowStepValidators().get("delete_connector").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("register_agent"));
-        assertEquals(2, validator.getWorkflowStepValidators().get("register_agent").getInputs().size());
-        assertEquals(1, validator.getWorkflowStepValidators().get("register_agent").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("delete_agent"));
-        assertEquals(1, validator.getWorkflowStepValidators().get("delete_agent").getInputs().size());
-        assertEquals(1, validator.getWorkflowStepValidators().get("delete_agent").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("create_tool"));
-        assertEquals(1, validator.getWorkflowStepValidators().get("create_tool").getInputs().size());
-        assertEquals(1, validator.getWorkflowStepValidators().get("create_tool").getOutputs().size());
-
-        assertTrue(validator.getWorkflowStepValidators().keySet().contains("noop"));
-        assertEquals(0, validator.getWorkflowStepValidators().get("noop").getInputs().size());
-        assertEquals(0, validator.getWorkflowStepValidators().get("noop").getOutputs().size());
+        assertEquals(21, validator.getWorkflowStepValidators().size());
     }
 
     public void testWorkflowStepFactoryHasValidators() throws IOException {
@@ -130,6 +74,11 @@ public class WorkflowValidatorTests extends OpenSearchTestCase {
         // Check if each registered step has a corresponding validator definition
         assertTrue(registeredWorkflowStepTypes.containsAll(registeredWorkflowValidatorTypes));
         assertTrue(registeredWorkflowValidatorTypes.containsAll(registeredWorkflowStepTypes));
-    }
 
+        // Check JSON
+        String json = workflowValidator.toJson();
+        for (String step : registeredWorkflowStepTypes) {
+            assertTrue(json.contains("\"" + step + "\""));
+        }
+    }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteIndexStepTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.Client;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.opensearch.flowframework.common.WorkflowResources.INDEX_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DeleteIndexStepTests extends OpenSearchTestCase {
+    private WorkflowData inputData;
+
+    @Mock
+    private Client client;
+    @Mock
+    private AdminClient adminClient;
+    @Mock
+    private IndicesAdminClient indicesAdminClient;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        MockitoAnnotations.openMocks(this);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
+
+        inputData = new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id");
+    }
+
+    public void testDeleteIndex() throws IOException, ExecutionException, InterruptedException {
+
+        String indexName = randomAlphaOfLength(5);
+        DeleteIndexStep deleteIndexStep = new DeleteIndexStep(client);
+
+        doAnswer(invocation -> {
+            @SuppressWarnings("deprecation")
+            ActionListener<AcknowledgedResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(new AcknowledgedResponse(true));
+            return null;
+        }).when(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());
+
+        PlainActionFuture<WorkflowData> future = deleteIndexStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Map.of("step_1", new WorkflowData(Map.of(INDEX_NAME, indexName), "workflowId", "nodeId")),
+            Map.of("step_1", INDEX_NAME),
+            Collections.emptyMap()
+        );
+        verify(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());
+
+        assertTrue(future.isDone());
+        assertEquals(indexName, future.get().getContent().get(INDEX_NAME));
+    }
+
+    public void testNoIndexNameInOutput() throws IOException {
+        DeleteIndexStep deleteIndexStep = new DeleteIndexStep(client);
+
+        PlainActionFuture<WorkflowData> future = deleteIndexStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        assertTrue(future.isDone());
+        ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
+        assertTrue(ex.getCause() instanceof FlowFrameworkException);
+        assertEquals("Missing required inputs [index_name] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
+    }
+
+    public void testDeleteIndexFailure() throws IOException {
+        DeleteIndexStep deleteIndexStep = new DeleteIndexStep(client);
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> actionListener = invocation.getArgument(1);
+            actionListener.onFailure(new FlowFrameworkException("Failed", RestStatus.INTERNAL_SERVER_ERROR));
+            return null;
+        }).when(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());
+
+        PlainActionFuture<WorkflowData> future = deleteIndexStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Map.of("step_1", new WorkflowData(Map.of(INDEX_NAME, "test"), "workflowId", "nodeId")),
+            Map.of("step_1", INDEX_NAME),
+            Collections.emptyMap()
+        );
+
+        verify(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());
+
+        assertTrue(future.isDone());
+        ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
+        assertTrue(ex.getCause() instanceof FlowFrameworkException);
+        assertEquals("Failed to delete the index test", ex.getCause().getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteIngestPipelineStepTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.ingest.DeletePipelineRequest;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.Client;
+import org.opensearch.client.ClusterAdminClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.opensearch.flowframework.common.WorkflowResources.PIPELINE_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DeleteIngestPipelineStepTests extends OpenSearchTestCase {
+    private WorkflowData inputData;
+
+    @Mock
+    private Client client;
+    @Mock
+    private AdminClient adminClient;
+    @Mock
+    private ClusterAdminClient clusterAdminClient;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        MockitoAnnotations.openMocks(this);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.cluster()).thenReturn(clusterAdminClient);
+
+        inputData = new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id");
+    }
+
+    public void testDeletePipeline() throws IOException, ExecutionException, InterruptedException {
+
+        String pipelineId = randomAlphaOfLength(5);
+        DeleteIngestPipelineStep deleteIngestPipelineStep = new DeleteIngestPipelineStep(client);
+
+        doAnswer(invocation -> {
+            @SuppressWarnings("deprecation")
+            ActionListener<AcknowledgedResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(new AcknowledgedResponse(true));
+            return null;
+        }).when(clusterAdminClient).deletePipeline(any(DeletePipelineRequest.class), any());
+
+        PlainActionFuture<WorkflowData> future = deleteIngestPipelineStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, pipelineId), "workflowId", "nodeId")),
+            Map.of("step_1", PIPELINE_ID),
+            Collections.emptyMap()
+        );
+        verify(clusterAdminClient).deletePipeline(any(DeletePipelineRequest.class), any());
+
+        assertTrue(future.isDone());
+        assertEquals(pipelineId, future.get().getContent().get(PIPELINE_ID));
+    }
+
+    public void testNoPipelineIdInOutput() throws IOException {
+        DeleteIngestPipelineStep deleteIngestPipelineStep = new DeleteIngestPipelineStep(client);
+
+        PlainActionFuture<WorkflowData> future = deleteIngestPipelineStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        assertTrue(future.isDone());
+        ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
+        assertTrue(ex.getCause() instanceof FlowFrameworkException);
+        assertEquals("Missing required inputs [pipeline_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
+    }
+
+    public void testDeletePipelineFailure() throws IOException {
+        DeleteIngestPipelineStep deleteIngestPipelineStep = new DeleteIngestPipelineStep(client);
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> actionListener = invocation.getArgument(1);
+            actionListener.onFailure(new FlowFrameworkException("Failed", RestStatus.INTERNAL_SERVER_ERROR));
+            return null;
+        }).when(clusterAdminClient).deletePipeline(any(DeletePipelineRequest.class), any());
+
+        PlainActionFuture<WorkflowData> future = deleteIngestPipelineStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, "test"), "workflowId", "nodeId")),
+            Map.of("step_1", PIPELINE_ID),
+            Collections.emptyMap()
+        );
+
+        verify(clusterAdminClient).deletePipeline(any(DeletePipelineRequest.class), any());
+
+        assertTrue(future.isDone());
+        ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
+        assertTrue(ex.getCause() instanceof FlowFrameworkException);
+        assertEquals("Failed to delete the ingest pipeline test", ex.getCause().getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteSearchPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteSearchPipelineStepTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.workflow;
+
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.search.DeleteSearchPipelineRequest;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.Client;
+import org.opensearch.client.ClusterAdminClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.opensearch.flowframework.common.WorkflowResources.PIPELINE_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DeleteSearchPipelineStepTests extends OpenSearchTestCase {
+    private WorkflowData inputData;
+
+    @Mock
+    private Client client;
+    @Mock
+    private AdminClient adminClient;
+    @Mock
+    private ClusterAdminClient clusterAdminClient;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        MockitoAnnotations.openMocks(this);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.cluster()).thenReturn(clusterAdminClient);
+
+        inputData = new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id");
+    }
+
+    public void testDeleteSearchPipeline() throws IOException, ExecutionException, InterruptedException {
+
+        String pipelineId = randomAlphaOfLength(5);
+        DeleteSearchPipelineStep deleteSearchPipelineStep = new DeleteSearchPipelineStep(client);
+
+        doAnswer(invocation -> {
+            @SuppressWarnings("deprecation")
+            ActionListener<AcknowledgedResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(new AcknowledgedResponse(true));
+            return null;
+        }).when(clusterAdminClient).deleteSearchPipeline(any(DeleteSearchPipelineRequest.class), any());
+
+        PlainActionFuture<WorkflowData> future = deleteSearchPipelineStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, pipelineId), "workflowId", "nodeId")),
+            Map.of("step_1", PIPELINE_ID),
+            Collections.emptyMap()
+        );
+        verify(clusterAdminClient).deleteSearchPipeline(any(DeleteSearchPipelineRequest.class), any());
+
+        assertTrue(future.isDone());
+        assertEquals(pipelineId, future.get().getContent().get(PIPELINE_ID));
+    }
+
+    public void testNoPipelineIdInOutput() throws IOException {
+        DeleteSearchPipelineStep deleteSearchPipelineStep = new DeleteSearchPipelineStep(client);
+
+        PlainActionFuture<WorkflowData> future = deleteSearchPipelineStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+
+        assertTrue(future.isDone());
+        ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
+        assertTrue(ex.getCause() instanceof FlowFrameworkException);
+        assertEquals("Missing required inputs [pipeline_id] in workflow [test-id] node [test-node-id]", ex.getCause().getMessage());
+    }
+
+    public void testDeleteSearchPipelineFailure() throws IOException {
+        DeleteSearchPipelineStep deleteSearchPipelineStep = new DeleteSearchPipelineStep(client);
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> actionListener = invocation.getArgument(1);
+            actionListener.onFailure(new FlowFrameworkException("Failed", RestStatus.INTERNAL_SERVER_ERROR));
+            return null;
+        }).when(clusterAdminClient).deleteSearchPipeline(any(DeleteSearchPipelineRequest.class), any());
+
+        PlainActionFuture<WorkflowData> future = deleteSearchPipelineStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, "test"), "workflowId", "nodeId")),
+            Map.of("step_1", PIPELINE_ID),
+            Collections.emptyMap()
+        );
+
+        verify(clusterAdminClient).deleteSearchPipeline(any(DeleteSearchPipelineRequest.class), any());
+
+        assertTrue(future.isDone());
+        ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
+        assertTrue(ex.getCause() instanceof FlowFrameworkException);
+        assertEquals("Failed to delete the search pipeline test", ex.getCause().getMessage());
+    }
+}


### PR DESCRIPTION
### Description

Adds an `allow_delete` parameter to the Deprovision Workflow API which can contain a comma-delimited list of resource ids  which may be deleted.  

When the parameter does not contain resources that require it, the deprovision API returns a 403 response identifying the remaining resources.

Added `DeleteIndexStep`, `DeleteIngestPipelineStep`, and `DeleteSearchPipelineStep` which require the use of this parameter.

Added a denylist to prevent the use of these steps when provisioning workflows, and filtered the Get Workflow Steps API return to remove them from that list as well

### Issues Resolved

- #748
- #579

### Documentation

Please review:
 - https://github.com/opensearch-project/documentation-website/pull/7639

### Note to Reviewers

This implementation causes a change in API behavior.

Current behavior is to simply remove these unimplemented deletions from the resource list and silently fail, giving a 200 (OK) on successful deprovision while the resources remain.  (As a concrete example, if an index was created and included in the created resources list, deprovisioning would simply remove it from the resources list without taking any action (deleting the index).)

This is misleading, as an attempt to provision again will fail with a pre-existing index, so I think the change is justified, but should be made clear to anyone using existing scripting relying on this behavior.

I think 403 (Forbidden) is the best response type here, but I'm open to discussion here if you have a better proposal.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
