### PR TITLE
Increase default index replicas to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Enhancements
 - Incrementally remove resources from workflow state during deprovisioning ([#898](https://github.com/opensearch-project/flow-framework/pull/898))
+- Increase default index replicas to 5 ([#916](https://github.com/opensearch-project/flow-framework/pull/916))
 
 ### Bug Fixes
 - Fixed Template Update Location and Improved Logger Statements in ReprovisionWorkflowTransportAction ([#918](https://github.com/opensearch-project/flow-framework/pull/918))

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -82,7 +82,7 @@ public class FlowFrameworkIndicesHandler {
     private final ClusterService clusterService;
     private final EncryptorUtils encryptorUtils;
     private static final Map<String, AtomicBoolean> indexMappingUpdated = new HashMap<>();
-    private static final Map<String, Object> indexSettings = Map.of("index.auto_expand_replicas", "0-1");
+    private static final Map<String, Object> indexSettings = Map.of("index.auto_expand_replicas", "0-5");
     private final NamedXContentRegistry xContentRegistry;
     // Retries in case of simultaneous updates
     private static final int RETRIES = 5;


### PR DESCRIPTION
### Description

Changes default index replicas to (up to) 5.

### Related Issues
Resolves #915 

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
