### PR TITLE
Update workflow state without using painless script 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add query assist data summary agent into sample templates ([#875](https://github.com/opensearch-project/flow-framework/pull/875))
 ### Maintenance
 ### Refactoring
+- Update workflow state without using painless script ([#894](https://github.com/opensearch-project/flow-framework/pull/894))

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -691,7 +691,7 @@ public class FlowFrameworkIndicesHandler {
                 getAndUpdateResourceInStateDocumentWithRetries(
                     workflowId,
                     newResource,
-                    3,
+                    5,
                     ActionListener.runBefore(listener, context::restore)
                 );
             }

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -727,31 +727,14 @@ public class FlowFrameworkIndicesHandler {
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .setIfSeqNo(getResponse.getSeqNo())
                 .setIfPrimaryTerm(getResponse.getPrimaryTerm());
-            updateResourceInStateDocumentWithRetries(updateRequest, newResource, retries, listener);
-        }, e -> handleStateUpdateException(workflowId, newResource, 0, listener, e)));
-    }
-
-    /**
-     * Performs an update of a State Index document with strong consistency and retries
-     * @param updateRequest An update request ensuring the document being updated is the one just fetched
-     * @param newResource The resource to add to the resources created list
-     * @param retries The number of retries on update version conflicts
-     * @param listener The listener to complete on success or failure
-     */
-    private void updateResourceInStateDocumentWithRetries(
-        UpdateRequest updateRequest,
-        ResourceCreated newResource,
-        int retries,
-        ActionListener<WorkflowData> listener
-    ) {
-        String workflowId = updateRequest.id();
-        client.update(
-            updateRequest,
-            ActionListener.wrap(
-                r -> handleStateUpdateSuccess(workflowId, newResource, listener),
-                e -> handleStateUpdateException(workflowId, newResource, retries, listener, e)
-            )
-        );
+            client.update(
+                updateRequest,
+                ActionListener.wrap(
+                    r -> handleStateUpdateSuccess(workflowId, newResource, listener),
+                    e -> handleStateUpdateException(workflowId, newResource, retries, listener, e)
+                )
+            );
+        }, ex -> handleStateUpdateException(workflowId, newResource, 0, listener, ex)));
     }
 
     private void handleStateUpdateSuccess(String workflowId, ResourceCreated newResource, ActionListener<WorkflowData> listener) {

--- a/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
+++ b/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
@@ -611,7 +611,7 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
             exceptionCaptor.getValue().getMessage()
         );
 
