### PR TITLE
Wrap CreateIndexRequest mappings in _doc key as required

### DIFF
--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -193,7 +193,8 @@ public class FlowFrameworkIndicesHandler {
                     logger.error(errorMessage, e);
                     internalListener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
                 });
-                CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping).settings(indexSettings);
+                CreateIndexRequest request = new CreateIndexRequest(indexName).mapping("{\"_doc\":" + mapping + "}")
+                    .settings(indexSettings);
                 client.admin().indices().create(request, actionListener);
             } else {
                 logger.debug("index: {} is already created", indexName);


### PR DESCRIPTION
### Description

Adds the `_doc` key wrapper around index mapping as required by `CreateIndexRequest` javadoc.

### Related Issues

Fixes #798

See also https://github.com/opensearch-project/OpenSearch/issues/14984

### Check List
- [x] New functionality includes testing. (Integ tests pass. I've manually tested as well.)
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
