### PR TITLE
Fix alert summary prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Fix alert summary prompt ([#958](https://github.com/opensearch-project/flow-framework/pull/958))
+
 ### Infrastructure
 - Set Java target compatibility to JDK 21 ([#730](https://github.com/opensearch-project/flow-framework/pull/730))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
-- Fix alert summary prompt ([#958](https://github.com/opensearch-project/flow-framework/pull/958))
-
 ### Infrastructure
 - Set Java target compatibility to JDK 21 ([#730](https://github.com/opensearch-project/flow-framework/pull/730))
 

--- a/sample-templates/alert-summary-agent-claude-tested.json
+++ b/sample-templates/alert-summary-agent-claude-tested.json
@@ -69,7 +69,7 @@
           },
           "user_inputs": {
             "parameters": {
-              "prompt": "You are an OpenSearch Alert Assistant to help summarize the alerts.\n Here is the detail of alert: ${parameters.context};\n The question is: ${parameters.question}."
+              "prompt": "\n\nHuman: You are an OpenSearch Alert Assistant to help summarize the alerts.\n Here is the detail of alert: ${parameters.context};\n The question is: ${parameters.question}."
             },
             "name": "MLModelTool",
             "type": "MLModelTool"

--- a/sample-templates/alert-summary-agent-claude-tested.json
+++ b/sample-templates/alert-summary-agent-claude-tested.json
@@ -26,7 +26,7 @@
                   "content-type": "application/json"
                 },
                 "method": "POST",
-                "request_body": "{\"prompt\":\"${parameters.prompt}\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature},  \"anthropic_version\":\"${parameters.anthropic_version}\" }",
+                "request_body": "{\"prompt\":\"\\n\\nHuman: ${parameters.prompt}\\n\\nAssistant:\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature},  \"anthropic_version\":\"${parameters.anthropic_version}\" }",
                 "action_type": "predict",
                 "url": "https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-instant-v1/invoke"
               }
@@ -69,7 +69,7 @@
           },
           "user_inputs": {
             "parameters": {
-              "prompt": "\n\nHuman: You are an OpenSearch Alert Assistant to help summarize the alerts.\n Here is the detail of alert: ${parameters.context};\n The question is: ${parameters.question}."
+              "prompt": "You are an OpenSearch Alert Assistant to help summarize the alerts.\n Here is the detail of alert: ${parameters.context};\n The question is: ${parameters.question}."
             },
             "name": "MLModelTool",
             "type": "MLModelTool"

--- a/sample-templates/alert-summary-agent-claude-tested.yml
+++ b/sample-templates/alert-summary-agent-claude-tested.yml
@@ -24,7 +24,7 @@ workflows:
             x-amz-content-sha256: required
             content-type: application/json
           method: POST
-          request_body: '{"prompt":"${parameters.prompt}", "max_tokens_to_sample":${parameters.max_tokens_to_sample},
+          request_body: '{"prompt":"\n\nHuman: ${parameters.prompt}\n\nAssistant:", "max_tokens_to_sample":${parameters.max_tokens_to_sample},
             "temperature":${parameters.temperature},  "anthropic_version":"${parameters.anthropic_version}"
             }'
           action_type: predict
@@ -57,7 +57,7 @@ workflows:
         register_claude_model: model_id
       user_inputs:
         parameters:
-          prompt:  "\n\nHuman: You are an OpenSearch Alert Assistant to help summarize the alerts.\n Here is the detail of alert: ${parameters.context};\n The question is: ${parameters.question}."
+          prompt:  "You are an OpenSearch Alert Assistant to help summarize the alerts.\n Here is the detail of alert: ${parameters.context};\n The question is: ${parameters.question}."
         name: MLModelTool
         type: MLModelTool
     - id: create_alert_summary_agent

--- a/sample-templates/alert-summary-agent-claude-tested.yml
+++ b/sample-templates/alert-summary-agent-claude-tested.yml
@@ -57,7 +57,7 @@ workflows:
         register_claude_model: model_id
       user_inputs:
         parameters:
-          prompt:  "You are an OpenSearch Alert Assistant to help summarize the alerts.\n Here is the detail of alert: ${parameters.context};\n The question is: ${parameters.question}."
+          prompt:  "\n\nHuman: You are an OpenSearch Alert Assistant to help summarize the alerts.\n Here is the detail of alert: ${parameters.context};\n The question is: ${parameters.question}."
         name: MLModelTool
         type: MLModelTool
     - id: create_alert_summary_agent


### PR DESCRIPTION
### Description
Fix alert summary prompt, it needs  to start prompt with `\n\nHuman:` for model claude v1 

### Related Issues
Resolves  https://github.com/opensearch-project/flow-framework/issues/955

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