-        // test index not found
+        // test document not found
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowData> notFoundListener = mock(ActionListener.class);
         doAnswer(invocation -> {
@@ -632,6 +632,24 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
         verify(notFoundListener, times(1)).onFailure(exceptionCaptor.capture());
         assertEquals("Workflow state not found for this_id", exceptionCaptor.getValue().getMessage());
 
+        // test index not found
+        when(mockMetaData.hasIndex(WORKFLOW_STATE_INDEX)).thenReturn(false);
+        @SuppressWarnings("unchecked")
+        ActionListener<WorkflowData> indexNotFoundListener = mock(ActionListener.class);
+        flowFrameworkIndicesHandler.addResourceToStateIndex(
+            new WorkflowData(Collections.emptyMap(), "this_id", null),
+            "node_id",
+            CreateConnectorStep.NAME,
+            "this_id",
+            indexNotFoundListener
+        );
+
+        exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(indexNotFoundListener, times(1)).onFailure(exceptionCaptor.capture());
+        assertEquals(
+            "Failed to update state for this_id due to missing .plugins-flow-framework-state index",
+            exceptionCaptor.getValue().getMessage()
+        );
     }
 
     public void testAddResourceToStateIndexWithRetries() throws IOException {

--- a/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
+++ b/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
@@ -700,10 +700,18 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
         verify(retryListener, times(1)).onResponse(responseCaptor.capture());
         assertEquals("this_id", responseCaptor.getValue().getContent().get(WorkflowResources.CONNECTOR_ID));
 
-        // test failure on 4th after 3 retries even if 5th would have been success
+        // test failure on 6th after 5 retries even if 7th would have been success
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowData> threeRetryListener = mock(ActionListener.class);
         doAnswer(invocation -> {
+            ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
+            responseListener.onFailure(conflictException);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
+            responseListener.onFailure(conflictException);
+            return null;
+        }).doAnswer(invocation -> {
             ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
             responseListener.onFailure(conflictException);
             return null;

--- a/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
+++ b/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
@@ -47,6 +47,7 @@ import org.opensearch.flowframework.util.EncryptorUtils;
 import org.opensearch.flowframework.workflow.CreateConnectorStep;
 import org.opensearch.flowframework.workflow.CreateIndexStep;
 import org.opensearch.flowframework.workflow.WorkflowData;
+import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -503,13 +504,23 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
         ActionListener<WorkflowData> listener = mock(ActionListener.class);
         // test success
         doAnswer(invocation -> {
+            ActionListener<GetResponse> responseListener = invocation.getArgument(1);
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            WorkflowState state = WorkflowState.builder().build();
+            state.toXContent(builder, null);
+            BytesReference workflowBytesRef = BytesReference.bytes(builder);
+            GetResult getResult = new GetResult(WORKFLOW_STATE_INDEX, "this_id", 1, 1, 1, true, workflowBytesRef, null, null);
+            responseListener.onResponse(new GetResponse(getResult));
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+        doAnswer(invocation -> {
             ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
             responseListener.onResponse(new UpdateResponse(new ShardId(WORKFLOW_STATE_INDEX, "", 1), "this_id", -2, 0, 0, Result.UPDATED));
             return null;
         }).when(client).update(any(UpdateRequest.class), any());
 
         flowFrameworkIndicesHandler.addResourceToStateIndex(
-            new WorkflowData(Collections.emptyMap(), null, null),
+            new WorkflowData(Collections.emptyMap(), "this_id", null),
             "node_id",
             CreateConnectorStep.NAME,
             "this_id",
@@ -528,7 +539,7 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
         }).when(client).update(any(UpdateRequest.class), any());
 
         flowFrameworkIndicesHandler.addResourceToStateIndex(
-            new WorkflowData(Collections.emptyMap(), null, null),
+            new WorkflowData(Collections.emptyMap(), "this_id", null),
             "node_id",
             CreateConnectorStep.NAME,
             "this_id",
@@ -537,6 +548,124 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
 
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener, times(1)).onFailure(exceptionCaptor.capture());
-        assertEquals("Failed to update new created node_id resource create_connector id this_id", exceptionCaptor.getValue().getMessage());
+        assertEquals(
+            "Failed to update workflow state for this_id on step node_id with connector_id this_id",
+            exceptionCaptor.getValue().getMessage()
+        );
+        
+        // test index not found
+        @SuppressWarnings("unchecked")
+        ActionListener<WorkflowData> notFoundListener = mock(ActionListener.class);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> responseListener = invocation.getArgument(1);
+            GetResult getResult = new GetResult(WORKFLOW_STATE_INDEX, "this_id", -2, 0, 1, false, null, null, null);
+            responseListener.onResponse(new GetResponse(getResult));
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+        flowFrameworkIndicesHandler.addResourceToStateIndex(
+            new WorkflowData(Collections.emptyMap(), "this_id", null),
+            "node_id",
+            CreateConnectorStep.NAME,
+            "this_id",
+            notFoundListener
+        );
+
+        exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(notFoundListener, times(1)).onFailure(exceptionCaptor.capture());
+        assertEquals(
+            "Workflow state not found for this_id",
+            exceptionCaptor.getValue().getMessage()
+        );
+
+    }
+
+    public void testAddResourceToStateIndexWithRetries() throws IOException {
+        ClusterState mockClusterState = mock(ClusterState.class);
+        Metadata mockMetaData = mock(Metadata.class);
+        when(clusterService.state()).thenReturn(mockClusterState);
+        when(mockClusterState.metadata()).thenReturn(mockMetaData);
+        when(mockMetaData.hasIndex(WORKFLOW_STATE_INDEX)).thenReturn(true);
+        VersionConflictEngineException conflictException = new VersionConflictEngineException(
+            new ShardId(WORKFLOW_STATE_INDEX, "", 1),
+            "this_id",
+            null
+        );
+        UpdateResponse updateResponse = new UpdateResponse(new ShardId(WORKFLOW_STATE_INDEX, "", 1), "this_id", -2, 0, 0, Result.UPDATED);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> responseListener = invocation.getArgument(1);
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            WorkflowState state = WorkflowState.builder().build();
+            state.toXContent(builder, null);
+            BytesReference workflowBytesRef = BytesReference.bytes(builder);
+            GetResult getResult = new GetResult(WORKFLOW_STATE_INDEX, "this_id", 1, 1, 1, true, workflowBytesRef, null, null);
+            responseListener.onResponse(new GetResponse(getResult));
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        // test success on retry
+        @SuppressWarnings("unchecked")
+        ActionListener<WorkflowData> retryListener = mock(ActionListener.class);
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
+            responseListener.onFailure(conflictException);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
+            responseListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), any());
+
+        flowFrameworkIndicesHandler.addResourceToStateIndex(
+            new WorkflowData(Collections.emptyMap(), "this_id", null),
+            "node_id",
+            CreateConnectorStep.NAME,
+            "this_id",
+            retryListener
+        );
+
+        ArgumentCaptor<WorkflowData> responseCaptor = ArgumentCaptor.forClass(WorkflowData.class);
+        verify(retryListener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals("this_id", responseCaptor.getValue().getContent().get(WorkflowResources.CONNECTOR_ID));
+
+        // test failure on 4th after 3 retries even if 5th would have been success
+        @SuppressWarnings("unchecked")
+        ActionListener<WorkflowData> threeRetryListener = mock(ActionListener.class);
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
+            responseListener.onFailure(conflictException);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
+            responseListener.onFailure(conflictException);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
+            responseListener.onFailure(conflictException);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
+            responseListener.onFailure(conflictException);
+            return null;
+        }).doAnswer(invocation -> {
+            // we'll never get here
+            ActionListener<UpdateResponse> responseListener = invocation.getArgument(1);
+            responseListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), any());
+
+        flowFrameworkIndicesHandler.addResourceToStateIndex(
+            new WorkflowData(Collections.emptyMap(), "this_id", null),
+            "node_id",
+            CreateConnectorStep.NAME,
+            "this_id",
+            threeRetryListener
+        );
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(threeRetryListener, times(1)).onFailure(exceptionCaptor.capture());
+        assertEquals(
+            "Failed to update workflow state for this_id on step node_id with connector_id this_id",
+            exceptionCaptor.getValue().getMessage()
+        );
     }
 }

