### PR TITLE
Add optional config field to tool step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.17...2.x)
 ### Features
 - Add ApiSpecFetcher for Fetching and Comparing API Specifications ([#651](https://github.com/opensearch-project/flow-framework/issues/651))
+- Add optional config field to tool step ([#899](https://github.com/opensearch-project/flow-framework/pull/899))
 
 ### Enhancements
 - Incrementally remove resources from workflow state during deprovisioning ([#898](https://github.com/opensearch-project/flow-framework/pull/898))
@@ -28,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Infrastructure
 ### Documentation
 - Add query assist data summary agent into sample templates ([#875](https://github.com/opensearch-project/flow-framework/pull/875))
+
 ### Maintenance
 ### Refactoring
 - Update workflow state without using painless script ([#894](https://github.com/opensearch-project/flow-framework/pull/894))

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -164,6 +164,8 @@ public class CommonValue {
     public static final String TOOLS_FIELD = "tools";
     /** The tools order field for an agent */
     public static final String TOOLS_ORDER_FIELD = "tools_order";
+    /** The tools config field */
+    public static final String CONFIG_FIELD = "config";
     /** The memory field for an agent */
     public static final String MEMORY_FIELD = "memory";
     /** The app type field for an agent */

--- a/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
@@ -88,6 +88,7 @@ public class ToolStep implements WorkflowStep {
                 outputs,
                 toolParameterKeys
             );
+            @SuppressWarnings("unchecked")
             Map<String, String> config = (Map<String, String>) inputs.getOrDefault(CONFIG_FIELD, Collections.emptyMap());
 
             MLToolSpec.MLToolSpecBuilder builder = MLToolSpec.builder();
@@ -105,8 +106,7 @@ public class ToolStep implements WorkflowStep {
             if (includeOutputInAgentResponse != null) {
                 builder.includeOutputInAgentResponse(includeOutputInAgentResponse);
             }
-            // TODO https://github.com/opensearch-project/ml-commons/pull/2977/files must be merged for this to compile
-            // builder.configMap(config);
+            builder.configMap(config);
 
             MLToolSpec mlToolSpec = builder.build();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -52,7 +52,6 @@ import static org.opensearch.flowframework.common.CommonValue.PROTOCOL_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.SOURCE_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.SUCCESS;
-import static org.opensearch.flowframework.common.CommonValue.TOOLS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TYPE;
 import static org.opensearch.flowframework.common.CommonValue.URL;
 import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
@@ -231,7 +230,7 @@ public class WorkflowStepFactory {
         DELETE_AGENT(DeleteAgentStep.NAME, List.of(AGENT_ID), List.of(AGENT_ID), List.of(OPENSEARCH_ML), null),
 
         /** Create Tool Step */
-        CREATE_TOOL(ToolStep.NAME, List.of(TYPE), List.of(TOOLS_FIELD), List.of(OPENSEARCH_ML), null),
+        CREATE_TOOL(ToolStep.NAME, ToolStep.REQUIRED_INPUTS, ToolStep.PROVIDED_OUTPUTS, List.of(OPENSEARCH_ML), null),
 
         /** Create Ingest Pipeline Step */
         CREATE_INGEST_PIPELINE(

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -56,7 +56,13 @@ public class RegisterAgentTests extends OpenSearchTestCase {
         this.flowFrameworkIndicesHandler = mock(FlowFrameworkIndicesHandler.class);
         MockitoAnnotations.openMocks(this);
 
-        MLToolSpec tools = new MLToolSpec("tool1", "CatIndexTool", "desc", Collections.emptyMap(), false);
+        MLToolSpec tools = MLToolSpec.builder()
+            .type("tool1")
+            .name("CatIndexTool")
+            .description("desc")
+            .parameters(Collections.emptyMap())
+            .includeOutputInAgentResponse(false)
+            .build();
 
         LLMSpec llmSpec = new LLMSpec("xyz", Collections.emptyMap());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
@@ -103,8 +103,7 @@ public class ToolStepTests extends OpenSearchTestCase {
         );
         assertTrue(future.isDone());
         assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
-        // TODO https://github.com/opensearch-project/ml-commons/pull/2977/files must be merged for this to compile
-        // assertEquals(Map.of("foo", "bar"), ((MLToolSpec) future.get().getContent().get("tools")).getConfigMap());
+        assertEquals(Map.of("foo", "bar"), ((MLToolSpec) future.get().getContent().get("tools")).getConfigMap());
     }
 
     public void testBoolParseFail() {

--- a/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
@@ -61,6 +61,7 @@ public class ToolStepTests extends OpenSearchTestCase {
                 Map.entry("name", "name"),
                 Map.entry("description", "description"),
                 Map.entry("parameters", Collections.emptyMap()),
+                Map.entry("config", Map.of("foo", "bar")),
                 Map.entry("include_output_in_agent_response", "false")
             ),
             "test-id",
@@ -102,6 +103,8 @@ public class ToolStepTests extends OpenSearchTestCase {
         );
         assertTrue(future.isDone());
         assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
+        // TODO https://github.com/opensearch-project/ml-commons/pull/2977/files must be merged for this to compile
+        // assertEquals(Map.of("foo", "bar"), ((MLToolSpec) future.get().getContent().get("tools")).getConfigMap());
     }
 
     public void testBoolParseFail() {


### PR DESCRIPTION
### Description

Adds the optional `config` map to the `ToolStep`

### Related Issues

Resolves #878 

Draft, pending merge:
 - https://github.com/opensearch-project/ml-commons/pull/2977

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
