### PR TITLE
Change deprecated Gradle wrapper validation workflow to replacement

### DIFF
--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -14,4 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
### Description

Updates the Gradle wrapper validation action to the new Gradle actions wrapper.

### Issues Resolved

See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlewrapper-validation-action-has-been-replaced-by-gradleactionswrapper-validation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
