### PR TITLE
Initialize all shards on index creation to avoid mapping conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Register system index descriptors through SystemIndexPlugin.getSystemIndexDescriptors ([#750](https://github.com/opensearch-project/flow-framework/pull/750))
 
 ### Bug Fixes
+- Initialize all shards on index creation to avoid mapping conflicts ([#799](https://github.com/opensearch-project/flow-framework/pull/799))
+
 
 ### Infrastructure
 ### Documentation

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -20,6 +20,7 @@ import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
@@ -193,7 +194,9 @@ public class FlowFrameworkIndicesHandler {
                     logger.error(errorMessage, e);
                     internalListener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
                 });
-                CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping).settings(indexSettings);
+                CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping)
+                    .settings(indexSettings)
+                    .waitForActiveShards(ActiveShardCount.ALL);
                 client.admin().indices().create(request, actionListener);
             } else {
                 logger.debug("index: {} is already created", indexName);


### PR DESCRIPTION
### Description

Ensures index mappings are applied to all shards on system index creation to avoid mapping type conflicts on race condition.

### Related Issues

Fixes #798 

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
