### PR TITLE
feat: parse connector id from tool parameters map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Adds reprovision API to support updating search pipelines, ingest pipelines index settings ([#804](https://github.com/opensearch-project/flow-framework/pull/804))
 - Adds user level access control based on backend roles ([#838](https://github.com/opensearch-project/flow-framework/pull/838))
 - Support parsing connector_id when creating tools ([#846](https://github.com/opensearch-project/flow-framework/pull/846))
->>>>>>> 222094d (update changelog)
 
 ### Enhancements
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 - Adds reprovision API to support updating search pipelines, ingest pipelines index settings ([#804](https://github.com/opensearch-project/flow-framework/pull/804))
 - Adds user level access control based on backend roles ([#838](https://github.com/opensearch-project/flow-framework/pull/838))
+- Support parsing connector_id when creating tools ([#846](https://github.com/opensearch-project/flow-framework/pull/846))
+>>>>>>> 222094d (update changelog)
 
 ### Enhancements
 ### Bug Fixes

--- a/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
@@ -65,7 +65,15 @@ public class ToolStep implements WorkflowStep {
             String name = (String) inputs.get(NAME_FIELD);
             String description = (String) inputs.get(DESCRIPTION_FIELD);
             Boolean includeOutputInAgentResponse = ParseUtils.parseIfExists(inputs, INCLUDE_OUTPUT_IN_AGENT_RESPONSE, Boolean.class);
-            Map<String, String> parameters = getToolsParametersMap(inputs.get(PARAMETERS_FIELD), previousNodeInputs, outputs);
+
+            // parse connector_id, model_id and agent_id from previous node inputs
+            Set<String> toolParameterKeys = Set.of(CONNECTOR_ID, MODEL_ID, AGENT_ID);
+            Map<String, String> parameters = getToolsParametersMap(
+                inputs.get(PARAMETERS_FIELD),
+                previousNodeInputs,
+                outputs,
+                toolParameterKeys
+            );
 
             MLToolSpec.MLToolSpecBuilder builder = MLToolSpec.builder();
 
@@ -111,54 +119,29 @@ public class ToolStep implements WorkflowStep {
     private Map<String, String> getToolsParametersMap(
         Object parameters,
         Map<String, String> previousNodeInputs,
-        Map<String, WorkflowData> outputs
+        Map<String, WorkflowData> outputs,
+        Set<String> toolParameterKeys
     ) {
         @SuppressWarnings("unchecked")
         Map<String, String> parametersMap = (Map<String, String>) parameters;
 
-        Optional<String> previousNodeConnector = previousNodeInputs.entrySet()
-            .stream()
-            .filter(e -> CONNECTOR_ID.equals(e.getValue()))
-            .map(Map.Entry::getKey)
-            .findFirst();
+        for (String toolParameterKey : toolParameterKeys) {
+            Optional<String> previousNodeParameter = previousNodeInputs.entrySet()
+                .stream()
+                .filter(e -> toolParameterKey.equals(e.getValue()))
+                .map(Map.Entry::getKey)
+                .findFirst();
 
-        Optional<String> previousNodeModel = previousNodeInputs.entrySet()
-            .stream()
-            .filter(e -> MODEL_ID.equals(e.getValue()))
-            .map(Map.Entry::getKey)
-            .findFirst();
-
-        Optional<String> previousNodeAgent = previousNodeInputs.entrySet()
-            .stream()
-            .filter(e -> AGENT_ID.equals(e.getValue()))
-            .map(Map.Entry::getKey)
-            .findFirst();
-
-        // Case when connectorId is passed through previousSteps and not present already in parameters
-        if (previousNodeConnector.isPresent() && !parametersMap.containsKey(CONNECTOR_ID)) {
-            WorkflowData previousNodeOutput = outputs.get(previousNodeConnector.get());
-            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(CONNECTOR_ID)) {
-                parametersMap.put(CONNECTOR_ID, previousNodeOutput.getContent().get(CONNECTOR_ID).toString());
+            // Case when toolParameterKey is passed through previousSteps and not present already in parameters
+            if (previousNodeParameter.isPresent() && !parametersMap.containsKey(toolParameterKey)) {
+                WorkflowData previousNodeOutput = outputs.get(previousNodeParameter.get());
+                if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(toolParameterKey)) {
+                    parametersMap.put(toolParameterKey, previousNodeOutput.getContent().get(toolParameterKey).toString());
+                }
             }
         }
 
-        // Case when modelId is passed through previousSteps and not present already in parameters
-        if (previousNodeModel.isPresent() && !parametersMap.containsKey(MODEL_ID)) {
-            WorkflowData previousNodeOutput = outputs.get(previousNodeModel.get());
-            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(MODEL_ID)) {
-                parametersMap.put(MODEL_ID, previousNodeOutput.getContent().get(MODEL_ID).toString());
-            }
-        }
-
-        // Case when agentId is passed through previousSteps and not present already in parameters
-        if (previousNodeAgent.isPresent() && !parametersMap.containsKey(AGENT_ID)) {
-            WorkflowData previousNodeOutput = outputs.get(previousNodeAgent.get());
-            if (previousNodeOutput != null && previousNodeOutput.getContent().containsKey(AGENT_ID)) {
-                parametersMap.put(AGENT_ID, previousNodeOutput.getContent().get(AGENT_ID).toString());
-            }
-        }
-
-        // For other cases where modelId is already present in the parameters or not return the parametersMap
+        // For other cases where toolParameterKey is already present in the parameters or not return the parametersMap
         return parametersMap;
     }
 

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -661,6 +661,23 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
     }
 
     /**
+     * Helper method to invoke the Get Agent Rest Action
+     * @param client the rest client
+     * @return rest response
+     * @throws Exception
+     */
+    protected Response getAgent(RestClient client, String agentId) throws Exception {
+        return TestHelpers.makeRequest(
+            client,
+            "GET",
+            String.format(Locale.ROOT, "/_plugins/_ml/agents/%s", agentId),
+            Collections.emptyMap(),
+            "",
+            null
+        );
+    }
+
+    /**
      * Helper method to invoke the Search Workflow Rest Action with the given query
      * @param client the rest client
      * @param query the search query
@@ -668,7 +685,6 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
      * @throws Exception if the request fails
      */
     protected SearchResponse searchWorkflows(RestClient client, String query) throws Exception {
-
         // Execute search
         Response restSearchResponse = TestHelpers.makeRequest(
             client,
@@ -706,38 +722,6 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
             client,
             "GET",
             String.format(Locale.ROOT, "%s/state/_search", WORKFLOW_URI),
-            Collections.emptyMap(),
-            query,
-            null
-        );
-        assertEquals(RestStatus.OK, TestHelpers.restStatus(restSearchResponse));
-
-        // Parse entity content into SearchResponse
-        MediaType mediaType = MediaType.fromMediaType(restSearchResponse.getEntity().getContentType());
-        try (
-            XContentParser parser = mediaType.xContent()
-                .createParser(
-                    NamedXContentRegistry.EMPTY,
-                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                    restSearchResponse.getEntity().getContent()
-                )
-        ) {
-            return SearchResponse.fromXContent(parser);
-        }
-    }
-
-    /**
-     * Helper method to invoke the Search Agent Rest Action
-     * @param client the rest client
-     * @param query the search query
-     * @return
-     * @throws Exception
-     */
-    protected SearchResponse searchAgent(RestClient client, String query) throws Exception {
-        Response restSearchResponse = TestHelpers.makeRequest(
-            client,
-            "GET",
-            "/_plugins/_ml/agents/_search",
             Collections.emptyMap(),
             query,
             null

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -727,6 +727,38 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
     }
 
     /**
+     * Helper method to invoke the Search Agent Rest Action
+     * @param client the rest client
+     * @param query the search query
+     * @return
+     * @throws Exception
+     */
+    protected SearchResponse searchAgent(RestClient client, String query) throws Exception {
+        Response restSearchResponse = TestHelpers.makeRequest(
+            client,
+            "GET",
+            "/_plugins/_ml/agents/_search",
+            Collections.emptyMap(),
+            query,
+            null
+        );
+        assertEquals(RestStatus.OK, TestHelpers.restStatus(restSearchResponse));
+
+        // Parse entity content into SearchResponse
+        MediaType mediaType = MediaType.fromMediaType(restSearchResponse.getEntity().getContentType());
+        try (
+            XContentParser parser = mediaType.xContent()
+                .createParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    restSearchResponse.getEntity().getContent()
+                )
+        ) {
+            return SearchResponse.fromXContent(parser);
+        }
+    }
+
+    /**
      * Helper method to invoke the Get Workflow Status Rest Action and assert the provisioning and state status
      * @param client the rest client
      * @param workflowId the workflow ID to get the status

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -25,11 +25,13 @@ import org.opensearch.flowframework.model.Workflow;
 import org.opensearch.flowframework.model.WorkflowEdge;
 import org.opensearch.flowframework.model.WorkflowNode;
 import org.opensearch.flowframework.model.WorkflowState;
+import org.opensearch.search.SearchHit;
 import org.junit.Before;
 import org.junit.ComparisonFailure;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -56,7 +58,6 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
     }
 
     public void testSearchWorkflows() throws Exception {
-
         // Create a Workflow that has a credential 12345
         Template template = TestHelpers.createTemplateFromFile("createconnector-registerremotemodel-deploymodel.json");
         Response response = createWorkflow(client(), template);
@@ -228,7 +229,6 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
     }
 
     public void testCreateAndProvisionRemoteModelWorkflow() throws Exception {
-
         // Using a 3 step template to create a connector, register remote model and deploy model
         Template template = TestHelpers.createTemplateFromFile("createconnector-registerremotemodel-deploymodel.json");
 
@@ -298,6 +298,91 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         assertEquals(5, resourcesCreated.size());
         assertEquals(stepNames, expectedStepNames);
         assertNotNull(resourcesCreated.get(0).resourceId());
+
+        // Hit Deprovision API
+        // By design, this may not completely deprovision the first time if it takes >2s to process removals
+        Response deprovisionResponse = deprovisionWorkflow(client(), workflowId);
+        try {
+            assertBusy(
+                () -> { getAndAssertWorkflowStatus(client(), workflowId, State.NOT_STARTED, ProvisioningProgress.NOT_STARTED); },
+                30,
+                TimeUnit.SECONDS
+            );
+        } catch (ComparisonFailure e) {
+            // 202 return if still processing
+            assertEquals(RestStatus.ACCEPTED, TestHelpers.restStatus(deprovisionResponse));
+        }
+        if (TestHelpers.restStatus(deprovisionResponse) == RestStatus.ACCEPTED) {
+            // Short wait before we try again
+            Thread.sleep(10000);
+            deprovisionResponse = deprovisionWorkflow(client(), workflowId);
+            assertBusy(
+                () -> { getAndAssertWorkflowStatus(client(), workflowId, State.NOT_STARTED, ProvisioningProgress.NOT_STARTED); },
+                30,
+                TimeUnit.SECONDS
+            );
+        }
+        assertEquals(RestStatus.OK, TestHelpers.restStatus(deprovisionResponse));
+        // Hit Delete API
+        Response deleteResponse = deleteWorkflow(client(), workflowId);
+        assertEquals(RestStatus.OK, TestHelpers.restStatus(deleteResponse));
+
+        // Verify state doc is deleted
+        assertBusy(() -> { getAndAssertWorkflowStatusNotFound(client(), workflowId); }, 30, TimeUnit.SECONDS);
+    }
+
+    public void testCreateAndProvisionConnectorToolAgentFrameworkWorkflow() throws Exception {
+        // Create a Workflow that has a credential 12345
+        Template template = TestHelpers.createTemplateFromFile("createconnector-createconnectortool-createflowagent.json");
+
+        // Hit Create Workflow API to create agent-framework template, with template validation check and provision parameter
+        Response response = createWorkflowWithProvision(client(), template);
+        assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
+        Map<String, Object> responseMap = entityAsMap(response);
+        String workflowId = (String) responseMap.get(WORKFLOW_ID);
+        // wait and ensure state is completed/done
+        assertBusy(
+            () -> { getAndAssertWorkflowStatus(client(), workflowId, State.COMPLETED, ProvisioningProgress.DONE); },
+            120,
+            TimeUnit.SECONDS
+        );
+
+        // Hit Search State API with the workflow id created above
+        String query = "{\"query\":{\"ids\":{\"values\":[\"" + workflowId + "\"]}}}";
+        SearchResponse searchResponse = searchWorkflowState(client(), query);
+        assertEquals(1, searchResponse.getHits().getTotalHits().value);
+        String searchHitSource = searchResponse.getHits().getAt(0).getSourceAsString();
+        WorkflowState searchHitWorkflowState = WorkflowState.parse(searchHitSource);
+
+        // Assert based on the agent-framework template
+        List<ResourceCreated> resourcesCreated = searchHitWorkflowState.resourcesCreated();
+        Set<String> expectedStepNames = new HashSet<>();
+        expectedStepNames.add("create_connector");
+        expectedStepNames.add("create_flow_agent");
+        Set<String> stepNames = resourcesCreated.stream().map(ResourceCreated::workflowStepId).collect(Collectors.toSet());
+
+        assertEquals(2, resourcesCreated.size());
+        assertEquals(stepNames, expectedStepNames);
+        String connectorId = resourcesCreated.getFirst().resourceId();
+        String agentId = resourcesCreated.get(1).resourceId();
+        assertNotNull(connectorId);
+        assertNotNull(agentId);
+
+        query = "{\"query\":{\"ids\":{\"values\":[\"" + agentId + "\"]}}}";
+        searchResponse = searchAgent(client(), query);
+        assertEquals(1, searchResponse.getHits().getTotalHits().value);
+        SearchHit searchHit = searchResponse.getHits().getAt(0);
+        Map<String, Object> searchHitSourceMap = searchHit.getSourceAsMap();
+        assertTrue(searchHitSourceMap.containsKey("tools"));
+
+        @SuppressWarnings("unchecked")
+        ArrayList<Map<String, Object>> tools = (ArrayList<Map<String, Object>>) searchHitSourceMap.get("tools");
+        assertEquals(1, tools.size());
+        Map<String, Object> tool = tools.getFirst();
+        assertTrue(tool.containsKey("parameters"));
+        @SuppressWarnings("unchecked")
+        Map<String, String> toolParameters = (Map<String, String>) tool.get("parameters");
+        assertEquals(toolParameters, Map.of("connector_id", connectorId));
 
         // Hit Deprovision API
         // By design, this may not completely deprovision the first time if it takes >2s to process removals

--- a/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
@@ -30,6 +30,9 @@ public class ToolStepTests extends OpenSearchTestCase {
     private static final String mockedConnectorId = "mocked-connector-id";
     private static final String mockedModelId = "mocked-model-id";
     private static final String mockedAgentId = "mocked-agent-id";
+    private static final String createConnectorNodeId = "create_connector_node_id";
+    private static final String createModelNodeId = "create_model_node_id";
+    private static final String createAgentNodeId = "create_agent_node_id";
 
     private WorkflowData boolStringInputData;
     private WorkflowData badBoolInputData;
@@ -49,9 +52,9 @@ public class ToolStepTests extends OpenSearchTestCase {
             "test-id",
             "test-node-id"
         );
-        inputDataWithConnectorId = new WorkflowData(Map.of(CONNECTOR_ID, mockedConnectorId), "test-id", "test-node-id");
-        inputDataWithModelId = new WorkflowData(Map.of(MODEL_ID, mockedModelId), "test-id", "test-node-id");
-        inputDataWithAgentId = new WorkflowData(Map.of(AGENT_ID, mockedAgentId), "test-id", "test-node-id");
+        inputDataWithConnectorId = new WorkflowData(Map.of(CONNECTOR_ID, mockedConnectorId), "test-id", createConnectorNodeId);
+        inputDataWithModelId = new WorkflowData(Map.of(MODEL_ID, mockedModelId), "test-id", createModelNodeId);
+        inputDataWithAgentId = new WorkflowData(Map.of(AGENT_ID, mockedAgentId), "test-id", createAgentNodeId);
         boolStringInputData = new WorkflowData(
             Map.ofEntries(
                 Map.entry("type", "type"),
@@ -123,12 +126,11 @@ public class ToolStepTests extends OpenSearchTestCase {
     public void testToolWithConnectorId() throws ExecutionException, InterruptedException {
         ToolStep toolStep = new ToolStep();
 
-        String createConnectorNodeName = "create_connector";
         PlainActionFuture<WorkflowData> future = toolStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of(createConnectorNodeName, inputDataWithConnectorId),
-            Map.of(createConnectorNodeName, CONNECTOR_ID),
+            Map.of(createConnectorNodeId, inputDataWithConnectorId),
+            Map.of(createConnectorNodeId, CONNECTOR_ID),
             Collections.emptyMap()
         );
         assertTrue(future.isDone());
@@ -141,12 +143,11 @@ public class ToolStepTests extends OpenSearchTestCase {
     public void testToolWithModelId() throws ExecutionException, InterruptedException {
         ToolStep toolStep = new ToolStep();
 
-        String createModelNodeName = "create_model";
         PlainActionFuture<WorkflowData> future = toolStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of(createModelNodeName, inputDataWithModelId),
-            Map.of(createModelNodeName, MODEL_ID),
+            Map.of(createModelNodeId, inputDataWithModelId),
+            Map.of(createModelNodeId, MODEL_ID),
             Collections.emptyMap()
         );
         assertTrue(future.isDone());
@@ -159,12 +160,11 @@ public class ToolStepTests extends OpenSearchTestCase {
     public void testToolWithAgentId() throws ExecutionException, InterruptedException {
         ToolStep toolStep = new ToolStep();
 
-        String createAgentNodeName = "create_agent";
         PlainActionFuture<WorkflowData> future = toolStep.execute(
             inputData.getNodeId(),
             inputData,
-            Map.of(createAgentNodeName, inputDataWithAgentId),
-            Map.of(createAgentNodeName, AGENT_ID),
+            Map.of(createAgentNodeId, inputDataWithAgentId),
+            Map.of(createAgentNodeId, AGENT_ID),
             Collections.emptyMap()
         );
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
@@ -14,13 +14,23 @@ import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.ml.common.agent.MLToolSpec;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import static org.opensearch.flowframework.common.WorkflowResources.AGENT_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
+import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
+
 public class ToolStepTests extends OpenSearchTestCase {
     private WorkflowData inputData;
+    private WorkflowData inputDataWithConnectorId;
+    private WorkflowData inputDataWithModelId;
+    private WorkflowData inputDataWithAgentId;
+    private static final String mockedConnectorId = "mocked-connector-id";
+    private static final String mockedModelId = "mocked-model-id";
+    private static final String mockedAgentId = "mocked-agent-id";
+
     private WorkflowData boolStringInputData;
     private WorkflowData badBoolInputData;
 
@@ -39,6 +49,9 @@ public class ToolStepTests extends OpenSearchTestCase {
             "test-id",
             "test-node-id"
         );
+        inputDataWithConnectorId = new WorkflowData(Map.of(CONNECTOR_ID, mockedConnectorId), "test-id", "test-node-id");
+        inputDataWithModelId = new WorkflowData(Map.of(MODEL_ID, mockedModelId), "test-id", "test-node-id");
+        inputDataWithAgentId = new WorkflowData(Map.of(AGENT_ID, mockedAgentId), "test-id", "test-node-id");
         boolStringInputData = new WorkflowData(
             Map.ofEntries(
                 Map.entry("type", "type"),
@@ -63,7 +76,7 @@ public class ToolStepTests extends OpenSearchTestCase {
         );
     }
 
-    public void testTool() throws IOException, ExecutionException, InterruptedException {
+    public void testTool() throws ExecutionException, InterruptedException {
         ToolStep toolStep = new ToolStep();
 
         PlainActionFuture<WorkflowData> future = toolStep.execute(
@@ -88,7 +101,7 @@ public class ToolStepTests extends OpenSearchTestCase {
         assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
     }
 
-    public void testBoolParseFail() throws IOException, ExecutionException, InterruptedException {
+    public void testBoolParseFail() {
         ToolStep toolStep = new ToolStep();
 
         PlainActionFuture<WorkflowData> future = toolStep.execute(
@@ -100,10 +113,64 @@ public class ToolStepTests extends OpenSearchTestCase {
         );
 
         assertTrue(future.isDone());
-        ExecutionException e = assertThrows(ExecutionException.class, () -> future.get());
+        ExecutionException e = assertThrows(ExecutionException.class, future::get);
         assertEquals(WorkflowStepException.class, e.getCause().getClass());
         WorkflowStepException w = (WorkflowStepException) e.getCause();
         assertEquals("Failed to parse value [yes] as only [true] or [false] are allowed.", w.getMessage());
         assertEquals(RestStatus.BAD_REQUEST, w.getRestStatus());
+    }
+
+    public void testToolWithConnectorId() throws ExecutionException, InterruptedException {
+        ToolStep toolStep = new ToolStep();
+
+        String createConnectorNodeName = "create_connector";
+        PlainActionFuture<WorkflowData> future = toolStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Map.of(createConnectorNodeName, inputDataWithConnectorId),
+            Map.of(createConnectorNodeName, CONNECTOR_ID),
+            Collections.emptyMap()
+        );
+        assertTrue(future.isDone());
+        Object tools = future.get().getContent().get("tools");
+        assertEquals(MLToolSpec.class, tools.getClass());
+        MLToolSpec mlToolSpec = (MLToolSpec) tools;
+        assertEquals(mlToolSpec.getParameters(), Map.of(CONNECTOR_ID, mockedConnectorId));
+    }
+
+    public void testToolWithModelId() throws ExecutionException, InterruptedException {
+        ToolStep toolStep = new ToolStep();
+
+        String createModelNodeName = "create_model";
+        PlainActionFuture<WorkflowData> future = toolStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Map.of(createModelNodeName, inputDataWithModelId),
+            Map.of(createModelNodeName, MODEL_ID),
+            Collections.emptyMap()
+        );
+        assertTrue(future.isDone());
+        Object tools = future.get().getContent().get("tools");
+        assertEquals(MLToolSpec.class, tools.getClass());
+        MLToolSpec mlToolSpec = (MLToolSpec) tools;
+        assertEquals(mlToolSpec.getParameters(), Map.of(MODEL_ID, mockedModelId));
+    }
+
+    public void testToolWithAgentId() throws ExecutionException, InterruptedException {
+        ToolStep toolStep = new ToolStep();
+
+        String createAgentNodeName = "create_agent";
+        PlainActionFuture<WorkflowData> future = toolStep.execute(
+            inputData.getNodeId(),
+            inputData,
+            Map.of(createAgentNodeName, inputDataWithAgentId),
+            Map.of(createAgentNodeName, AGENT_ID),
+            Collections.emptyMap()
+        );
+        assertTrue(future.isDone());
+        Object tools = future.get().getContent().get("tools");
+        assertEquals(MLToolSpec.class, tools.getClass());
+        MLToolSpec mlToolSpec = (MLToolSpec) tools;
+        assertEquals(mlToolSpec.getParameters(), Map.of(AGENT_ID, mockedAgentId));
     }
 }

--- a/src/test/resources/template/createconnector-createconnectortool-createflowagent.json
+++ b/src/test/resources/template/createconnector-createconnectortool-createflowagent.json
@@ -1,11 +1,11 @@
 {
-  "name": "createconnector-registerremotemodel-deploymodel",
+  "name": "createconnector-createconnectortool-createflowagent",
   "description": "test case",
   "use_case": "TEST_CASE",
   "version": {
     "template": "1.0.0",
     "compatibility": [
-      "2.12.0",
+      "2.15.0",
       "3.0.0"
     ]
   },
@@ -13,7 +13,7 @@
     "provision": {
       "nodes": [
         {
-          "id": "workflow_step_1",
+          "id": "create_connector",
           "type": "create_connector",
           "user_inputs": {
             "name": "OpenAI Chat Connector",
@@ -37,33 +37,38 @@
           }
         },
         {
-          "id": "workflow_step_2",
-          "type": "register_remote_model",
+          "id": "create_tool",
+          "type": "create_tool",
           "previous_node_inputs": {
-            "workflow_step_1": "connector_id"
+            "create_connector": "connector_id"
           },
           "user_inputs": {
-            "name": "openAI-gpt-3.5-turbo",
-            "function_name": "remote",
-            "description": "test model"
+            "parameters": {},
+            "name": "ConnectorTool",
+            "type": "ConnectorTool"
           }
         },
         {
-          "id": "workflow_step_3",
-          "type": "deploy_model",
+          "id": "create_flow_agent",
+          "type": "register_agent",
           "previous_node_inputs": {
-            "workflow_step_2": "model_id"
+            "create_tool": "tools"
+          },
+          "user_inputs": {
+            "parameters": {},
+            "type": "flow",
+            "name": "OpenAI Chat Agent"
           }
         }
       ],
       "edges": [
         {
-          "source": "workflow_step_1",
-          "dest": "workflow_step_2"
+          "source": "create_connector",
+          "dest": "create_tool"
         },
         {
-          "source": "workflow_step_2",
-          "dest": "workflow_step_3"
+          "source": "create_tool",
+          "dest": "create_flow_agent"
         }
       ]
     }


### PR DESCRIPTION
### Description
Parse connector id from `previous_node_inputs` into the parameters map

```
{
  "id": "create_connector_tool",
  "type": "create_tool",
  "previous_node_inputs": {
    "create_connector": "connector_id"
  },
  "user_inputs": {
    "parameters": {},
    "name": "ConnectorTool",
    "type": "ConnectorTool"
  }
}
```

### Related Issues
Resolves https://github.com/opensearch-project/flow-framework/issues/845
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~ [Already documented](https://opensearch.org/docs/latest/ml-commons-plugin/agents-tools/tools/connector-tool/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