--- a/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
@@ -71,6 +71,7 @@ import static org.opensearch.flowframework.common.WorkflowResources.REGISTER_REM
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -770,7 +771,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             ActionListener<UpdateResponse> updateResponseListener = invocation.getArgument(2);
             updateResponseListener.onResponse(new UpdateResponse(new ShardId(WORKFLOW_STATE_INDEX, "", 1), "id", -2, 0, 0, UPDATED));
             return null;
-        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(anyString(), any(), any());
+        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(anyString(), anyMap(), any());
 
         createWorkflowTransportAction.doExecute(mock(Task.class), updateWorkflow, listener);
         ArgumentCaptor<WorkflowResponse> responseCaptor = ArgumentCaptor.forClass(WorkflowResponse.class);

--- a/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
@@ -54,6 +54,7 @@ import org.mockito.ArgumentCaptor;
 import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -164,7 +165,7 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
             ActionListener<UpdateResponse> actionListener = invocation.getArgument(2);
             actionListener.onResponse(mock(UpdateResponse.class));
             return null;
-        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(any(), any(), any());
+        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(any(), anyMap(), any());
 
         doAnswer(invocation -> {
             ActionListener<IndexResponse> responseListener = invocation.getArgument(2);
@@ -211,7 +212,7 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
             ActionListener<UpdateResponse> actionListener = invocation.getArgument(2);
             actionListener.onResponse(mock(UpdateResponse.class));
             return null;
-        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(any(), any(), any());
+        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(any(), anyMap(), any());
 
         provisionWorkflowTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);

--- a/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportActionTests.java
@@ -44,6 +44,7 @@ import org.mockito.ArgumentCaptor;
 
 import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -147,7 +148,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
             ActionListener<UpdateResponse> actionListener = invocation.getArgument(2);
             actionListener.onResponse(mock(UpdateResponse.class));
             return null;
-        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(any(), any(), any());
+        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(any(), anyMap(), any());
 
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
@@ -275,7 +276,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
             ActionListener<UpdateResponse> actionListener = invocation.getArgument(2);
             actionListener.onFailure(new Exception("failed"));
             return null;
-        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(any(), any(), any());
+        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(any(), anyMap(), any());
 
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);


### PR DESCRIPTION
### Description

Removes methods using painless script for workflow state updates.

### Related Issues

Fixes #779 (except for the part that will be covered by #780)

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
