### PR TITLE
Quick fix for flaky integ test reprovisioning before template update

### DIFF
--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -446,6 +446,7 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         assertTrue(getPipelineResponse.pipelines().get(0).getConfigAsMap().toString().contains(modelId));
 
         // Reprovision template to add index which uses default ingest pipeline
+        Instant preUpdateTime = Instant.now(); // Store a timestamp
         template = TestHelpers.createTemplateFromFile("registerremotemodel-ingestpipeline-createindex.json");
         response = reprovisionWorkflow(client(), workflowId, template);
         assertEquals(RestStatus.CREATED, TestHelpers.restStatus(response));
@@ -462,6 +463,17 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         String indexName = resourceMap.get("create_index").resourceId();
         Map<String, Object> indexSettings = getIndexSettingsAsMap(indexName);
         assertEquals(pipelineId, indexSettings.get("index.default_pipeline"));
+
+        // The template doesn't get updated until after the resources are created which can cause a race condition and flaky failure
+        // See https://github.com/opensearch-project/flow-framework/issues/870
+        // Making sure the template got updated before reprovisioning again.
+        // Quick fix to stop this from being flaky, needs a more permanent fix to synchronize template update with COMPLETED provisioning
+        assertBusy(() -> {
+            Response r = getWorkflow(client(), workflowId);
+            assertEquals(RestStatus.OK.getStatus(), r.getStatusLine().getStatusCode());
+            Template t = Template.parse(EntityUtils.toString(r.getEntity(), StandardCharsets.UTF_8));
+            assertTrue(t.lastUpdatedTime().isAfter(preUpdateTime));
+        }, 30, TimeUnit.SECONDS);
 
         // Reprovision template to remove default ingest pipeline
         template = TestHelpers.createTemplateFromFile("registerremotemodel-ingestpipeline-updateindex.json");


### PR DESCRIPTION
### Description

Quick fix for flaky integ test, to reduce retry churn for 2.17.1 release. 

### Related Issues

Temporary workaround for https://github.com/opensearch-project/flow-framework/issues/870.  Needs a better permanent fix where we can just test the completed state and be assured the template is also updated.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
