### PR TITLE
Fixed RBAC fetching from workflow state when template is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 ### Bug Fixes
 - Remove useCase and defaultParams field in WorkflowRequest ([#758](https://github.com/opensearch-project/flow-framework/pull/758))
+- Fix RBAC fetching from workflow state when template is not present ([#998](https://github.com/opensearch-project/flow-framework/pull/998))
 
 ### Infrastructure
 ### Documentation

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -156,7 +156,17 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
                 boolean filterByBackendRole = requestedUser == null ? false : filterByEnabled;
                 // Update workflow request, check if user has permissions to update the workflow
                 // Get workflow and verify backend roles
-                getWorkflow(requestedUser, workflowId, filterByBackendRole, listener, function, client, clusterService, xContentRegistry);
+                getWorkflow(
+                    requestedUser,
+                    workflowId,
+                    filterByBackendRole,
+                    false,
+                    listener,
+                    function,
+                    client,
+                    clusterService,
+                    xContentRegistry
+                );
             } else {
                 // Create Workflow. No need to get current workflow.
                 function.run();

--- a/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeleteWorkflowTransportAction.java
@@ -83,12 +83,15 @@ public class DeleteWorkflowTransportAction extends HandledTransportAction<Workfl
             String workflowId = request.getWorkflowId();
             User user = getUserContext(client);
 
+            final boolean clearStatus = Booleans.parseBoolean(request.getParams().get(CLEAR_STATUS), false);
+
             ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext();
 
             resolveUserAndExecute(
                 user,
                 workflowId,
                 filterByEnabled,
+                clearStatus,
                 listener,
                 () -> executeDeleteRequest(request, listener, context),
                 client,

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportAction.java
@@ -89,6 +89,7 @@ public class GetWorkflowStateTransportAction extends HandledTransportAction<GetW
                 user,
                 workflowId,
                 filterByEnabled,
+                true,
                 listener,
                 () -> executeGetWorkflowStateRequest(request, listener, context),
                 client,

--- a/src/main/java/org/opensearch/flowframework/transport/GetWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/GetWorkflowTransportAction.java
@@ -98,6 +98,7 @@ public class GetWorkflowTransportAction extends HandledTransportAction<WorkflowR
                     user,
                     workflowId,
                     filterByEnabled,
+                    false,
                     listener,
                     () -> executeGetRequest(request, listener, context),
                     client,

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -132,6 +132,7 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
                 user,
                 workflowId,
                 filterByEnabled,
+                false,
                 listener,
                 () -> executeProvisionRequest(request, listener, context),
                 client,

--- a/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
@@ -139,6 +139,7 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
                 user,
                 workflowId,
                 filterByEnabled,
+                false,
                 listener,
                 () -> executeReprovisionRequest(request, listener, context),
                 client,

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkRestTestCase.java
@@ -337,6 +337,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
             TestHelpers.toHttpEntity(
                 "{\n"
                     + "\"cluster_permissions\": [\n"
+                    + "\"cluster:admin/ingest/pipeline/put\",\n"
                     + "\"cluster:admin/ingest/pipeline/delete\"\n"
                     + "],\n"
                     + "\"index_permissions\": [\n"
@@ -353,6 +354,7 @@ public abstract class FlowFrameworkRestTestCase extends OpenSearchRestTestCase {
                     + "\"crud\",\n"
                     + "\"indices:admin/create\",\n"
                     + "\"indices:admin/aliases\",\n"
+                    + "\"indices:admin/settings/update\",\n"
                     + "\"indices:admin/delete\"\n"
                     + "]\n"
                     + "}\n"


### PR DESCRIPTION
### Description
In the current implementation of Role Based Access Control, the user is fetched only from Template. After invoking delete API, the template gets deleted but that should not stop from fetching the state of the same workflow or deprovisioning it. This PR fixes it with reading the user from workflow state index rather global context.

### Related Issues
Resolves https://github.com/opensearch-project/flow-framework/issues/986

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
