### PR TITLE
[Backport-2.x] Force tests jackson dependencies to 2.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,10 +189,16 @@ dependencies {
     implementation "io.swagger.parser.v3:swagger-parser-core:${swaggerVersion}"
     implementation "io.swagger.parser.v3:swagger-parser:${swaggerVersion}"
     implementation "io.swagger.parser.v3:swagger-parser-v3:${swaggerVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    // Declare and force Jackson dependencies for tests
+    testImplementation("com.fasterxml.jackson.core:jackson-databind") {
+        version { strictly("${jacksonVersion}") }
+    }
+    testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310") {
+        version { strictly("${jacksonVersion}") }
+    }
+    testImplementation("com.fasterxml.jackson.core:jackson-annotations") {
+        version { strictly("${jacksonVersion}") }
+    }
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/flow-framework/pull/911

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
