### PR TITLE
Add synchronous execution option to workflow provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.18...2.x)
 ### Features
+- Add synchronous execution option to workflow provisioning ([#990](https://github.com/opensearch-project/flow-framework/pull/990))
+
 ### Enhancements
 ### Bug Fixes
 - Remove useCase and defaultParams field in WorkflowRequest ([#758](https://github.com/opensearch-project/flow-framework/pull/758))

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -192,6 +192,8 @@ public class CommonValue {
     public static final String SOURCE_INDEX = "source_index";
     /** The destination index field for reindex */
     public static final String DESTINATION_INDEX = "destination_index";
+    /** Provision Timeout field */
+    public static final String PROVISION_TIMEOUT_FIELD = "provision.timeout";
     /*
      * Constants associated with resource provisioning / state
      */

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -57,8 +57,6 @@ public class CommonValue {
     /** The last provisioned time field */
     public static final String LAST_PROVISIONED_TIME_FIELD = "last_provisioned_time";
 
-    public static final TimeValue DEFAULT_WAIT_FOR_COMPLETION_TIMEOUT = TimeValue.timeValueSeconds(1);
-
     /*
      * Constants associated with Rest or Transport actions
      */

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -8,6 +8,8 @@
  */
 package org.opensearch.flowframework.common;
 
+import org.opensearch.common.unit.TimeValue;
+
 /**
  * Representation of common values that are used across project
  */
@@ -55,6 +57,8 @@ public class CommonValue {
     /** The last provisioned time field */
     public static final String LAST_PROVISIONED_TIME_FIELD = "last_provisioned_time";
 
+    public static final TimeValue DEFAULT_WAIT_FOR_COMPLETION_TIMEOUT = TimeValue.timeValueSeconds(1);
+
     /*
      * Constants associated with Rest or Transport actions
      */
@@ -74,6 +78,8 @@ public class CommonValue {
     public static final String PROVISION_WORKFLOW = "provision";
     /** The param name for update workflow field in create API */
     public static final String UPDATE_WORKFLOW_FIELDS = "update_fields";
+    /** The param name for specifying the timeout duration in seconds to wait for workflow completion */
+    public static final String WAIT_FOR_COMPLETION_TIMEOUT = "wait_for_completion_timeout";
     /** The field name for workflow steps. This field represents the name of the workflow steps to be fetched. */
     public static final String WORKFLOW_STEP = "workflow_step";
     /** The param name for default use case, used by the create workflow API */

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -8,8 +8,6 @@
  */
 package org.opensearch.flowframework.common;
 
-import org.opensearch.common.unit.TimeValue;
-
 /**
  * Representation of common values that are used across project
  */

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -151,9 +151,7 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
         // Ensure wait_for_completion is not set unless reprovision or provision is true
         if (waitForCompletionTimeout != TimeValue.MINUS_ONE && !(reprovision || provision)) {
             FlowFrameworkException ffe = new FlowFrameworkException(
-                "Request parameters "
-                    + request.consumedParams()
-                    + " are not allowed unless the 'provision' or 'reprovision' parameter is set to true.",
+                "Request parameters 'wait_for_completion_timeout' are not allowed unless the 'provision' or 'reprovision' parameter is set to true.",
                 RestStatus.BAD_REQUEST
             );
             return processError(ffe, params, request);

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
@@ -43,6 +44,7 @@ import static org.opensearch.flowframework.common.CommonValue.REPROVISION_WORKFL
 import static org.opensearch.flowframework.common.CommonValue.UPDATE_WORKFLOW_FIELDS;
 import static org.opensearch.flowframework.common.CommonValue.USE_CASE;
 import static org.opensearch.flowframework.common.CommonValue.VALIDATION;
+import static org.opensearch.flowframework.common.CommonValue.WAIT_FOR_COMPLETION_TIMEOUT;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
@@ -87,6 +89,7 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
         boolean provision = request.paramAsBoolean(PROVISION_WORKFLOW, false);
         boolean reprovision = request.paramAsBoolean(REPROVISION_WORKFLOW, false);
         boolean updateFields = request.paramAsBoolean(UPDATE_WORKFLOW_FIELDS, false);
+        TimeValue waitForCompletionTimeout = request.paramAsTime(WAIT_FOR_COMPLETION_TIMEOUT, null);
         String useCase = request.param(USE_CASE);
 
         // If provisioning, consume all other params and pass to provision transport action
@@ -226,7 +229,8 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                 validation,
                 provision || updateFields,
                 params,
-                reprovision
+                reprovision,
+                waitForCompletionTimeout
             );
 
             return channel -> client.execute(CreateWorkflowAction.INSTANCE, workflowRequest, ActionListener.wrap(response -> {

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
@@ -43,6 +44,7 @@ import static org.opensearch.flowframework.common.CommonValue.REPROVISION_WORKFL
 import static org.opensearch.flowframework.common.CommonValue.UPDATE_WORKFLOW_FIELDS;
 import static org.opensearch.flowframework.common.CommonValue.USE_CASE;
 import static org.opensearch.flowframework.common.CommonValue.VALIDATION;
+import static org.opensearch.flowframework.common.CommonValue.WAIT_FOR_COMPLETION_TIMEOUT;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
@@ -88,6 +90,7 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
         boolean reprovision = request.paramAsBoolean(REPROVISION_WORKFLOW, false);
         boolean updateFields = request.paramAsBoolean(UPDATE_WORKFLOW_FIELDS, false);
         String useCase = request.param(USE_CASE);
+        TimeValue waitForCompletionTimeout = request.paramAsTime(WAIT_FOR_COMPLETION_TIMEOUT, TimeValue.MINUS_ONE);
 
         // If provisioning, consume all other params and pass to provision transport action
         Map<String, String> params = provision
@@ -145,6 +148,17 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
             );
             return processError(ffe, params, request);
         }
+        // Ensure wait_for_completion is not set unless reprovision or provision is true
+        if (waitForCompletionTimeout != TimeValue.MINUS_ONE && !(reprovision || provision)) {
+            FlowFrameworkException ffe = new FlowFrameworkException(
+                "Request parameters "
+                    + request.consumedParams()
+                    + " are not allowed unless the 'provision' or 'reprovision' parameter is set to true.",
+                RestStatus.BAD_REQUEST
+            );
+            return processError(ffe, params, request);
+        }
+
         try {
             Template template;
             Map<String, String> useCaseDefaultsMap = Collections.emptyMap();
@@ -219,7 +233,9 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
             if (updateFields) {
                 params = Map.of(UPDATE_WORKFLOW_FIELDS, "true");
             }
-
+            if (waitForCompletionTimeout != TimeValue.MINUS_ONE) {
+                params = Map.of(WAIT_FOR_COMPLETION_TIMEOUT, waitForCompletionTimeout.toString());
+            }
             WorkflowRequest workflowRequest = new WorkflowRequest(
                 workflowId,
                 template,

--- a/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestCreateWorkflowAction.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
@@ -44,7 +43,6 @@ import static org.opensearch.flowframework.common.CommonValue.REPROVISION_WORKFL
 import static org.opensearch.flowframework.common.CommonValue.UPDATE_WORKFLOW_FIELDS;
 import static org.opensearch.flowframework.common.CommonValue.USE_CASE;
 import static org.opensearch.flowframework.common.CommonValue.VALIDATION;
-import static org.opensearch.flowframework.common.CommonValue.WAIT_FOR_COMPLETION_TIMEOUT;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
@@ -89,7 +87,6 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
         boolean provision = request.paramAsBoolean(PROVISION_WORKFLOW, false);
         boolean reprovision = request.paramAsBoolean(REPROVISION_WORKFLOW, false);
         boolean updateFields = request.paramAsBoolean(UPDATE_WORKFLOW_FIELDS, false);
-        TimeValue waitForCompletionTimeout = request.paramAsTime(WAIT_FOR_COMPLETION_TIMEOUT, null);
         String useCase = request.param(USE_CASE);
 
         // If provisioning, consume all other params and pass to provision transport action
@@ -229,8 +226,7 @@ public class RestCreateWorkflowAction extends BaseRestHandler {
                 validation,
                 provision || updateFields,
                 params,
-                reprovision,
-                waitForCompletionTimeout
+                reprovision
             );
 
             return channel -> client.execute(CreateWorkflowAction.INSTANCE, workflowRequest, ActionListener.wrap(response -> {

--- a/src/main/java/org/opensearch/flowframework/rest/RestProvisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestProvisionWorkflowAction.java
@@ -75,7 +75,7 @@ public class RestProvisionWorkflowAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String workflowId = request.param(WORKFLOW_ID);
-        TimeValue waitForCompletionTimeout = request.paramAsTime(WAIT_FOR_COMPLETION_TIMEOUT, null);
+        TimeValue waitForCompletionTimeout = request.paramAsTime(WAIT_FOR_COMPLETION_TIMEOUT, TimeValue.MINUS_ONE);
         try {
             Map<String, String> params = parseParamsAndContent(request);
             if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {

--- a/src/main/java/org/opensearch/flowframework/rest/RestProvisionWorkflowAction.java
+++ b/src/main/java/org/opensearch/flowframework/rest/RestProvisionWorkflowAction.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
@@ -33,6 +34,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.flowframework.common.CommonValue.WAIT_FOR_COMPLETION_TIMEOUT;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
@@ -73,6 +75,7 @@ public class RestProvisionWorkflowAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String workflowId = request.param(WORKFLOW_ID);
+        TimeValue waitForCompletionTimeout = request.paramAsTime(WAIT_FOR_COMPLETION_TIMEOUT, null);
         try {
             Map<String, String> params = parseParamsAndContent(request);
             if (!flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()) {
@@ -86,7 +89,7 @@ public class RestProvisionWorkflowAction extends BaseRestHandler {
                 throw new FlowFrameworkException("workflow_id cannot be null", RestStatus.BAD_REQUEST);
             }
             // Create request and provision
-            WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null, params);
+            WorkflowRequest workflowRequest = new WorkflowRequest(workflowId, null, params, waitForCompletionTimeout);
             return channel -> client.execute(ProvisionWorkflowAction.INSTANCE, workflowRequest, ActionListener.wrap(response -> {
                 XContentBuilder builder = response.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS);
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -52,7 +52,6 @@ import java.util.Map;
 import static java.lang.Boolean.FALSE;
 import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.PROVISIONING_PROGRESS_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.PROVISION_TIMEOUT_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.STATE_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.WAIT_FOR_COMPLETION_TIMEOUT;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FILTER_BY_BACKEND_ROLES;

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -251,7 +251,8 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                                                     WorkflowRequest workflowRequest = new WorkflowRequest(
                                                         globalContextResponse.getId(),
                                                         null,
-                                                        request.getParams()
+                                                        request.getParams(),
+                                                        request.getWaitForCompletionTimeout()
                                                     );
                                                     logger.info(
                                                         "Provisioning parameter is set, continuing to provision workflow {}",
@@ -261,7 +262,18 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                                                         ProvisionWorkflowAction.INSTANCE,
                                                         workflowRequest,
                                                         ActionListener.wrap(provisionResponse -> {
-                                                            listener.onResponse(new WorkflowResponse(provisionResponse.getWorkflowId()));
+                                                            if (request.getWaitForCompletionTimeout() != null) {
+                                                                listener.onResponse(
+                                                                    new WorkflowResponse(
+                                                                        provisionResponse.getWorkflowId(),
+                                                                        provisionResponse.getWorkflowState()
+                                                                    )
+                                                                );
+                                                            } else {
+                                                                listener.onResponse(
+                                                                    new WorkflowResponse(provisionResponse.getWorkflowId())
+                                                                );
+                                                            }
                                                         }, exception -> {
                                                             String errorMessage = "Provisioning failed.";
                                                             logger.error(errorMessage, exception);

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -215,6 +215,16 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
             }
         }
         String workflowId = request.getWorkflowId();
+        TimeValue waitForTimeCompletion;
+        if (request.getParams().containsKey(WAIT_FOR_COMPLETION_TIMEOUT)) {
+            waitForTimeCompletion = TimeValue.parseTimeValue(
+                request.getParams().get(WAIT_FOR_COMPLETION_TIMEOUT),
+                WAIT_FOR_COMPLETION_TIMEOUT
+            );
+        } else {
+            // default to minus one indicate async execution
+            waitForTimeCompletion = TimeValue.MINUS_ONE;
+        }
         if (workflowId == null) {
             // This is a new workflow (POST)
             // Throttle incoming requests
@@ -249,14 +259,6 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                                             ActionListener.wrap(stateResponse -> {
                                                 logger.info("Creating state workflow doc: {}", globalContextResponse.getId());
                                                 if (request.isProvision()) {
-                                                    // default to minus one indicate async execution
-                                                    TimeValue waitForTimeCompletion = TimeValue.MINUS_ONE;
-                                                    if (request.getParams().containsKey(WAIT_FOR_COMPLETION_TIMEOUT)) {
-                                                        waitForTimeCompletion = TimeValue.parseTimeValue(
-                                                            request.getParams().get(WAIT_FOR_COMPLETION_TIMEOUT),
-                                                            WAIT_FOR_COMPLETION_TIMEOUT
-                                                        );
-                                                    }
                                                     WorkflowRequest workflowRequest = new WorkflowRequest(
                                                         globalContextResponse.getId(),
                                                         null,
@@ -363,14 +365,6 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                                 .build();
 
                         if (request.isReprovision()) {
-                            // default to minus one indicate async execution
-                            TimeValue waitForTimeCompletion = TimeValue.MINUS_ONE;
-                            if (request.getParams().containsKey(WAIT_FOR_COMPLETION_TIMEOUT)) {
-                                waitForTimeCompletion = TimeValue.parseTimeValue(
-                                    request.getParams().get(WAIT_FOR_COMPLETION_TIMEOUT),
-                                    WAIT_FOR_COMPLETION_TIMEOUT
-                                );
-                            }
                             // Reprovision request
                             ReprovisionWorkflowRequest reprovisionRequest = new ReprovisionWorkflowRequest(
                                 getResponse.getId(),

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -250,13 +250,19 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                                             ActionListener.wrap(stateResponse -> {
                                                 logger.info("Creating state workflow doc: {}", globalContextResponse.getId());
                                                 if (request.isProvision()) {
-                                                    String waitForTimeCompletion = request.getParams()
-                                                        .getOrDefault(WAIT_FOR_COMPLETION_TIMEOUT, TimeValue.MINUS_ONE.toString());
+                                                    // default to minus one indicate async execution
+                                                    TimeValue waitForTimeCompletion = TimeValue.MINUS_ONE;
+                                                    if (request.getParams().containsKey(WAIT_FOR_COMPLETION_TIMEOUT)) {
+                                                        waitForTimeCompletion = TimeValue.parseTimeValue(
+                                                            request.getParams().get(WAIT_FOR_COMPLETION_TIMEOUT),
+                                                            WAIT_FOR_COMPLETION_TIMEOUT
+                                                        );
+                                                    }
                                                     WorkflowRequest workflowRequest = new WorkflowRequest(
                                                         globalContextResponse.getId(),
                                                         null,
                                                         request.getParams(),
-                                                        TimeValue.parseTimeValue(waitForTimeCompletion, PROVISION_TIMEOUT_FIELD)
+                                                        waitForTimeCompletion
                                                     );
                                                     logger.info(
                                                         "Provisioning parameter is set, continuing to provision workflow {}",
@@ -358,14 +364,20 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                                 .build();
 
                         if (request.isReprovision()) {
-                            String waitForTimeCompletion = request.getParams()
-                                .getOrDefault(WAIT_FOR_COMPLETION_TIMEOUT, TimeValue.MINUS_ONE.toString());
+                            // default to minus one indicate async execution
+                            TimeValue waitForTimeCompletion = TimeValue.MINUS_ONE;
+                            if (request.getParams().containsKey(WAIT_FOR_COMPLETION_TIMEOUT)) {
+                                waitForTimeCompletion = TimeValue.parseTimeValue(
+                                    request.getParams().get(WAIT_FOR_COMPLETION_TIMEOUT),
+                                    WAIT_FOR_COMPLETION_TIMEOUT
+                                );
+                            }
                             // Reprovision request
                             ReprovisionWorkflowRequest reprovisionRequest = new ReprovisionWorkflowRequest(
                                 getResponse.getId(),
                                 existingTemplate,
                                 template,
-                                TimeValue.parseTimeValue(waitForTimeCompletion, PROVISION_TIMEOUT_FIELD)
+                                waitForTimeCompletion
                             );
                             logger.info("Reprovisioning parameter is set, continuing to reprovision workflow {}", getResponse.getId());
                             client.execute(

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -262,18 +262,14 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                                                         ProvisionWorkflowAction.INSTANCE,
                                                         workflowRequest,
                                                         ActionListener.wrap(provisionResponse -> {
-                                                            if (request.getWaitForCompletionTimeout() != null) {
-                                                                listener.onResponse(
-                                                                    new WorkflowResponse(
+                                                            listener.onResponse(
+                                                                request.getWaitForCompletionTimeout() != null
+                                                                    ? new WorkflowResponse(
                                                                         provisionResponse.getWorkflowId(),
                                                                         provisionResponse.getWorkflowState()
                                                                     )
-                                                                );
-                                                            } else {
-                                                                listener.onResponse(
-                                                                    new WorkflowResponse(provisionResponse.getWorkflowId())
-                                                                );
-                                                            }
+                                                                    : new WorkflowResponse(provisionResponse.getWorkflowId())
+                                                            );
                                                         }, exception -> {
                                                             String errorMessage = "Provisioning failed.";
                                                             logger.error(errorMessage, exception);

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -372,7 +372,14 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                                 ReprovisionWorkflowAction.INSTANCE,
                                 reprovisionRequest,
                                 ActionListener.wrap(reprovisionResponse -> {
-                                    listener.onResponse(new WorkflowResponse(reprovisionResponse.getWorkflowId()));
+                                    listener.onResponse(
+                                        reprovisionRequest.getWaitForCompletionTimeout() == TimeValue.MINUS_ONE
+                                            ? new WorkflowResponse(reprovisionResponse.getWorkflowId())
+                                            : new WorkflowResponse(
+                                                reprovisionResponse.getWorkflowId(),
+                                                reprovisionResponse.getWorkflowState()
+                                            )
+                                    );
                                 }, exception -> {
                                     String errorMessage = ParameterizedMessageFactory.INSTANCE.newMessage(
                                         "Reprovisioning failed for workflow {}",

--- a/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowRequest.java
@@ -70,8 +70,7 @@ public class ReprovisionWorkflowRequest extends ActionRequest {
         this.workflowId = in.readString();
         this.originalTemplate = Template.parse(in.readString());
         this.updatedTemplate = Template.parse(in.readString());
-        // todo:change to 2.19
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+        if (in.getVersion().onOrAfter(Version.V_2_19_0)) {
             this.waitForCompletionTimeout = in.readTimeValue();
         }
 
@@ -83,8 +82,7 @@ public class ReprovisionWorkflowRequest extends ActionRequest {
         out.writeString(workflowId);
         out.writeString(originalTemplate.toJson());
         out.writeString(updatedTemplate.toJson());
-        // todo:change to 2.19
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+        if (out.getVersion().onOrAfter(Version.V_2_19_0)) {
             out.writeTimeValue(waitForCompletionTimeout);
         }
     }

--- a/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowRequest.java
@@ -8,8 +8,10 @@
  */
 package org.opensearch.flowframework.transport;
 
+import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.flowframework.model.Template;
@@ -35,15 +37,27 @@ public class ReprovisionWorkflowRequest extends ActionRequest {
     private Template updatedTemplate;
 
     /**
+     * The timeout value for waiting for completion
+     */
+    private TimeValue waitForCompletionTimeout;
+
+    /**
      * Instantiates a new ReprovisionWorkflowRequest
      * @param workflowId the workflow ID
      * @param originalTemplate the original Template
      * @param updatedTemplate the updated Template
+     * @param waitForCompletionTimeout the maximum duration to wait for the workflow execution to complete.
      */
-    public ReprovisionWorkflowRequest(String workflowId, Template originalTemplate, Template updatedTemplate) {
+    public ReprovisionWorkflowRequest(
+        String workflowId,
+        Template originalTemplate,
+        Template updatedTemplate,
+        TimeValue waitForCompletionTimeout
+    ) {
         this.workflowId = workflowId;
         this.originalTemplate = originalTemplate;
         this.updatedTemplate = updatedTemplate;
+        this.waitForCompletionTimeout = waitForCompletionTimeout;
     }
 
     /**
@@ -56,6 +70,11 @@ public class ReprovisionWorkflowRequest extends ActionRequest {
         this.workflowId = in.readString();
         this.originalTemplate = Template.parse(in.readString());
         this.updatedTemplate = Template.parse(in.readString());
+        // todo:change to 2.19
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+            this.waitForCompletionTimeout = in.readTimeValue();
+        }
+
     }
 
     @Override
@@ -64,6 +83,10 @@ public class ReprovisionWorkflowRequest extends ActionRequest {
         out.writeString(workflowId);
         out.writeString(originalTemplate.toJson());
         out.writeString(updatedTemplate.toJson());
+        // todo:change to 2.19
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+            out.writeTimeValue(waitForCompletionTimeout);
+        }
     }
 
     @Override
@@ -95,4 +118,11 @@ public class ReprovisionWorkflowRequest extends ActionRequest {
         return this.updatedTemplate;
     }
 
+    /**
+     * Gets the waitForCompletion timeout value
+     * @return the timeout value
+     */
+    public TimeValue getWaitForCompletionTimeout() {
+        return this.waitForCompletionTimeout;
+    }
 }

--- a/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
@@ -19,6 +19,7 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
@@ -34,6 +35,7 @@ import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.model.Workflow;
 import org.opensearch.flowframework.model.WorkflowState;
 import org.opensearch.flowframework.util.EncryptorUtils;
+import org.opensearch.flowframework.util.WorkflowTimeoutUtility;
 import org.opensearch.flowframework.workflow.ProcessNode;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
@@ -48,6 +50,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static org.opensearch.flowframework.common.CommonValue.ERROR_FIELD;
@@ -243,9 +247,23 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
                     Template updatedTemplateWithProvisionedTime = Template.builder(updatedTemplate)
                         .lastProvisionedTime(Instant.now())
                         .build();
-                    executeWorkflowAsync(workflowId, updatedTemplateWithProvisionedTime, reprovisionProcessSequence, listener);
+                    if (request.getWaitForCompletionTimeout() == TimeValue.MINUS_ONE) {
+                        executeWorkflowAsync(workflowId, updatedTemplateWithProvisionedTime, reprovisionProcessSequence, listener);
+                    } else {
+                        executeWorkflowSync(
+                            workflowId,
+                            updatedTemplate,
+                            reprovisionProcessSequence,
+                            listener,
+                            request.getWaitForCompletionTimeout().getMillis()
+                        );
+                    }
 
-                    listener.onResponse(new WorkflowResponse(workflowId));
+                    if (request.getWaitForCompletionTimeout() == TimeValue.MINUS_ONE) {
+                        listener.onResponse(new WorkflowResponse(workflowId));
+                    } else {
+                        logger.info("Waiting for workflow completion");
+                    }
 
                 }, exception -> {
                     String errorMessage = ParameterizedMessageFactory.INSTANCE.newMessage("Failed to update workflow state: {}", workflowId)
@@ -284,11 +302,40 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
         try {
             threadPool.executor(PROVISION_WORKFLOW_THREAD_POOL).execute(() -> {
                 updateTemplate(template, workflowId);
-                executeWorkflow(template, workflowSequence, workflowId);
+                executeWorkflow(template, workflowSequence, workflowId, listener, false);
             });
         } catch (Exception exception) {
             listener.onFailure(new FlowFrameworkException("Failed to execute workflow " + workflowId, ExceptionsHelper.status(exception)));
         }
+    }
+
+    private void executeWorkflowSync(
+        String workflowId,
+        Template template,
+        List<ProcessNode> workflowSequence,
+        ActionListener<WorkflowResponse> listener,
+        long timeout
+    ) {
+        AtomicBoolean isResponseSent = new AtomicBoolean(false);
+        CompletableFuture.runAsync(() -> {
+            try {
+                updateTemplate(template, workflowId);
+                executeWorkflow(template, workflowSequence, workflowId, new ActionListener<>() {
+                    @Override
+                    public void onResponse(WorkflowResponse workflowResponse) {
+                        WorkflowTimeoutUtility.handleResponse(workflowId, workflowResponse, isResponseSent, listener);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        WorkflowTimeoutUtility.handleFailure(workflowId, e, isResponseSent, listener);
+                    }
+                }, true);
+            } catch (Exception ex) {
+                WorkflowTimeoutUtility.handleFailure(workflowId, ex, isResponseSent, listener);
+            }
+        }, threadPool.executor(PROVISION_WORKFLOW_THREAD_POOL));
+        WorkflowTimeoutUtility.scheduleTimeoutHandler(client, threadPool, workflowId, listener, timeout, isResponseSent);
     }
 
     /**
@@ -310,7 +357,13 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
      * @param workflowSequence The topologically sorted workflow to execute
      * @param workflowId The workflowId associated with the workflow that is executing
      */
-    private void executeWorkflow(Template template, List<ProcessNode> workflowSequence, String workflowId) {
+    private void executeWorkflow(
+        Template template,
+        List<ProcessNode> workflowSequence,
+        String workflowId,
+        ActionListener<WorkflowResponse> listener,
+        boolean isSyncExecution
+    ) {
         String currentStepId = "";
         try {
             Map<String, PlainActionFuture<?>> workflowFutureMap = new LinkedHashMap<>();
@@ -349,7 +402,23 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
                 ActionListener.wrap(updateResponse -> {
 
                     logger.info("updated workflow {} state to {}", workflowId, State.COMPLETED);
-
+                    if (isSyncExecution) {
+                        client.execute(
+                            GetWorkflowStateAction.INSTANCE,
+                            new GetWorkflowStateRequest(workflowId, false),
+                            ActionListener.wrap(response -> {
+                                listener.onResponse(new WorkflowResponse(workflowId, response.getWorkflowState()));
+                            }, exception -> {
+                                String errorMessage = "Failed to get workflow state.";
+                                logger.error(errorMessage, exception);
+                                if (exception instanceof FlowFrameworkException) {
+                                    listener.onFailure(exception);
+                                } else {
+                                    listener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(exception)));
+                                }
+                            })
+                        );
+                    }
                 }, exception -> { logger.error("Failed to update workflow state for workflow {}", workflowId, exception); })
             );
         } catch (Exception ex) {

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import static org.opensearch.flowframework.common.CommonValue.REPROVISION_WORKFLOW;
 import static org.opensearch.flowframework.common.CommonValue.UPDATE_WORKFLOW_FIELDS;
+import static org.opensearch.flowframework.common.CommonValue.WAIT_FOR_COMPLETION_TIMEOUT;
 
 /**
  * Transport Request to create, provision, and deprovision a workflow
@@ -154,7 +155,8 @@ public class WorkflowRequest extends ActionRequest {
         this.validation = validation;
         this.provision = provisionOrUpdate && !params.containsKey(UPDATE_WORKFLOW_FIELDS);
         this.updateFields = !provision && Boolean.parseBoolean(params.get(UPDATE_WORKFLOW_FIELDS));
-        if (!this.provision && params.keySet().stream().anyMatch(k -> !UPDATE_WORKFLOW_FIELDS.equals(k))) {
+        if (!this.provision
+            && params.keySet().stream().anyMatch(k -> !UPDATE_WORKFLOW_FIELDS.equals(k) && !WAIT_FOR_COMPLETION_TIMEOUT.equals(k))) {
             throw new IllegalArgumentException("Params may only be included when provisioning.");
         }
         this.params = this.updateFields ? Collections.emptyMap() : params;

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.flowframework.transport;
 
+import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.Nullable;
@@ -184,7 +185,11 @@ public class WorkflowRequest extends ActionRequest {
             this.params = Collections.emptyMap();
         }
         this.reprovision = !provision && Boolean.parseBoolean(params.get(REPROVISION_WORKFLOW));
-        this.waitForCompletionTimeout = in.readOptionalTimeValue();
+        // todo:change to 2.19
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+            this.waitForCompletionTimeout = in.readOptionalTimeValue();
+        }
+
     }
 
     /**
@@ -268,7 +273,10 @@ public class WorkflowRequest extends ActionRequest {
         } else if (reprovision) {
             out.writeMap(Map.of(REPROVISION_WORKFLOW, "true"), StreamOutput::writeString, StreamOutput::writeString);
         }
-        out.writeOptionalTimeValue(waitForCompletionTimeout);
+        // todo: change to 2.19
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+            out.writeOptionalTimeValue(waitForCompletionTimeout);
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
@@ -76,7 +76,7 @@ public class WorkflowRequest extends ActionRequest {
      * @param template the use case template which describes the workflow
      */
     public WorkflowRequest(@Nullable String workflowId, @Nullable Template template) {
-        this(workflowId, template, new String[] { "all" }, false, Collections.emptyMap(), false, null);
+        this(workflowId, template, new String[] { "all" }, false, Collections.emptyMap(), false, TimeValue.MINUS_ONE);
     }
 
     /**
@@ -86,7 +86,7 @@ public class WorkflowRequest extends ActionRequest {
      * @param params The parameters from the REST path
      */
     public WorkflowRequest(@Nullable String workflowId, @Nullable Template template, Map<String, String> params) {
-        this(workflowId, template, new String[] { "all" }, true, params, false, null);
+        this(workflowId, template, new String[] { "all" }, true, params, false, TimeValue.MINUS_ONE);
     }
 
     /**
@@ -107,6 +107,26 @@ public class WorkflowRequest extends ActionRequest {
         TimeValue waitForCompletionTimeout
     ) {
         this(workflowId, template, new String[] { "all" }, true, params, false, waitForCompletionTimeout);
+    }
+
+    /**
+     * Instantiates a new WorkflowRequest
+     * @param workflowId the documentId of the workflow
+     * @param template the use case template which describes the workflow
+     * @param validation flag to indicate if validation is necessary
+     * @param provisionOrUpdate provision or updateFields flag. Only one may be true, the presence of update_fields key in map indicates if updating fields, otherwise true means it's provisioning.
+     * @param params map of REST path params. If provisionOrUpdate is false, must be an empty map. If update_fields key is present, must be only key.
+     * @param reprovision flag to indicate if request is to reprovision
+     */
+    public WorkflowRequest(
+        @Nullable String workflowId,
+        @Nullable Template template,
+        String[] validation,
+        boolean provisionOrUpdate,
+        Map<String, String> params,
+        boolean reprovision
+    ) {
+        this(workflowId, template, validation, provisionOrUpdate, params, reprovision, TimeValue.MINUS_ONE);
     }
 
     /**

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
@@ -67,9 +67,9 @@ public class WorkflowRequest extends ActionRequest {
 
     /**
      * The timeout duration to wait for workflow completion.
-     * If null, the request will respond immediately with the workflowId.
+     * default set to -1, the request will respond immediately with the workflowId,
+     * indicating asynchronous execution.
      */
-    @Nullable
     private TimeValue waitForCompletionTimeout;
 
     /**
@@ -139,7 +139,7 @@ public class WorkflowRequest extends ActionRequest {
      * @param provisionOrUpdate provision or updateFields flag. Only one may be true, the presence of update_fields key in map indicates if updating fields, otherwise true means it's provisioning.
      * @param params map of REST path params. If provisionOrUpdate is false, must be an empty map. If update_fields key is present, must be only key.
      * @param reprovision flag to indicate if request is to reprovision
-     * @param waitForCompletionTimeout the timeout duration (in milliseconds) to wait for workflow completion
+     * @param waitForCompletionTimeout the timeout duration to wait for workflow completion
      */
     public WorkflowRequest(
         @Nullable String workflowId,
@@ -187,8 +187,7 @@ public class WorkflowRequest extends ActionRequest {
             this.params = Collections.emptyMap();
         }
         this.reprovision = !provision && Boolean.parseBoolean(params.get(REPROVISION_WORKFLOW));
-        // todo:change to 2.19
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+        if (in.getVersion().onOrAfter(Version.V_2_19_0)) {
             this.waitForCompletionTimeout = in.readOptionalTimeValue();
         }
 
@@ -275,8 +274,7 @@ public class WorkflowRequest extends ActionRequest {
         } else if (reprovision) {
             out.writeMap(Map.of(REPROVISION_WORKFLOW, "true"), StreamOutput::writeString, StreamOutput::writeString);
         }
-        // todo: change to 2.19
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+        if (out.getVersion().onOrAfter(Version.V_2_19_0)) {
             out.writeOptionalTimeValue(waitForCompletionTimeout);
         }
     }

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowResponse.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowResponse.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.flowframework.transport;
 
+import org.opensearch.Version;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -47,7 +48,10 @@ public class WorkflowResponse extends ActionResponse implements ToXContentObject
     public WorkflowResponse(StreamInput in) throws IOException {
         super(in);
         this.workflowId = in.readString();
-        this.workflowState = in.readOptionalWriteable(WorkflowState::new);
+        // todo : change version to 2_19_0
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+            this.workflowState = in.readOptionalWriteable(WorkflowState::new);
+        }
 
     }
 
@@ -89,7 +93,10 @@ public class WorkflowResponse extends ActionResponse implements ToXContentObject
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(workflowId);
-        out.writeOptionalWriteable(workflowState);
+        // todo : change version to 2_19_0
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+            out.writeOptionalWriteable(workflowState);
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowResponse.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowResponse.java
@@ -49,8 +49,7 @@ public class WorkflowResponse extends ActionResponse implements ToXContentObject
     public WorkflowResponse(StreamInput in) throws IOException {
         super(in);
         this.workflowId = in.readString();
-        // todo : change version to 2_19_0
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+        if (in.getVersion().onOrAfter(Version.V_2_19_0)) {
             this.workflowState = in.readOptionalWriteable(WorkflowState::new);
         }
 
@@ -95,8 +94,7 @@ public class WorkflowResponse extends ActionResponse implements ToXContentObject
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(workflowId);
-        // todo : change version to 2_19_0
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+        if (out.getVersion().onOrAfter(Version.V_2_19_0)) {
             out.writeOptionalWriteable(workflowState);
         }
     }

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowResponse.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowResponse.java
@@ -9,6 +9,7 @@
 package org.opensearch.flowframework.transport;
 
 import org.opensearch.Version;
+import org.opensearch.common.Nullable;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -67,6 +68,7 @@ public class WorkflowResponse extends ActionResponse implements ToXContentObject
      * Gets the workflowState of this repsonse
      * @return the workflowState
      */
+    @Nullable
     public WorkflowState getWorkflowState() {
         return this.workflowState;
     }

--- a/src/main/java/org/opensearch/flowframework/util/WorkflowTimeoutUtility.java
+++ b/src/main/java/org/opensearch/flowframework/util/WorkflowTimeoutUtility.java
@@ -18,7 +18,6 @@ import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.transport.GetWorkflowStateAction;
 import org.opensearch.flowframework.transport.GetWorkflowStateRequest;
 import org.opensearch.flowframework.transport.WorkflowResponse;
-import org.opensearch.search.aggregations.metrics.Min;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -34,6 +33,7 @@ public class WorkflowTimeoutUtility {
     private static final Logger logger = LogManager.getLogger(WorkflowTimeoutUtility.class);
     private static final TimeValue MAX_TIMEOUT_MILLIS = TimeValue.timeValueSeconds(300);
     private static final TimeValue MIN_TIMEOUT_MILLIS = TimeValue.timeValueSeconds(1);
+
     /**
      * Schedules a timeout task for a workflow execution.
      *

--- a/src/main/java/org/opensearch/flowframework/util/WorkflowTimeoutUtility.java
+++ b/src/main/java/org/opensearch/flowframework/util/WorkflowTimeoutUtility.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.client.Client;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.transport.GetWorkflowStateAction;
+import org.opensearch.flowframework.transport.GetWorkflowStateRequest;
+import org.opensearch.flowframework.transport.WorkflowResponse;
+import org.opensearch.threadpool.Scheduler;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Utility class for managing timeout tasks in workflow execution.
+ * This class provides methods to schedule timeout handlers, wrap listeners with timeout cancellation logic,
+ * and fetch workflow states after timeouts.
+ */
+public class WorkflowTimeoutUtility {
+
+    private static final Logger logger = LogManager.getLogger(WorkflowTimeoutUtility.class);
+    private static final TimeValue MAX_TIMEOUT_MILLIS = TimeValue.timeValueSeconds(300);
+
+    /**
+     * Schedules a timeout task for a workflow execution.
+     *
+     * @param client        The OpenSearch client used to interact with the cluster.
+     * @param threadPool    The thread pool to schedule the timeout task.
+     * @param workflowId    The unique identifier of the workflow being executed.
+     * @param listener      The listener to notify when the task completes or times out.
+     * @param timeout       The timeout duration in milliseconds.
+     * @param isResponseSent An atomic boolean to ensure the response is sent only once.
+     * @return A wrapped ActionListener with timeout cancellation logic.
+     */
+    public static ActionListener<WorkflowResponse> scheduleTimeoutHandler(
+        Client client,
+        ThreadPool threadPool,
+        final String workflowId,
+        ActionListener<WorkflowResponse> listener,
+        long timeout,
+        AtomicBoolean isResponseSent
+    ) {
+        long adjustedTimeout = Math.min(timeout, MAX_TIMEOUT_MILLIS.millis());
+        Scheduler.ScheduledCancellable scheduledCancellable = threadPool.schedule(
+            new WorkflowTimeoutListener(client, workflowId, listener, isResponseSent),
+            TimeValue.timeValueMillis(adjustedTimeout),
+            ThreadPool.Names.GENERIC
+        );
+
+        return wrapWithTimeoutCancellationListener(listener, scheduledCancellable, isResponseSent);
+    }
+
+    /**
+     * A listener that handles timeout for a workflow execution.
+     */
+    private static class WorkflowTimeoutListener implements Runnable {
+        private final Client client;
+        private final String workflowId;
+        private final ActionListener<WorkflowResponse> listener;
+        private final AtomicBoolean isResponseSent;
+
+        WorkflowTimeoutListener(Client client, String workflowId, ActionListener<WorkflowResponse> listener, AtomicBoolean isResponseSent) {
+            this.client = client;
+            this.workflowId = workflowId;
+            this.listener = listener;
+            this.isResponseSent = isResponseSent;
+        }
+
+        @Override
+        public void run() {
+            if (isResponseSent.compareAndSet(false, true)) {
+                logger.warn("Workflow execution timed out for workflowId: {}", workflowId);
+                fetchWorkflowStateAfterTimeout(client, workflowId, listener);
+            }
+        }
+    }
+
+    /**
+     * Wraps a listener with a timeout cancellation listener to cancel the timeout task when the workflow completes.
+     *
+     * @param listener             The original listener to wrap.
+     * @param scheduledCancellable The cancellable timeout task.
+     * @param isResponseSent        An atomic boolean to ensure the response is sent only once.
+     * @param <Response>            The type of the response expected by the listener.
+     * @return A wrapped ActionListener with timeout cancellation logic.
+     */
+    public static <Response> ActionListener<Response> wrapWithTimeoutCancellationListener(
+        ActionListener<Response> listener,
+        Scheduler.ScheduledCancellable scheduledCancellable,
+        AtomicBoolean isResponseSent
+    ) {
+        return new ActionListener<>() {
+            @Override
+            public void onResponse(Response response) {
+                if (isResponseSent.compareAndSet(false, true)) {
+                    scheduledCancellable.cancel();
+                }
+                listener.onResponse(response);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (isResponseSent.compareAndSet(false, true)) {
+                    scheduledCancellable.cancel();
+                }
+                listener.onFailure(e);
+            }
+        };
+    }
+
+    /**
+     * Handles the successful completion of a workflow.
+     *
+     * @param workflowId     The unique identifier of the workflow.
+     * @param workflowResponse The response from the workflow execution.
+     * @param isResponseSent  An atomic boolean to ensure the response is sent only once.
+     * @param listener        The listener to notify of the workflow completion.
+     */
+    public static void handleResponse(
+        String workflowId,
+        WorkflowResponse workflowResponse,
+        AtomicBoolean isResponseSent,
+        ActionListener<WorkflowResponse> listener
+    ) {
+        if (isResponseSent.compareAndSet(false, true)) {
+            listener.onResponse(new WorkflowResponse(workflowResponse.getWorkflowId(), workflowResponse.getWorkflowState()));
+        } else {
+            logger.info("Ignoring onResponse for workflowId: {} as timeout already occurred", workflowId);
+        }
+    }
+
+    /**
+     * Handles the failure of a workflow execution.
+     *
+     * @param workflowId    The unique identifier of the workflow.
+     * @param e             The exception that occurred during workflow execution.
+     * @param isResponseSent An atomic boolean to ensure the response is sent only once.
+     * @param listener       The listener to notify of the workflow failure.
+     */
+    public static void handleFailure(
+        String workflowId,
+        Exception e,
+        AtomicBoolean isResponseSent,
+        ActionListener<WorkflowResponse> listener
+    ) {
+        if (isResponseSent.compareAndSet(false, true)) {
+            FlowFrameworkException exception = new FlowFrameworkException(
+                "Failed to execute workflow " + workflowId,
+                ExceptionsHelper.status(e)
+            );
+            listener.onFailure(exception);
+        } else {
+            logger.info("Ignoring onFailure for workflowId: {} as timeout already occurred", workflowId);
+        }
+    }
+
+    /**
+     * Fetches the workflow state after a timeout has occurred.
+     * This method sends a request to retrieve the current state of the workflow
+     * and notifies the listener with the updated state or an error if the request fails.
+     *
+     * @param client      The OpenSearch client used to fetch the workflow state.
+     * @param workflowId  The unique identifier of the workflow.
+     * @param listener    The listener to notify with the updated state or failure.
+     */
+    public static void fetchWorkflowStateAfterTimeout(
+        final Client client,
+        final String workflowId,
+        final ActionListener<WorkflowResponse> listener
+    ) {
+        client.execute(
+            GetWorkflowStateAction.INSTANCE,
+            new GetWorkflowStateRequest(workflowId, false),
+            ActionListener.wrap(
+                response -> listener.onResponse(new WorkflowResponse(workflowId, response.getWorkflowState())),
+                exception -> listener.onFailure(
+                    new FlowFrameworkException("Failed to get workflow state after timeout", ExceptionsHelper.status(exception))
+                )
+            )
+        );
+    }
+}

--- a/src/main/java/org/opensearch/flowframework/util/WorkflowTimeoutUtility.java
+++ b/src/main/java/org/opensearch/flowframework/util/WorkflowTimeoutUtility.java
@@ -31,8 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class WorkflowTimeoutUtility {
 
     private static final Logger logger = LogManager.getLogger(WorkflowTimeoutUtility.class);
-    private static final TimeValue MAX_TIMEOUT_MILLIS = TimeValue.timeValueSeconds(300);
-    private static final TimeValue MIN_TIMEOUT_MILLIS = TimeValue.timeValueSeconds(1);
+    private static final TimeValue MIN_TIMEOUT_MILLIS = TimeValue.timeValueSeconds(0);
 
     /**
      * Schedules a timeout task for a workflow execution.
@@ -53,8 +52,8 @@ public class WorkflowTimeoutUtility {
         long timeout,
         AtomicBoolean isResponseSent
     ) {
-        long adjustedTimeout = Math.min(timeout, MAX_TIMEOUT_MILLIS.millis());
-        adjustedTimeout = Math.max(adjustedTimeout, MIN_TIMEOUT_MILLIS.millis());
+        // Ensure timeout is within the valid range (non-negative)
+        long adjustedTimeout = Math.max(timeout, MIN_TIMEOUT_MILLIS.millis());
         Scheduler.ScheduledCancellable scheduledCancellable = threadPool.schedule(
             new WorkflowTimeoutListener(client, workflowId, listener, isResponseSent),
             TimeValue.timeValueMillis(adjustedTimeout),

--- a/src/main/java/org/opensearch/flowframework/util/WorkflowTimeoutUtility.java
+++ b/src/main/java/org/opensearch/flowframework/util/WorkflowTimeoutUtility.java
@@ -18,6 +18,7 @@ import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.transport.GetWorkflowStateAction;
 import org.opensearch.flowframework.transport.GetWorkflowStateRequest;
 import org.opensearch.flowframework.transport.WorkflowResponse;
+import org.opensearch.search.aggregations.metrics.Min;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -32,7 +33,7 @@ public class WorkflowTimeoutUtility {
 
     private static final Logger logger = LogManager.getLogger(WorkflowTimeoutUtility.class);
     private static final TimeValue MAX_TIMEOUT_MILLIS = TimeValue.timeValueSeconds(300);
-
+    private static final TimeValue MIN_TIMEOUT_MILLIS = TimeValue.timeValueSeconds(1);
     /**
      * Schedules a timeout task for a workflow execution.
      *
@@ -53,6 +54,7 @@ public class WorkflowTimeoutUtility {
         AtomicBoolean isResponseSent
     ) {
         long adjustedTimeout = Math.min(timeout, MAX_TIMEOUT_MILLIS.millis());
+        adjustedTimeout = Math.max(adjustedTimeout, MIN_TIMEOUT_MILLIS.millis());
         Scheduler.ScheduledCancellable scheduledCancellable = threadPool.schedule(
             new WorkflowTimeoutListener(client, workflowId, listener, isResponseSent),
             TimeValue.timeValueMillis(adjustedTimeout),

--- a/src/main/java/org/opensearch/flowframework/util/WorkflowTimeoutUtility.java
+++ b/src/main/java/org/opensearch/flowframework/util/WorkflowTimeoutUtility.java
@@ -23,6 +23,8 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
+
 /**
  * Utility class for managing timeout tasks in workflow execution.
  * This class provides methods to schedule timeout handlers, wrap listeners with timeout cancellation logic,
@@ -57,7 +59,7 @@ public class WorkflowTimeoutUtility {
         Scheduler.ScheduledCancellable scheduledCancellable = threadPool.schedule(
             new WorkflowTimeoutListener(client, workflowId, listener, isResponseSent),
             TimeValue.timeValueMillis(adjustedTimeout),
-            ThreadPool.Names.GENERIC
+            PROVISION_WORKFLOW_THREAD_POOL
         );
 
         return wrapWithTimeoutCancellationListener(listener, scheduledCancellable, isResponseSent);
@@ -181,6 +183,7 @@ public class WorkflowTimeoutUtility {
         final String workflowId,
         final ActionListener<WorkflowResponse> listener
     ) {
+        logger.info("Fetching workflow state after timeout");
         client.execute(
             GetWorkflowStateAction.INSTANCE,
             new GetWorkflowStateRequest(workflowId, false),

--- a/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
@@ -148,7 +148,6 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
         assertTrue(channel.capturedResponse().content().utf8ToString().contains("workflow_1"));
     }
 
-
     public void testCreateWorkflowRequestWithParamsButNoProvision() throws Exception {
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
             .withPath(this.createWorkflowPath)

--- a/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
@@ -130,7 +130,7 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
 
     public void testRestCreateWorkflow_withWaitForCompletionTimeout() throws Exception {
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
-            .withParams(Map.of("wait_for_completion_timeout", "5s"))
+            .withParams(Map.ofEntries(Map.entry(PROVISION_WORKFLOW, "true"), Map.entry("wait_for_completion_timeout", "5s")))
             .withContent(new BytesArray(validTemplate), MediaTypeRegistry.JSON)
             .build();
 
@@ -148,20 +148,6 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
         assertTrue(channel.capturedResponse().content().utf8ToString().contains("workflow_1"));
     }
 
-    public void testInvalidValueForCompletionTimeout() throws Exception {
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
-            .withParams(Map.of("wait_for_completion_timeout", "invalid_value"))
-            .withContent(new BytesArray(validTemplate), MediaTypeRegistry.JSON)
-            .build();
-
-        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
-
-        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
-            createWorkflowRestAction.handleRequest(request, channel, nodeClient);
-        });
-
-        assertTrue(exception.getMessage().contains("failed to parse setting [wait_for_completion_timeout] with value [invalid_value]"));
-    }
 
     public void testCreateWorkflowRequestWithParamsButNoProvision() throws Exception {
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)

--- a/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
@@ -39,6 +39,7 @@ import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW
 import static org.opensearch.flowframework.common.CommonValue.REPROVISION_WORKFLOW;
 import static org.opensearch.flowframework.common.CommonValue.UPDATE_WORKFLOW_FIELDS;
 import static org.opensearch.flowframework.common.CommonValue.USE_CASE;
+import static org.opensearch.flowframework.common.CommonValue.WAIT_FOR_COMPLETION_TIMEOUT;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -128,7 +129,7 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
         assertTrue(channel.capturedResponse().content().utf8ToString().contains("id-123"));
     }
 
-    public void testRestCreateWorkflow_withWaitForCompletionTimeout() throws Exception {
+    public void testRestCreateWorkflowWithWaitForCompletionTimeout() throws Exception {
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
             .withParams(Map.ofEntries(Map.entry(PROVISION_WORKFLOW, "true"), Map.entry("wait_for_completion_timeout", "5s")))
             .withContent(new BytesArray(validTemplate), MediaTypeRegistry.JSON)
@@ -159,6 +160,23 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
         assertEquals(RestStatus.BAD_REQUEST, channel.capturedResponse().status());
         assertTrue(
             channel.capturedResponse().content().utf8ToString().contains("are permitted unless the provision parameter is set to true.")
+        );
+    }
+
+    public void testCreateWorkflowRequestWithWaitForTimeCompletionTimeoutButNoProvision() throws Exception {
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath(this.createWorkflowPath)
+            .withParams(Map.of(WAIT_FOR_COMPLETION_TIMEOUT, "1s"))
+            .withContent(new BytesArray(validTemplate), MediaTypeRegistry.JSON)
+            .build();
+        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
+        createWorkflowRestAction.handleRequest(request, channel, nodeClient);
+        assertEquals(RestStatus.BAD_REQUEST, channel.capturedResponse().status());
+        assertTrue(
+            channel.capturedResponse()
+                .content()
+                .utf8ToString()
+                .contains("are not allowed unless the 'provision' or 'reprovision' parameter is set to true.")
         );
     }
 

--- a/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/CreateWorkflowTransportActionTests.java
@@ -38,6 +38,7 @@ import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.model.Workflow;
 import org.opensearch.flowframework.model.WorkflowEdge;
 import org.opensearch.flowframework.model.WorkflowNode;
+import org.opensearch.flowframework.model.WorkflowState;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.search.SearchHit;
@@ -48,6 +49,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -252,7 +254,7 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
 
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap(), false);
+        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap(), false,null);
 
         doAnswer(invocation -> {
             ActionListener<SearchResponse> searchListener = invocation.getArgument(1);
@@ -289,7 +291,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
     public void testFailedToCreateNewWorkflow() {
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap(), false);
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            null,
+            template,
+            new String[] { "off" },
+            false,
+            Collections.emptyMap(),
+            false,
+            null
+        );
 
         // Bypass checkMaxWorkflows and force onResponse
         doAnswer(invocation -> {
@@ -320,7 +330,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
     public void testCreateNewWorkflow() {
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap(), false);
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            null,
+            template,
+            new String[] { "off" },
+            false,
+            Collections.emptyMap(),
+            false,
+            null
+        );
 
         // Bypass checkMaxWorkflows and force onResponse
         doAnswer(invocation -> {
@@ -384,7 +402,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         );
 
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap(), false);
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            null,
+            template,
+            new String[] { "off" },
+            false,
+            Collections.emptyMap(),
+            false,
+            null
+        );
 
         // Bypass checkMaxWorkflows and force onResponse
         doAnswer(invocation -> {
@@ -448,7 +474,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
 
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
 
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap(), false);
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            null,
+            template,
+            new String[] { "off" },
+            false,
+            Collections.emptyMap(),
+            false,
+            null
+        );
 
         createWorkflowTransportAction1.doExecute(mock(Task.class), workflowRequest, listener);
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -483,7 +517,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
 
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
 
-        WorkflowRequest workflowRequest = new WorkflowRequest(null, template, new String[] { "off" }, false, Collections.emptyMap(), false);
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            null,
+            template,
+            new String[] { "off" },
+            false,
+            Collections.emptyMap(),
+            false,
+            null
+        );
 
         createWorkflowTransportAction1.doExecute(mock(Task.class), workflowRequest, listener);
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -497,7 +539,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
     public void testUpdateWorkflowWithReprovision() throws IOException {
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        WorkflowRequest workflowRequest = new WorkflowRequest("1", template, new String[] { "off" }, false, Collections.emptyMap(), true);
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            "1",
+            template,
+            new String[] { "off" },
+            false,
+            Collections.emptyMap(),
+            true,
+            null
+        );
 
         doAnswer(invocation -> {
             ActionListener<GetResponse> getListener = invocation.getArgument(1);
@@ -541,7 +591,15 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
     public void testFailedToUpdateWorkflowWithReprovision() throws IOException {
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        WorkflowRequest workflowRequest = new WorkflowRequest("1", template, new String[] { "off" }, false, Collections.emptyMap(), true);
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            "1",
+            template,
+            new String[] { "off" },
+            false,
+            Collections.emptyMap(),
+            true,
+            null
+        );
 
         doAnswer(invocation -> {
             ActionListener<GetResponse> getListener = invocation.getArgument(1);
@@ -841,7 +899,8 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             new String[] { "all" },
             true,
             Collections.emptyMap(),
-            false
+            false,
+            null
         );
 
         // Bypass checkMaxWorkflows and force onResponse
@@ -888,6 +947,82 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
         assertEquals("1", workflowResponseCaptor.getValue().getWorkflowId());
     }
 
+    public void testCreateWorkflow_withValidation_withWaitForCompletion_withProvision_Success() throws Exception {
+
+        Template validTemplate = generateValidTemplate();
+
+        @SuppressWarnings("unchecked")
+        ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
+
+        doNothing().when(workflowProcessSorter).validate(any(), any());
+        WorkflowRequest workflowRequest = new WorkflowRequest(
+            null,
+            validTemplate,
+            new String[] { "all" },
+            true,
+            Collections.emptyMap(),
+            false,
+            TimeValue.timeValueSeconds(5)
+        );
+
+        // Bypass checkMaxWorkflows and force onResponse
+        doAnswer(invocation -> {
+            ActionListener<Boolean> checkMaxWorkflowListener = invocation.getArgument(2);
+            checkMaxWorkflowListener.onResponse(true);
+            return null;
+        }).when(createWorkflowTransportAction).checkMaxWorkflows(any(TimeValue.class), anyInt(), any());
+
+        // Bypass initializeConfigIndex and force onResponse
+        doAnswer(invocation -> {
+            ActionListener<Boolean> initalizeMasterKeyIndexListener = invocation.getArgument(0);
+            initalizeMasterKeyIndexListener.onResponse(true);
+            return null;
+        }).when(flowFrameworkIndicesHandler).initializeConfigIndex(any());
+
+        // Bypass putTemplateToGlobalContext and force onResponse
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> responseListener = invocation.getArgument(1);
+            responseListener.onResponse(new IndexResponse(new ShardId(GLOBAL_CONTEXT_INDEX, "", 1), "1", 1L, 1L, 1L, true));
+            return null;
+        }).when(flowFrameworkIndicesHandler).putTemplateToGlobalContext(any(), any());
+
+        // Bypass putInitialStateToWorkflowState and force on response
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(new IndexResponse(new ShardId(WORKFLOW_STATE_INDEX, "", 1), "1", 1L, 1L, 1L, true));
+            return null;
+        }).when(flowFrameworkIndicesHandler).putInitialStateToWorkflowState(any(), any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<WorkflowResponse> responseListener = invocation.getArgument(2);
+            WorkflowResponse response = mock(WorkflowResponse.class);
+            when(response.getWorkflowId()).thenReturn("1");
+            when(response.getWorkflowState()).thenReturn(
+                new WorkflowState(
+                    "1",
+                    "test",
+                    "PROVISIONING",
+                    "IN_PROGRESS",
+                    Instant.now(),
+                    Instant.now(),
+                    TestHelpers.randomUser(),
+                    Collections.emptyMap(),
+                    Collections.emptyList()
+                )
+            );
+            responseListener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(ProvisionWorkflowAction.INSTANCE), any(WorkflowRequest.class), any(ActionListener.class));
+
+        ArgumentCaptor<WorkflowResponse> workflowResponseCaptor = ArgumentCaptor.forClass(WorkflowResponse.class);
+
+        createWorkflowTransportAction.doExecute(mock(Task.class), workflowRequest, listener);
+
+        verify(listener, times(1)).onResponse(workflowResponseCaptor.capture());
+        assertEquals("1", workflowResponseCaptor.getValue().getWorkflowId());
+        assertEquals("PROVISIONING", workflowResponseCaptor.getValue().getWorkflowState().getState());
+    }
+
     public void testCreateWorkflow_withValidation_withProvision_FailedProvisioning() throws Exception {
 
         Template validTemplate = generateValidTemplate();
@@ -901,7 +1036,8 @@ public class CreateWorkflowTransportActionTests extends OpenSearchTestCase {
             new String[] { "all" },
             true,
             Collections.emptyMap(),
-            false
+            false,
+            null
         );
 
         // Bypass checkMaxWorkflows and force onResponse

--- a/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowRequestTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowRequestTests.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.transport;
 
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.BytesStreamInput;
 import org.opensearch.flowframework.TestHelpers;
@@ -72,7 +73,7 @@ public class ReprovisionWorkflowRequestTests extends OpenSearchTestCase {
     }
 
     public void testReprovisionWorkflowRequest() throws IOException {
-        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest("123", originalTemplate, updatedTemplate);
+        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest("123", originalTemplate, updatedTemplate, TimeValue.MINUS_ONE);
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);

--- a/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportActionTests.java
@@ -14,6 +14,7 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
@@ -152,7 +153,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(workflowId, mockTemplate, mockTemplate);
+        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(workflowId, mockTemplate, mockTemplate, TimeValue.MINUS_ONE);
 
         reprovisionWorkflowTransportAction.doExecute(mock(Task.class), request, listener);
         ArgumentCaptor<WorkflowResponse> responseCaptor = ArgumentCaptor.forClass(WorkflowResponse.class);
@@ -189,7 +190,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(workflowId, mockTemplate, mockTemplate);
+        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(workflowId, mockTemplate, mockTemplate, TimeValue.MINUS_ONE);
 
         reprovisionWorkflowTransportAction.doExecute(mock(Task.class), request, listener);
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -229,7 +230,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(workflowId, mockTemplate, mockTemplate);
+        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(workflowId, mockTemplate, mockTemplate, TimeValue.MINUS_ONE);
 
         reprovisionWorkflowTransportAction.doExecute(mock(Task.class), request, listener);
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -280,7 +281,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(workflowId, mockTemplate, mockTemplate);
+        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(workflowId, mockTemplate, mockTemplate, TimeValue.MINUS_ONE);
 
         reprovisionWorkflowTransportAction.doExecute(mock(Task.class), request, listener);
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -312,7 +313,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         @SuppressWarnings("unchecked")
         ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
-        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(workflowId, mockTemplate, mockTemplate);
+        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(workflowId, mockTemplate, mockTemplate, TimeValue.MINUS_ONE);
 
         reprovisionWorkflowTransportAction.doExecute(mock(Task.class), request, listener);
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);

--- a/src/test/java/org/opensearch/flowframework/util/WorkflowTimeoutUtilityTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/WorkflowTimeoutUtilityTests.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -69,7 +70,7 @@ public class WorkflowTimeoutUtilityTests extends OpenSearchTestCase {
         verify(mockThreadPool, times(1)).schedule(
             any(Runnable.class),
             eq(TimeValue.timeValueMillis(timeout)),
-            eq(ThreadPool.Names.GENERIC)
+            eq(PROVISION_WORKFLOW_THREAD_POOL)
         );
     }
 

--- a/src/test/java/org/opensearch/flowframework/util/WorkflowTimeoutUtilityTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/WorkflowTimeoutUtilityTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.util;
+
+import org.opensearch.client.Client;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.flowframework.TestHelpers;
+import org.opensearch.flowframework.model.WorkflowState;
+import org.opensearch.flowframework.transport.GetWorkflowStateAction;
+import org.opensearch.flowframework.transport.GetWorkflowStateRequest;
+import org.opensearch.flowframework.transport.WorkflowResponse;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.Scheduler;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WorkflowTimeoutUtilityTests extends OpenSearchTestCase {
+
+    private Client mockClient;
+    private ThreadPool mockThreadPool;
+    private Scheduler.ScheduledCancellable mockScheduledCancellable;
+    private AtomicBoolean isResponseSent;
+    private ActionListener<WorkflowResponse> mockListener;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockClient = mock(Client.class);
+        mockThreadPool = mock(ThreadPool.class);
+        mockScheduledCancellable = mock(Scheduler.ScheduledCancellable.class);
+        isResponseSent = new AtomicBoolean(false);
+        mockListener = mock(ActionListener.class);
+
+        when(mockThreadPool.schedule(any(Runnable.class), any(TimeValue.class), anyString())).thenReturn(mockScheduledCancellable);
+    }
+
+    public void testScheduleTimeoutHandler() {
+        String workflowId = "testWorkflowId";
+        long timeout = 1000L;
+
+        ActionListener<WorkflowResponse> returnedListener = WorkflowTimeoutUtility.scheduleTimeoutHandler(
+            mockClient,
+            mockThreadPool,
+            workflowId,
+            mockListener,
+            timeout,
+            isResponseSent
+        );
+
+        assertNotNull(returnedListener);
+        verify(mockThreadPool, times(1)).schedule(
+            any(Runnable.class),
+            eq(TimeValue.timeValueMillis(timeout)),
+            eq(ThreadPool.Names.GENERIC)
+        );
+    }
+
+    public void testWrapWithTimeoutCancellationListener_OnResponse() {
+        WorkflowResponse response = new WorkflowResponse(
+            "testWorkflowId",
+            new WorkflowState(
+                "1",
+                "test",
+                "PROVISIONING",
+                "IN_PROGRESS",
+                Instant.now(),
+                Instant.now(),
+                TestHelpers.randomUser(),
+                Collections.emptyMap(),
+                Collections.emptyList()
+            )
+        );
+        Scheduler.ScheduledCancellable scheduledCancellable = mock(Scheduler.ScheduledCancellable.class);
+
+        ActionListener<WorkflowResponse> wrappedListener = WorkflowTimeoutUtility.wrapWithTimeoutCancellationListener(
+            mockListener,
+            scheduledCancellable,
+            isResponseSent
+        );
+
+        wrappedListener.onResponse(response);
+
+        assertTrue(isResponseSent.get());
+        verify(scheduledCancellable, times(1)).cancel();
+        verify(mockListener, times(1)).onResponse(response);
+    }
+
+    public void testWrapWithTimeoutCancellationListener_OnFailure() {
+        Exception exception = new Exception("Test exception");
+        Scheduler.ScheduledCancellable scheduledCancellable = mock(Scheduler.ScheduledCancellable.class);
+
+        ActionListener<WorkflowResponse> wrappedListener = WorkflowTimeoutUtility.wrapWithTimeoutCancellationListener(
+            mockListener,
+            scheduledCancellable,
+            isResponseSent
+        );
+
+        wrappedListener.onFailure(exception);
+
+        assertTrue(isResponseSent.get());
+        verify(scheduledCancellable, times(1)).cancel();
+        verify(mockListener, times(1)).onFailure(exception);
+    }
+
+    public void testFetchWorkflowStateAfterTimeout() {
+        String workflowId = "testWorkflowId";
+        ActionListener<WorkflowResponse> mockListener = mock(ActionListener.class);
+
+        WorkflowTimeoutUtility.fetchWorkflowStateAfterTimeout(mockClient, workflowId, mockListener);
+
+        verify(mockClient, times(1)).execute(
+            eq(GetWorkflowStateAction.INSTANCE),
+            any(GetWorkflowStateRequest.class),
+            any(ActionListener.class)
+        );
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/util/WorkflowTimeoutUtilityTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/WorkflowTimeoutUtilityTests.java
@@ -74,7 +74,7 @@ public class WorkflowTimeoutUtilityTests extends OpenSearchTestCase {
         );
     }
 
-    public void testWrapWithTimeoutCancellationListener_OnResponse() {
+    public void testWrapWithTimeoutCancellationListenerOnResponse() {
         WorkflowResponse response = new WorkflowResponse(
             "testWorkflowId",
             new WorkflowState(
@@ -104,7 +104,7 @@ public class WorkflowTimeoutUtilityTests extends OpenSearchTestCase {
         verify(mockListener, times(1)).onResponse(response);
     }
 
-    public void testWrapWithTimeoutCancellationListener_OnFailure() {
+    public void testWrapWithTimeoutCancellationListenerOnFailure() {
         Exception exception = new Exception("Test exception");
         Scheduler.ScheduledCancellable scheduledCancellable = mock(Scheduler.ScheduledCancellable.class);
 


### PR DESCRIPTION
Jan 14 Revision
Added synchronous execution option to reprovision 




### Description
This PR introduces a new `wait_for_completion_timeout ` feature to the Provision Workflow API in the OpenSearch Flow Framework. The feature allows users to control whether the API call waits for the entire workflow provisioning process to complete before returning a response.

#### What’s Changed:
1. Added support for the wait_for_completion_timeout parameter in the REST layer (RestProvisionWorkflowAction).

- Accepts a time duration value (e.g., 30s, 1m).
- If the workflow is provisioned within the specified timeout, the API returns the created resources (same response as GetWorkflowStatus).
- If the timeout is reached before provisioning completes, the API returns the workflow state without waiting further.

3. Updated the transport layer (ProvisionWorkflowTransportAction) to handle the timeout logic and ensure correct behavior during synchronous provisioning.


Success Response:
```
{
    "workflow_id": "K13IR5QBEpCfUu_-AQdU",
    "state": "COMPLETED",
    "resources_created": [
        {
            "workflow_step_name": "create_connector",
            "workflow_step_id": "create_connector_1",
            "resource_id": "LF3IR5QBEpCfUu_-Awd_",
            "resource_type": "connector_id"
        },
        {
            "workflow_step_id": "register_model_2",
            "workflow_step_name": "register_remote_model",
            "resource_id": "L13IR5QBEpCfUu_-BQdI",
            "resource_type": "model_id"
        },
        {
            "workflow_step_name": "deploy_model",
            "workflow_step_id": "deploy_model_3",
            "resource_id": "L13IR5QBEpCfUu_-BQdI",
            "resource_type": "model_id"
        }
    ]
}
```
TimeOut Response:
```
{
    "workflow_id": "SmACR5QBdrR0lYdqgHa9",
    "state": "PROVISIONING",
    "resources_created": [
        {
            "workflow_step_name": "create_connector",
            "workflow_step_id": "create_connector_1",
            "resource_type": "connector_id",
            "resource_id": "S2ACR5QBdrR0lYdqgXYK"
        },
        {
            "workflow_step_name": "register_remote_model",
            "workflow_step_id": "register_model_2",
            "resource_type": "model_id",
            "resource_id": "TWACR5QBdrR0lYdqgXZ-"
        }
    ]
}
```
#### Areas of Concern:
I have a few parts of the implementation that I believe can be further improved, particularly in ProvisionWorkflowTransportAction. Some of the logic feels a bit verbose and might not be the most efficient way to handle the timeout and synchronous execution. I’d appreciate the feedback from reviewers.
### Related Issues
Resolves #967 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
