### PR TITLE
Handle Not Found deprovision exceptions as successful deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Register system index descriptors through SystemIndexPlugin.getSystemIndexDescriptors ([#750](https://github.com/opensearch-project/flow-framework/pull/750))
 
 ### Bug Fixes
+- Handle Not Found exceptions as successful deletions for agents and models ([#805](https://github.com/opensearch-project/flow-framework/pull/805))
 
 ### Infrastructure
 ### Documentation

--- a/release-notes/opensearch-flow-framework.release-notes-2.16.0.0.md
+++ b/release-notes/opensearch-flow-framework.release-notes-2.16.0.0.md
@@ -8,6 +8,9 @@ Compatible with OpenSearch 2.16.0
 - Add allow_delete parameter to Deprovision API ([#763](https://github.com/opensearch-project/flow-framework/pull/763))
 - Improve Template and WorkflowState builders ([#778](https://github.com/opensearch-project/flow-framework/pull/778))
 
+### Bug Fixes
+- Handle Not Found deprovision exceptions as successful deletions ([#805](https://github.com/opensearch-project/flow-framework/pull/805))
+
 ### Infrastructure
 - Update dependency com.fasterxml.jackson.core:jackson-core to v2.17.2 ([#760](https://github.com/opensearch-project/flow-framework/pull/760))
 - Update dependency gradle to v8.8 ([#725](https://github.com/opensearch-project/flow-framework/pull/725))

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
@@ -11,9 +11,11 @@ package org.opensearch.flowframework.workflow;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.util.ParseUtils;
@@ -85,9 +87,21 @@ public class DeleteAgentStep implements WorkflowStep {
                 @Override
                 public void onFailure(Exception ex) {
                     Exception e = getSafeException(ex);
-                    String errorMessage = (e == null ? "Failed to delete agent " + agentId : e.getMessage());
-                    logger.error(errorMessage, e);
-                    deleteAgentFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
+                    // NOT_FOUND exception should be treated as successful deletion
+                    // https://github.com/opensearch-project/ml-commons/issues/2751
+                    if (e instanceof OpenSearchStatusException && ((OpenSearchStatusException) e).status().equals(RestStatus.NOT_FOUND)) {
+                        deleteAgentFuture.onResponse(
+                            new WorkflowData(
+                                Map.ofEntries(Map.entry(AGENT_ID, agentId)),
+                                currentNodeInputs.getWorkflowId(),
+                                currentNodeInputs.getNodeId()
+                            )
+                        );
+                    } else {
+                        String errorMessage = (e == null ? "Failed to delete agent " + agentId : e.getMessage());
+                        logger.error(errorMessage, e);
+                        deleteAgentFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
+                    }
                 }
             });
         } catch (FlowFrameworkException e) {


### PR DESCRIPTION
### Description

Treats a NOT_FOUND exception on deprovisioning agents and models as successful deprovision.

### Related Issues

Fixes #803 

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
