### PR TITLE
Reset CHANGELOG for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,11 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Maintenance
 ### Refactoring
 
-## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.14...2.x)
+## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.17...2.x)
 ### Features
-- Adds reprovision API to support updating search pipelines, ingest pipelines index settings ([#804](https://github.com/opensearch-project/flow-framework/pull/804))
-- Adds user level access control based on backend roles ([#838](https://github.com/opensearch-project/flow-framework/pull/838))
-- Support parsing connector_id when creating tools ([#846](https://github.com/opensearch-project/flow-framework/pull/846))
-
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
 ### Documentation
 ### Maintenance
 ### Refactoring
-- Refactor workflow step resource updates to eliminate duplication ([#796](https://github.com/opensearch-project/flow-framework/pull/796))


### PR DESCRIPTION
### Description

Resets the change log, as all the 2.17.0 changes have been copied to release notes

### Related Issues

Follow on to  #853 

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
