### PR TITLE
Add API Consistency Tests with ML-Common and Set Up Daily GitHub Action Trigger

### DIFF
--- a/.github/workflows/test-api-consistency.yml
+++ b/.github/workflows/test-api-consistency.yml
@@ -3,6 +3,7 @@ name: Daily API Consistency Test
 on:
   schedule:
     - cron: '0 8 * * *'  # Runs daily at 8 AM UTC
+  workflow_dispatch:
 
 jobs:
   API-consistency-test:

--- a/.github/workflows/test-api-consistency.yml
+++ b/.github/workflows/test-api-consistency.yml
@@ -1,0 +1,25 @@
+name: Daily API Consistency Test
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Runs daily at 8 AM UTC
+
+jobs:
+  API-consistency-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [21]
+
+    steps:
+      - name: Checkout Flow Framework
+        uses: actions/checkout@v3
+
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+
+      - name: Run API Consistency Tests
+        run: ./gradlew test --tests "org.opensearch.flowframework.workflow.*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 - Add ApiSpecFetcher for Fetching and Comparing API Specifications ([#651](https://github.com/opensearch-project/flow-framework/issues/651))
 - Add optional config field to tool step ([#899](https://github.com/opensearch-project/flow-framework/pull/899))
+- Add API Consistency Tests with ML-Common and Set Up Daily GitHub Action Trigger([#908](https://github.com/opensearch-project/flow-framework/issues/908))
 
 ### Enhancements
 - Incrementally remove resources from workflow state during deprovisioning ([#898](https://github.com/opensearch-project/flow-framework/pull/898))

--- a/src/main/java/org/opensearch/flowframework/util/ApiSpecFetcher.java
+++ b/src/main/java/org/opensearch/flowframework/util/ApiSpecFetcher.java
@@ -81,7 +81,7 @@ public class ApiSpecFetcher {
 
             List<String> requiredApiParams = schema.getRequired();
             if (requiredApiParams != null && !requiredApiParams.isEmpty()) {
-                return new HashSet<>(requiredEnumParams).equals(new HashSet<>(requiredApiParams));
+                return new HashSet<>(requiredEnumParams).containsAll(new HashSet<>(requiredApiParams));
             }
         }
         return false;

--- a/src/main/java/org/opensearch/flowframework/util/ApiSpecFetcher.java
+++ b/src/main/java/org/opensearch/flowframework/util/ApiSpecFetcher.java
@@ -14,7 +14,6 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.flowframework.exception.ApiSpecParseException;
 import org.opensearch.rest.RestRequest;
 
-import java.util.HashSet;
 import java.util.List;
 
 import io.swagger.v3.oas.models.OpenAPI;
@@ -81,7 +80,7 @@ public class ApiSpecFetcher {
 
             List<String> requiredApiParams = schema.getRequired();
             if (requiredApiParams != null && !requiredApiParams.isEmpty()) {
-                return new HashSet<>(requiredEnumParams).containsAll(new HashSet<>(requiredApiParams));
+                return requiredApiParams.stream().allMatch(requiredEnumParams::contains);
             }
         }
         return false;

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
@@ -142,10 +142,10 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
         List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.CREATE_CONNECTOR.inputs();
 
         boolean isMatch = ApiSpecFetcher.compareRequiredFields(
-                requiredEnumParams,
-                ML_COMMONS_API_SPEC_YAML_URI,
-                "/_plugins/_ml/connectors/_create",
-                RestRequest.Method.POST
+            requiredEnumParams,
+            ML_COMMONS_API_SPEC_YAML_URI,
+            "/_plugins/_ml/connectors/_create",
+            RestRequest.Method.POST
         );
 
         assertTrue(isMatch);

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
@@ -14,20 +14,24 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.common.CommonValue;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.util.ApiSpecFetcher;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.opensearch.flowframework.common.CommonValue.ML_COMMONS_API_SPEC_YAML_URI;
 import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -132,6 +136,19 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to create connector", ex.getCause().getMessage());
+    }
+
+    public void testApiSpecCreateConnectorInputParamComparison() throws Exception {
+        List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.CREATE_CONNECTOR.inputs();
+
+        boolean isMatch = ApiSpecFetcher.compareRequiredFields(
+                requiredEnumParams,
+                ML_COMMONS_API_SPEC_YAML_URI,
+                "/_plugins/_ml/connectors/_create",
+                RestRequest.Method.POST
+        );
+
+        assertTrue(isMatch);
     }
 
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -20,11 +20,13 @@ import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.util.ApiSpecFetcher;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
@@ -33,6 +35,7 @@ import org.junit.AfterClass;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -41,11 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
-import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
-import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
-import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_THREAD_POOL;
+import static org.opensearch.flowframework.common.CommonValue.*;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
@@ -397,5 +396,18 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
         WorkflowStepException w = (WorkflowStepException) e.getCause();
         assertEquals("Failed to parse value [no] as only [true] or [false] are allowed.", w.getMessage());
         assertEquals(RestStatus.BAD_REQUEST, w.getRestStatus());
+    }
+
+    public void testApiSpecRegisterLocalCustomModelInputParamComparison() throws Exception {
+        List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.REGISTER_LOCAL_CUSTOM_MODEL.inputs();
+
+        boolean isMatch = ApiSpecFetcher.compareRequiredFields(
+                requiredEnumParams,
+                ML_COMMONS_API_SPEC_YAML_URI,
+                "/_plugins/_ml/models/_register",
+                RestRequest.Method.POST
+        );
+
+        assertTrue(isMatch);
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -402,10 +402,10 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
         List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.REGISTER_LOCAL_CUSTOM_MODEL.inputs();
 
         boolean isMatch = ApiSpecFetcher.compareRequiredFields(
-                requiredEnumParams,
-                ML_COMMONS_API_SPEC_YAML_URI,
-                "/_plugins/_ml/models/_register",
-                RestRequest.Method.POST
+            requiredEnumParams,
+            ML_COMMONS_API_SPEC_YAML_URI,
+            "/_plugins/_ml/models/_register",
+            RestRequest.Method.POST
         );
 
         assertTrue(isMatch);

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -44,7 +44,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.opensearch.flowframework.common.CommonValue.*;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
+import static org.opensearch.flowframework.common.CommonValue.ML_COMMONS_API_SPEC_YAML_URI;
+import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
+import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_THREAD_POOL;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
@@ -43,7 +43,12 @@ import java.util.concurrent.TimeUnit;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.opensearch.flowframework.common.CommonValue.*;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
+import static org.opensearch.flowframework.common.CommonValue.ML_COMMONS_API_SPEC_YAML_URI;
+import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
+import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_THREAD_POOL;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
@@ -307,10 +307,10 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
         List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.REGISTER_LOCAL_PRETRAINED_MODEL.inputs();
 
         boolean isMatch = ApiSpecFetcher.compareRequiredFields(
-                requiredEnumParams,
-                ML_COMMONS_API_SPEC_YAML_URI,
-                "/_plugins/_ml/models/_register",
-                RestRequest.Method.POST
+            requiredEnumParams,
+            ML_COMMONS_API_SPEC_YAML_URI,
+            "/_plugins/_ml/models/_register",
+            RestRequest.Method.POST
         );
 
         assertTrue(isMatch);

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
@@ -20,11 +20,13 @@ import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.util.ApiSpecFetcher;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
@@ -33,6 +35,7 @@ import org.junit.AfterClass;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -40,11 +43,7 @@ import java.util.concurrent.TimeUnit;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
-import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
-import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
-import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_THREAD_POOL;
+import static org.opensearch.flowframework.common.CommonValue.*;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
@@ -302,5 +301,18 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
         WorkflowStepException w = (WorkflowStepException) e.getCause();
         assertEquals("Failed to parse value [no] as only [true] or [false] are allowed.", w.getMessage());
         assertEquals(RestStatus.BAD_REQUEST, w.getRestStatus());
+    }
+
+    public void testApiSpecRegisterLocalPretrainedModelInputParamComparison() throws Exception {
+        List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.REGISTER_LOCAL_PRETRAINED_MODEL.inputs();
+
+        boolean isMatch = ApiSpecFetcher.compareRequiredFields(
+                requiredEnumParams,
+                ML_COMMONS_API_SPEC_YAML_URI,
+                "/_plugins/_ml/models/_register",
+                RestRequest.Method.POST
+        );
+
+        assertTrue(isMatch);
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
@@ -43,7 +43,12 @@ import java.util.concurrent.TimeUnit;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.opensearch.flowframework.common.CommonValue.*;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
+import static org.opensearch.flowframework.common.CommonValue.ML_COMMONS_API_SPEC_YAML_URI;
+import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
+import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_THREAD_POOL;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
@@ -314,10 +314,10 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
         List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.REGISTER_LOCAL_SPARSE_ENCODING_MODEL.inputs();
 
         boolean isMatch = ApiSpecFetcher.compareRequiredFields(
-                requiredEnumParams,
-                ML_COMMONS_API_SPEC_YAML_URI,
-                "/_plugins/_ml/models/_register",
-                RestRequest.Method.POST
+            requiredEnumParams,
+            ML_COMMONS_API_SPEC_YAML_URI,
+            "/_plugins/_ml/models/_register",
+            RestRequest.Method.POST
         );
 
         assertTrue(isMatch);

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
@@ -20,11 +20,13 @@ import org.opensearch.flowframework.common.FlowFrameworkSettings;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.util.ApiSpecFetcher;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
@@ -33,6 +35,7 @@ import org.junit.AfterClass;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -40,11 +43,7 @@ import java.util.concurrent.TimeUnit;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
-import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
-import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
-import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_THREAD_POOL;
+import static org.opensearch.flowframework.common.CommonValue.*;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
@@ -309,5 +308,18 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
         WorkflowStepException w = (WorkflowStepException) e.getCause();
         assertEquals("Failed to parse value [no] as only [true] or [false] are allowed.", w.getMessage());
         assertEquals(RestStatus.BAD_REQUEST, w.getRestStatus());
+    }
+
+    public void testApiSpecRegisterLocalSparseEncodingModelInputParamComparison() throws Exception {
+        List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.REGISTER_LOCAL_SPARSE_ENCODING_MODEL.inputs();
+
+        boolean isMatch = ApiSpecFetcher.compareRequiredFields(
+                requiredEnumParams,
+                ML_COMMONS_API_SPEC_YAML_URI,
+                "/_plugins/_ml/models/_register",
+                RestRequest.Method.POST
+        );
+
+        assertTrue(isMatch);
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterModelGroupStepTests.java
@@ -212,10 +212,10 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
         List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.REGISTER_MODEL_GROUP.inputs();
 
         boolean isMatch = ApiSpecFetcher.compareRequiredFields(
-                requiredEnumParams,
-                ML_COMMONS_API_SPEC_YAML_URI,
-                "/_plugins/_ml/model_groups/_register",
-                RestRequest.Method.POST
+            requiredEnumParams,
+            ML_COMMONS_API_SPEC_YAML_URI,
+            "/_plugins/_ml/model_groups/_register",
+            RestRequest.Method.POST
         );
 
         assertTrue(isMatch);

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterModelGroupStepTests.java
@@ -14,11 +14,13 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.util.ApiSpecFetcher;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupResponse;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -31,6 +33,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.opensearch.flowframework.common.CommonValue.ML_COMMONS_API_SPEC_YAML_URI;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_STATUS;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 import static org.mockito.ArgumentMatchers.any;
@@ -203,5 +206,18 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
         WorkflowStepException w = (WorkflowStepException) e.getCause();
         assertEquals("Failed to parse value [no] as only [true] or [false] are allowed.", w.getMessage());
         assertEquals(RestStatus.BAD_REQUEST, w.getRestStatus());
+    }
+
+    public void testApiSpecRegisterModelGroupInputParamComparison() throws Exception {
+        List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.REGISTER_MODEL_GROUP.inputs();
+
+        boolean isMatch = ApiSpecFetcher.compareRequiredFields(
+                requiredEnumParams,
+                ML_COMMONS_API_SPEC_YAML_URI,
+                "/_plugins/_ml/model_groups/_register",
+                RestRequest.Method.POST
+        );
+
+        assertTrue(isMatch);
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -17,15 +17,18 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
+import org.opensearch.flowframework.util.ApiSpecFetcher;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.RemoteTransportException;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -33,9 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
+import static org.opensearch.flowframework.common.CommonValue.*;
 import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;
@@ -415,5 +416,18 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
         WorkflowStepException w = (WorkflowStepException) e.getCause();
         assertEquals("Failed to parse value [yes] as only [true] or [false] are allowed.", w.getMessage());
         assertEquals(RestStatus.BAD_REQUEST, w.getRestStatus());
+    }
+
+    public void testApiSpecRegisterRemoteModelInputParamComparison() throws Exception {
+        List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.REGISTER_REMOTE_MODEL.inputs();
+
+        boolean isMatch = ApiSpecFetcher.compareRequiredFields(
+                requiredEnumParams,
+                ML_COMMONS_API_SPEC_YAML_URI,
+                "/_plugins/_ml/model_groups/_register",
+                RestRequest.Method.POST
+        );
+
+        assertTrue(isMatch);
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -422,10 +422,10 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
         List<String> requiredEnumParams = WorkflowStepFactory.WorkflowSteps.REGISTER_REMOTE_MODEL.inputs();
 
         boolean isMatch = ApiSpecFetcher.compareRequiredFields(
-                requiredEnumParams,
-                ML_COMMONS_API_SPEC_YAML_URI,
-                "/_plugins/_ml/model_groups/_register",
-                RestRequest.Method.POST
+            requiredEnumParams,
+            ML_COMMONS_API_SPEC_YAML_URI,
+            "/_plugins/_ml/model_groups/_register",
+            RestRequest.Method.POST
         );
 
         assertTrue(isMatch);

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -36,7 +36,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.opensearch.flowframework.common.CommonValue.*;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.ML_COMMONS_API_SPEC_YAML_URI;
+import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
### Description

1. Modified the `compareRequiredFields` method in `ApiFetcher` to use `containsAll` instead of  `equal` , ensuring that all required fields for our step inputs are included. For example, while `registerLocalModel` and `registerRemoteModel` require different input parameters, they both call the same API in ML Common.
2. Added all the remained Consistency Tests.


### Related Issues
Resolves #908 
Resolves #651
<!-- List any other related issues here -->
Issue Related #833 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
