### PR TITLE
Fixed Template Update Location and Improved Logger Statements in ReprovisionWorkflowTransportAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Fixed Template Update Location and Improved Logger Statements in ReprovisionWorkflowTransportAction ([#918](https://github.com/opensearch-project/flow-framework/pull/918))
 ### Infrastructure
 - Set Java target compatibility to JDK 21 ([#730](https://github.com/opensearch-project/flow-framework/pull/730))
 - Add knowledge base alert agent into sample templates ([#874](https://github.com/opensearch-project/flow-framework/pull/874))
-
 ### Documentation
 - Add alert summary agent template ([#873](https://github.com/opensearch-project/flow-framework/pull/873))
 
@@ -25,6 +25,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Incrementally remove resources from workflow state during deprovisioning ([#898](https://github.com/opensearch-project/flow-framework/pull/898))
 
 ### Bug Fixes
+- Fixed Template Update Location and Improved Logger Statements in ReprovisionWorkflowTransportAction ([#918](https://github.com/opensearch-project/flow-framework/pull/918))
 ### Infrastructure
 ### Documentation
 - Add query assist data summary agent into sample templates ([#875](https://github.com/opensearch-project/flow-framework/pull/875))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
-- Fixed Template Update Location and Improved Logger Statements in ReprovisionWorkflowTransportAction ([#918](https://github.com/opensearch-project/flow-framework/pull/918))
 ### Infrastructure
 - Set Java target compatibility to JDK 21 ([#730](https://github.com/opensearch-project/flow-framework/pull/730))
 - Add knowledge base alert agent into sample templates ([#874](https://github.com/opensearch-project/flow-framework/pull/874))
+
 ### Documentation
 - Add alert summary agent template ([#873](https://github.com/opensearch-project/flow-framework/pull/873))
 
@@ -26,9 +26,11 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Bug Fixes
 - Fixed Template Update Location and Improved Logger Statements in ReprovisionWorkflowTransportAction ([#918](https://github.com/opensearch-project/flow-framework/pull/918))
+
 ### Infrastructure
 ### Documentation
 - Add query assist data summary agent into sample templates ([#875](https://github.com/opensearch-project/flow-framework/pull/875))
+
 ### Maintenance
 ### Refactoring
 - Update workflow state without using painless script ([#894](https://github.com/opensearch-project/flow-framework/pull/894))

--- a/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
@@ -271,8 +271,9 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
     ) {
         try {
             threadPool.executor(PROVISION_WORKFLOW_THREAD_POOL).execute(() -> {
-                updateTemplate( template,workflowId);
-                executeWorkflow(template, workflowSequence, workflowId); });
+                updateTemplate(template, workflowId);
+                executeWorkflow(template, workflowSequence, workflowId);
+            });
         } catch (Exception exception) {
             listener.onFailure(new FlowFrameworkException("Failed to execute workflow " + workflowId, ExceptionsHelper.status(exception)));
         }
@@ -283,16 +284,11 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
      * @param template The template to store after reprovisioning completes successfully
      * @param workflowId The workflowId associated with the workflow that is executing
      */
-    private void updateTemplate ( Template template, String workflowId) {
-        flowFrameworkIndicesHandler.updateTemplateInGlobalContext(
-                workflowId,
-                template,
-                ActionListener.wrap(templateResponse -> {
-                    logger.info("Updated template for {}", workflowId);
-                }, exception -> {
-                    logger.error("Failed to update use case template for {}", workflowId, exception);
-                }),
-                true  // ignores NOT_STARTED state if request is to reprovision
+    private void updateTemplate(Template template, String workflowId) {
+        flowFrameworkIndicesHandler.updateTemplateInGlobalContext(workflowId, template, ActionListener.wrap(templateResponse -> {
+            logger.info("Updated template for {}", workflowId);
+        }, exception -> { logger.error("Failed to update use case template for {}", workflowId, exception); }),
+            true  // ignores NOT_STARTED state if request is to reprovision
         );
     }
 

--- a/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
@@ -305,8 +305,9 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
             for (ProcessNode processNode : workflowSequence) {
                 List<ProcessNode> predecessors = processNode.predecessors();
                 logger.info(
-                    "Queueing process [{}].{}",
-                    String.format(Locale.getDefault(), "%s (type: %s)", processNode.id(), processNode.workflowStep().getName()),
+                    "Queueing Process [{} (type: {})].{}",
+                    processNode.id(),
+                    processNode.workflowStep().getName(),
                     predecessors.isEmpty()
                         ? " Can start immediately!"
                         : String.format(

--- a/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
@@ -306,7 +306,7 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
                 List<ProcessNode> predecessors = processNode.predecessors();
                 logger.info(
                     "Queueing process [{}].{}",
-                    String.format("%s (type: %s)", processNode.id(), processNode.workflowStep().getName()),
+                    String.format(Locale.getDefault(), "%s (type: %s)", processNode.id(), processNode.workflowStep().getName()),
                     predecessors.isEmpty()
                         ? " Can start immediately!"
                         : String.format(


### PR DESCRIPTION
### Description
This PR fixes the template update location in ReprovisionWorkflowTransportAction.java and enhances logger statements for better clarity and debugging.

### Related Issues
closes #870 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
