### PR TITLE
Fix tests to handle ambiguous mlClient method signature

### DIFF
--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
@@ -28,6 +28,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
@@ -58,7 +59,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             DeleteResponse output = new DeleteResponse(shardId, connectorIdArg, 1, 1, 1, true);
             actionListener.onResponse(output);
             return null;
-        }).when(machineLearningNodeClient).deleteConnector(any(String.class), any());
+        }).when(machineLearningNodeClient).deleteConnector(anyString(), anyActionListener());
 
         PlainActionFuture<WorkflowData> future = deleteConnectorStep.execute(
             inputData.getNodeId(),
@@ -67,7 +68,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             Map.of("step_1", CONNECTOR_ID),
             Collections.emptyMap()
         );
-        verify(machineLearningNodeClient).deleteConnector(any(String.class), any());
+        verify(machineLearningNodeClient).deleteConnector(anyString(), anyActionListener());
 
         assertTrue(future.isDone());
         assertEquals(connectorId, future.get().getContent().get(CONNECTOR_ID));
@@ -97,7 +98,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             ActionListener<DeleteResponse> actionListener = invocation.getArgument(1);
             actionListener.onFailure(new FlowFrameworkException("Failed to delete connector", RestStatus.INTERNAL_SERVER_ERROR));
             return null;
-        }).when(machineLearningNodeClient).deleteConnector(any(String.class), any());
+        }).when(machineLearningNodeClient).deleteConnector(anyString(), anyActionListener());
 
         PlainActionFuture<WorkflowData> future = deleteConnectorStep.execute(
             inputData.getNodeId(),
@@ -107,11 +108,16 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             Collections.emptyMap()
         );
 
-        verify(machineLearningNodeClient).deleteConnector(any(String.class), any());
+        verify(machineLearningNodeClient).deleteConnector(anyString(), anyActionListener());
 
         assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
         assertTrue(ex.getCause() instanceof FlowFrameworkException);
         assertEquals("Failed to delete connector test", ex.getCause().getMessage());
+    }
+
+    @SuppressWarnings("unchecked")
+    private ActionListener<DeleteResponse> anyActionListener() {
+        return any(ActionListener.class);
     }
 }


### PR DESCRIPTION
### Description

Following https://github.com/opensearch-project/ml-commons/pull/3382, the ML Client has multiple method signatures matching `deleteConnector(String, Object)`.  

Updates tests that were failing due to this ambiguity.

### Related Issues

Resolves failing compilation and tests such as https://github.com/opensearch-project/flow-framework/actions/runs/12784028161/job/35636228362

### Check List
- [x] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
