### PR TITLE
Integrate multitenancy into workflow provisioning 

### DIFF
--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -517,11 +517,7 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
 
     private void validateWorkflows(Template template) throws Exception {
         for (Workflow workflow : template.workflows().values()) {
-            List<ProcessNode> sortedNodes = workflowProcessSorter.sortProcessNodes(
-                    workflow,
-                    null,
-                    Collections.emptyMap(),
-                    "fakeTenantId");
+            List<ProcessNode> sortedNodes = workflowProcessSorter.sortProcessNodes(workflow, null, Collections.emptyMap(), "fakeTenantId");
             workflowProcessSorter.validate(sortedNodes, pluginsService);
         }
     }

--- a/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/CreateWorkflowTransportAction.java
@@ -517,7 +517,11 @@ public class CreateWorkflowTransportAction extends HandledTransportAction<Workfl
 
     private void validateWorkflows(Template template) throws Exception {
         for (Workflow workflow : template.workflows().values()) {
-            List<ProcessNode> sortedNodes = workflowProcessSorter.sortProcessNodes(workflow, null, Collections.emptyMap());
+            List<ProcessNode> sortedNodes = workflowProcessSorter.sortProcessNodes(
+                    workflow,
+                    null,
+                    Collections.emptyMap(),
+                    "fakeTenantId");
             workflowProcessSorter.validate(sortedNodes, pluginsService);
         }
     }

--- a/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
@@ -211,7 +211,8 @@ public class DeprovisionWorkflowTransportAction extends HandledTransportAction<W
                     Collections.emptyList(),
                     this.threadPool,
                     DEPROVISION_WORKFLOW_THREAD_POOL,
-                    flowFrameworkSettings.getRequestTimeout()
+                    flowFrameworkSettings.getRequestTimeout(),
+                    "fakeTenantId"
                 )
             );
         }
@@ -274,7 +275,8 @@ public class DeprovisionWorkflowTransportAction extends HandledTransportAction<W
                         pn.predecessors(),
                         this.threadPool,
                         DEPROVISION_WORKFLOW_THREAD_POOL,
-                        pn.nodeTimeout()
+                        pn.nodeTimeout(),
+                        "fakeTenantId"
                     );
                 }).collect(Collectors.toList());
                 // Pause briefly before next loop

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -198,7 +198,8 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
             List<ProcessNode> provisionProcessSequence = workflowProcessSorter.sortProcessNodes(
                 provisionWorkflow,
                 workflowId,
-                request.getParams()
+                request.getParams(),
+                "fakeTenantId"
             );
             workflowProcessSorter.validate(provisionProcessSequence, pluginsService);
 

--- a/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
@@ -198,7 +198,8 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
             List<ProcessNode> updatedProcessSequence = workflowProcessSorter.sortProcessNodes(
                 provisionWorkflow,
                 request.getWorkflowId(),
-                Collections.emptyMap() // TODO : Add suport to reprovision substitution templates
+                Collections.emptyMap(), // TODO : Add suport to reprovision substitution templates
+                "fakeTenantId"
             );
 
             try {

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractCreatePipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractCreatePipelineStep.java
@@ -63,7 +63,8 @@ public abstract class AbstractCreatePipelineStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
 
         PlainActionFuture<WorkflowData> createPipelineFuture = PlainActionFuture.newFuture();

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
@@ -89,7 +89,8 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
 
         PlainActionFuture<WorkflowData> registerLocalModelFuture = PlainActionFuture.newFuture();

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractUpdatePipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractUpdatePipelineStep.java
@@ -70,7 +70,8 @@ public abstract class AbstractUpdatePipelineStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> createPipelineFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -76,7 +76,8 @@ public class CreateConnectorStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> createConnectorFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateIndexStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateIndexStep.java
@@ -67,7 +67,8 @@ public class CreateIndexStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> createIndexFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteAgentStep.java
@@ -55,7 +55,8 @@ public class DeleteAgentStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> deleteAgentFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteConnectorStep.java
@@ -53,7 +53,8 @@ public class DeleteConnectorStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> deleteConnectorFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteIndexStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteIndexStep.java
@@ -58,7 +58,8 @@ public class DeleteIndexStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> deleteIndexFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteIngestPipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteIngestPipelineStep.java
@@ -58,7 +58,8 @@ public class DeleteIngestPipelineStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> deletePipelineFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteModelStep.java
@@ -55,7 +55,8 @@ public class DeleteModelStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> deleteModelFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeleteSearchPipelineStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeleteSearchPipelineStep.java
@@ -58,7 +58,8 @@ public class DeleteSearchPipelineStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> deleteSearchPipelineFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/DeployModelStep.java
@@ -65,7 +65,8 @@ public class DeployModelStep extends AbstractRetryableWorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
 
         PlainActionFuture<WorkflowData> deployModelFuture = PlainActionFuture.newFuture();

--- a/src/main/java/org/opensearch/flowframework/workflow/NoOpStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/NoOpStep.java
@@ -38,7 +38,8 @@ public class NoOpStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
@@ -152,7 +152,9 @@ public class ProcessNode {
      * Returns the tenantId value for this node in the workflow.
      * @return The node's tenantId value
      */
-    public String tenantId() { return tenantId; }
+    public String tenantId() {
+        return tenantId;
+    }
 
     /**
      * Execute this node in the sequence.

--- a/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
@@ -36,6 +36,7 @@ public class ProcessNode {
     private final ThreadPool threadPool;
     private final String threadPoolName;
     private final TimeValue nodeTimeout;
+    private final String tenantId;
 
     private final PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
 
@@ -51,6 +52,7 @@ public class ProcessNode {
      * @param threadPool The OpenSearch thread pool
      * @param threadPoolName The thread pool to use
      * @param nodeTimeout The timeout value for executing on this node
+     * @param tenantId The tenantId
      */
     public ProcessNode(
         String id,
@@ -61,7 +63,8 @@ public class ProcessNode {
         List<ProcessNode> predecessors,
         ThreadPool threadPool,
         String threadPoolName,
-        TimeValue nodeTimeout
+        TimeValue nodeTimeout,
+        String tenantId
     ) {
         this.id = id;
         this.workflowStep = workflowStep;
@@ -72,6 +75,7 @@ public class ProcessNode {
         this.threadPool = threadPool;
         this.threadPoolName = threadPoolName;
         this.nodeTimeout = nodeTimeout;
+        this.tenantId = tenantId;
     }
 
     /**
@@ -145,6 +149,12 @@ public class ProcessNode {
     }
 
     /**
+     * Returns the tenantId value for this node in the workflow.
+     * @return The node's tenantId value
+     */
+    public String tenantId() { return tenantId; }
+
+    /**
      * Execute this node in the sequence.
      * Initializes the node's {@link CompletableFuture} and completes it when the process completes.
      *
@@ -172,7 +182,8 @@ public class ProcessNode {
                     this.input,
                     inputMap,
                     this.previousNodeInputs,
-                    this.params
+                    this.params,
+                    this.tenantId
                 );
                 // If completed exceptionally, this is a no-op
                 future.onResponse(stepFuture.actionGet(this.nodeTimeout));

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -84,7 +84,8 @@ public class RegisterAgentStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
 
         String workflowId = currentNodeInputs.getWorkflowId();

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterModelGroupStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterModelGroupStep.java
@@ -70,7 +70,8 @@ public class RegisterModelGroupStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> registerModelGroupFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -74,7 +74,8 @@ public class RegisterRemoteModelStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
 
         PlainActionFuture<WorkflowData> registerRemoteModelFuture = PlainActionFuture.newFuture();

--- a/src/main/java/org/opensearch/flowframework/workflow/ReindexStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ReindexStep.java
@@ -68,7 +68,8 @@ public class ReindexStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
 
         PlainActionFuture<WorkflowData> reIndexFuture = PlainActionFuture.newFuture();

--- a/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
@@ -63,7 +63,8 @@ public class ToolStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         try {
             Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(

--- a/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/UndeployModelStep.java
@@ -58,7 +58,8 @@ public class UndeployModelStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> undeployModelFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/UpdateIndexStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/UpdateIndexStep.java
@@ -64,7 +64,8 @@ public class UpdateIndexStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> updateIndexFuture = PlainActionFuture.newFuture();
 

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowDataStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowDataStep.java
@@ -40,7 +40,8 @@ public class WorkflowDataStep implements WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     ) {
         PlainActionFuture<WorkflowData> workflowDataFuture = PlainActionFuture.newFuture();
         workflowDataFuture.onResponse(

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -90,9 +90,10 @@ public class WorkflowProcessSorter {
      * @param workflow A workflow with (unsorted) nodes and edges which define predecessors and successors
      * @param workflowId The workflowId associated with the step
      * @param params Parameters passed on the REST path
+     * @param tenantId The tenantId associated with the step
      * @return A list of Process Nodes sorted topologically.  All predecessors of any node will occur prior to it in the list.
      */
-    public List<ProcessNode> sortProcessNodes(Workflow workflow, String workflowId, Map<String, String> params) {
+    public List<ProcessNode> sortProcessNodes(Workflow workflow, String workflowId, Map<String, String> params, String tenantId) {
         if (workflow.nodes().size() > this.maxWorkflowSteps) {
             throw new FlowFrameworkException(
                 "Workflow "
@@ -141,7 +142,7 @@ public class WorkflowProcessSorter {
                 threadPool,
                 PROVISION_WORKFLOW_THREAD_POOL,
                 nodeTimeout,
-                "fakeTenantId"
+                tenantId
             );
             idToNodeMap.put(processNode.id(), processNode);
             nodes.add(processNode);

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -140,7 +140,8 @@ public class WorkflowProcessSorter {
                 predecessorNodes,
                 threadPool,
                 PROVISION_WORKFLOW_THREAD_POOL,
-                nodeTimeout
+                nodeTimeout,
+                "fakeTenantId"
             );
             idToNodeMap.put(processNode.id(), processNode);
             nodes.add(processNode);
@@ -319,7 +320,8 @@ public class WorkflowProcessSorter {
             predecessorNodes,
             threadPool,
             PROVISION_WORKFLOW_THREAD_POOL,
-            nodeTimeout
+            nodeTimeout,
+            "fakeTenantId"
         );
     }
 
@@ -350,7 +352,8 @@ public class WorkflowProcessSorter {
                 predecessorNodes,
                 threadPool,
                 PROVISION_WORKFLOW_THREAD_POOL,
-                nodeTimeout
+                nodeTimeout,
+                "fakeTenantId"
             );
         } else {
             // Case 3 : Cannot update step (not supported)
@@ -392,7 +395,8 @@ public class WorkflowProcessSorter {
                 predecessorNodes,
                 threadPool,
                 PROVISION_WORKFLOW_THREAD_POOL,
-                nodeTimeout
+                nodeTimeout,
+                "fakeTenantId"
             );
         } else {
             return null;

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
@@ -24,6 +24,7 @@ public interface WorkflowStep {
      * @param outputs WorkflowData content of previous steps.
      * @param previousNodeInputs Input params for this node that come from previous steps
      * @param params Params passed on the REST path
+     * @param tenantId The tenantId
      * @return A CompletableFuture of the building block. This block should return immediately, but not be completed until the step executes, containing either the step's output data or {@link WorkflowData#EMPTY} which may be passed to follow-on steps.
      */
     PlainActionFuture<WorkflowData> execute(
@@ -31,7 +32,8 @@ public interface WorkflowStep {
         WorkflowData currentNodeInputs,
         Map<String, WorkflowData> outputs,
         Map<String, String> previousNodeInputs,
-        Map<String, String> params
+        Map<String, String> params,
+        String tenantId
     );
 
     /**

--- a/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
@@ -165,7 +165,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onResponse(WorkflowData.EMPTY);
-        when(this.deleteConnectorStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap())).thenReturn(future);
+        when(this.deleteConnectorStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), anyString())).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<WorkflowResponse> latchedActionListener = new LatchedActionListener<>(listener, latch);
@@ -197,7 +197,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onFailure(new RuntimeException("rte"));
-        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap())).thenReturn(future);
+        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), anyString())).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<WorkflowResponse> latchedActionListener = new LatchedActionListener<>(listener, latch);
@@ -274,7 +274,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onResponse(WorkflowData.EMPTY);
-        when(this.deleteIndexStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap())).thenReturn(future);
+        when(this.deleteIndexStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), anyString())).thenReturn(future);
 
         latch = new CountDownLatch(1);
         latchedActionListener = new LatchedActionListener<>(listener, latch);
@@ -312,7 +312,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onFailure(new RuntimeException("rte"));
-        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap())).thenReturn(future);
+        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), anyString())).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<WorkflowResponse> latchedActionListener = new LatchedActionListener<>(listener, latch);

--- a/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
@@ -50,6 +50,7 @@ import java.util.function.Consumer;
 
 import org.mockito.ArgumentCaptor;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.opensearch.flowframework.common.CommonValue.ALLOW_DELETE;
 import static org.opensearch.flowframework.common.CommonValue.DEPROVISION_WORKFLOW_THREAD_POOL;
 import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
@@ -165,7 +166,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onResponse(WorkflowData.EMPTY);
-        when(this.deleteConnectorStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), anyString())).thenReturn(future);
+        when(this.deleteConnectorStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class))).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<WorkflowResponse> latchedActionListener = new LatchedActionListener<>(listener, latch);
@@ -197,7 +198,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onFailure(new RuntimeException("rte"));
-        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), anyString())).thenReturn(future);
+        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class))).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<WorkflowResponse> latchedActionListener = new LatchedActionListener<>(listener, latch);
@@ -274,7 +275,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onResponse(WorkflowData.EMPTY);
-        when(this.deleteIndexStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), anyString())).thenReturn(future);
+        when(this.deleteIndexStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class))).thenReturn(future);
 
         latch = new CountDownLatch(1);
         latchedActionListener = new LatchedActionListener<>(listener, latch);
@@ -312,7 +313,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onFailure(new RuntimeException("rte"));
-        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), anyString())).thenReturn(future);
+        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class))).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<WorkflowResponse> latchedActionListener = new LatchedActionListener<>(listener, latch);

--- a/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
@@ -50,7 +50,6 @@ import java.util.function.Consumer;
 
 import org.mockito.ArgumentCaptor;
 
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.opensearch.flowframework.common.CommonValue.ALLOW_DELETE;
 import static org.opensearch.flowframework.common.CommonValue.DEPROVISION_WORKFLOW_THREAD_POOL;
 import static org.opensearch.flowframework.common.CommonValue.FLOW_FRAMEWORK_THREAD_POOL_PREFIX;
@@ -61,6 +60,7 @@ import static org.opensearch.flowframework.common.WorkflowResources.PIPELINE_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -166,7 +166,8 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onResponse(WorkflowData.EMPTY);
-        when(this.deleteConnectorStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class))).thenReturn(future);
+        when(this.deleteConnectorStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class)))
+            .thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<WorkflowResponse> latchedActionListener = new LatchedActionListener<>(listener, latch);
@@ -198,7 +199,8 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onFailure(new RuntimeException("rte"));
-        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class))).thenReturn(future);
+        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class)))
+            .thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<WorkflowResponse> latchedActionListener = new LatchedActionListener<>(listener, latch);
@@ -275,7 +277,8 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onResponse(WorkflowData.EMPTY);
-        when(this.deleteIndexStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class))).thenReturn(future);
+        when(this.deleteIndexStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class)))
+            .thenReturn(future);
 
         latch = new CountDownLatch(1);
         latchedActionListener = new LatchedActionListener<>(listener, latch);
@@ -313,7 +316,8 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
         future.onFailure(new RuntimeException("rte"));
-        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class))).thenReturn(future);
+        when(this.undeployModelStep.execute(anyString(), any(WorkflowData.class), anyMap(), anyMap(), anyMap(), nullable(String.class)))
+            .thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<WorkflowResponse> latchedActionListener = new LatchedActionListener<>(listener, latch);

--- a/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportActionTests.java
@@ -123,7 +123,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         // Stub validations
         when(mockTemplate.workflows()).thenReturn(mockWorkflows);
-        when(workflowProcessSorter.sortProcessNodes(any(), any(), any())).thenReturn(List.of());
+        when(workflowProcessSorter.sortProcessNodes(any(), any(), any(), any())).thenReturn(List.of());
         doNothing().when(workflowProcessSorter).validate(any(), any());
         when(encryptorUtils.decryptTemplateCredentials(any())).thenReturn(mockTemplate);
 
@@ -171,7 +171,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         // Stub validations
         when(mockTemplate.workflows()).thenReturn(mockWorkflows);
-        when(workflowProcessSorter.sortProcessNodes(any(), any(), any())).thenReturn(List.of());
+        when(workflowProcessSorter.sortProcessNodes(any(), any(), any(), any())).thenReturn(List.of());
         doNothing().when(workflowProcessSorter).validate(any(), any());
         when(encryptorUtils.decryptTemplateCredentials(any())).thenReturn(mockTemplate);
 
@@ -211,7 +211,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         // Stub validations
         when(mockTemplate.workflows()).thenReturn(mockWorkflows);
-        when(workflowProcessSorter.sortProcessNodes(any(), any(), any())).thenReturn(List.of());
+        when(workflowProcessSorter.sortProcessNodes(any(), any(), any(), any())).thenReturn(List.of());
         doNothing().when(workflowProcessSorter).validate(any(), any());
         when(encryptorUtils.decryptTemplateCredentials(any())).thenReturn(mockTemplate);
 
@@ -251,7 +251,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         // Stub validations
         when(mockTemplate.workflows()).thenReturn(mockWorkflows);
-        when(workflowProcessSorter.sortProcessNodes(any(), any(), any())).thenReturn(List.of());
+        when(workflowProcessSorter.sortProcessNodes(any(), any(), any(), any())).thenReturn(List.of());
         doNothing().when(workflowProcessSorter).validate(any(), any());
         when(encryptorUtils.decryptTemplateCredentials(any())).thenReturn(mockTemplate);
 
@@ -299,7 +299,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         // Stub validations
         when(mockTemplate.workflows()).thenReturn(mockWorkflows);
-        when(workflowProcessSorter.sortProcessNodes(any(), any(), any())).thenReturn(List.of());
+        when(workflowProcessSorter.sortProcessNodes(any(), any(), any(), any())).thenReturn(List.of());
         doNothing().when(workflowProcessSorter).validate(any(), any());
         when(encryptorUtils.decryptTemplateCredentials(any())).thenReturn(mockTemplate);
 

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
@@ -105,7 +105,7 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());
@@ -129,7 +129,7 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
@@ -104,7 +104,8 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());
@@ -127,7 +128,8 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
@@ -105,7 +105,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertFalse(future.isDone());
         verify(indicesAdminClient, times(1)).create(any(CreateIndexRequest.class), actionListenerCaptor.capture());
@@ -127,7 +127,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertFalse(future.isDone());
         verify(indicesAdminClient, times(1)).create(any(CreateIndexRequest.class), actionListenerCaptor.capture());
@@ -149,7 +149,7 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertFalse(future.isDone());
         verify(indicesAdminClient, times(1)).create(any(CreateIndexRequest.class), actionListenerCaptor.capture());

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIndexStepTests.java
@@ -104,7 +104,8 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertFalse(future.isDone());
         verify(indicesAdminClient, times(1)).create(any(CreateIndexRequest.class), actionListenerCaptor.capture());
@@ -125,7 +126,8 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertFalse(future.isDone());
         verify(indicesAdminClient, times(1)).create(any(CreateIndexRequest.class), actionListenerCaptor.capture());
@@ -146,7 +148,8 @@ public class CreateIndexStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertFalse(future.isDone());
         verify(indicesAdminClient, times(1)).create(any(CreateIndexRequest.class), actionListenerCaptor.capture());

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
@@ -86,7 +86,8 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertFalse(future.isDone());
@@ -110,7 +111,8 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertFalse(future.isDone());
@@ -146,7 +148,8 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
             incorrectData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateIngestPipelineStepTests.java
@@ -87,7 +87,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertFalse(future.isDone());
@@ -112,7 +112,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertFalse(future.isDone());
@@ -149,7 +149,7 @@ public class CreateIngestPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateSearchPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateSearchPipelineStepTests.java
@@ -86,7 +86,8 @@ public class CreateSearchPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertFalse(future.isDone());
@@ -110,7 +111,8 @@ public class CreateSearchPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertFalse(future.isDone());
@@ -146,7 +148,8 @@ public class CreateSearchPipelineStepTests extends OpenSearchTestCase {
             incorrectData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateSearchPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateSearchPipelineStepTests.java
@@ -87,7 +87,7 @@ public class CreateSearchPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertFalse(future.isDone());
@@ -112,7 +112,7 @@ public class CreateSearchPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertFalse(future.isDone());
@@ -149,7 +149,7 @@ public class CreateSearchPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteAgentStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteAgentStepTests.java
@@ -67,7 +67,7 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(AGENT_ID, agentId), "workflowId", "nodeId")),
             Map.of("step_1", AGENT_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         verify(machineLearningNodeClient).deleteAgent(any(String.class), any());
 
@@ -92,7 +92,7 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(AGENT_ID, agentId), "workflowId", "nodeId")),
             Map.of("step_1", AGENT_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         verify(machineLearningNodeClient).deleteAgent(any(String.class), any());
 
@@ -109,7 +109,7 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -133,7 +133,7 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(AGENT_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", AGENT_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).deleteAgent(any(String.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteAgentStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteAgentStepTests.java
@@ -66,7 +66,8 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(AGENT_ID, agentId), "workflowId", "nodeId")),
             Map.of("step_1", AGENT_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         verify(machineLearningNodeClient).deleteAgent(any(String.class), any());
 
@@ -90,7 +91,8 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(AGENT_ID, agentId), "workflowId", "nodeId")),
             Map.of("step_1", AGENT_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         verify(machineLearningNodeClient).deleteAgent(any(String.class), any());
 
@@ -106,7 +108,8 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -129,7 +132,8 @@ public class DeleteAgentStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(AGENT_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", AGENT_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).deleteAgent(any(String.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
@@ -66,7 +66,8 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(CONNECTOR_ID, connectorId), "workflowId", "nodeId")),
             Map.of("step_1", CONNECTOR_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         verify(machineLearningNodeClient).deleteConnector(anyString(), anyActionListener());
 
@@ -82,7 +83,8 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -105,7 +107,8 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(CONNECTOR_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", CONNECTOR_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).deleteConnector(anyString(), anyActionListener());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteConnectorStepTests.java
@@ -67,7 +67,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(CONNECTOR_ID, connectorId), "workflowId", "nodeId")),
             Map.of("step_1", CONNECTOR_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         verify(machineLearningNodeClient).deleteConnector(anyString(), anyActionListener());
 
@@ -84,7 +84,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -108,7 +108,7 @@ public class DeleteConnectorStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(CONNECTOR_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", CONNECTOR_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).deleteConnector(anyString(), anyActionListener());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteIndexStepTests.java
@@ -72,7 +72,8 @@ public class DeleteIndexStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(INDEX_NAME, indexName), "workflowId", "nodeId")),
             Map.of("step_1", INDEX_NAME),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         verify(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());
 
@@ -88,7 +89,8 @@ public class DeleteIndexStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -111,7 +113,8 @@ public class DeleteIndexStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(INDEX_NAME, "test"), "workflowId", "nodeId")),
             Map.of("step_1", INDEX_NAME),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteIndexStepTests.java
@@ -73,7 +73,7 @@ public class DeleteIndexStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(INDEX_NAME, indexName), "workflowId", "nodeId")),
             Map.of("step_1", INDEX_NAME),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         verify(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());
 
@@ -90,7 +90,7 @@ public class DeleteIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -114,7 +114,7 @@ public class DeleteIndexStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(INDEX_NAME, "test"), "workflowId", "nodeId")),
             Map.of("step_1", INDEX_NAME),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteIngestPipelineStepTests.java
@@ -72,7 +72,8 @@ public class DeleteIngestPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, pipelineId), "workflowId", "nodeId")),
             Map.of("step_1", PIPELINE_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         verify(clusterAdminClient).deletePipeline(any(DeletePipelineRequest.class), any());
 
@@ -88,7 +89,8 @@ public class DeleteIngestPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -111,7 +113,8 @@ public class DeleteIngestPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", PIPELINE_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(clusterAdminClient).deletePipeline(any(DeletePipelineRequest.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteIngestPipelineStepTests.java
@@ -73,7 +73,7 @@ public class DeleteIngestPipelineStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, pipelineId), "workflowId", "nodeId")),
             Map.of("step_1", PIPELINE_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         verify(clusterAdminClient).deletePipeline(any(DeletePipelineRequest.class), any());
 
@@ -90,7 +90,7 @@ public class DeleteIngestPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -114,7 +114,7 @@ public class DeleteIngestPipelineStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", PIPELINE_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(clusterAdminClient).deletePipeline(any(DeletePipelineRequest.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
@@ -66,7 +66,8 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, modelId), "workflowId", "nodeId")),
             Map.of("step_1", MODEL_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         verify(machineLearningNodeClient).deleteModel(any(String.class), any());
 
@@ -90,7 +91,8 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, modelId), "workflowId", "nodeId")),
             Map.of("step_1", MODEL_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         verify(machineLearningNodeClient).deleteModel(any(String.class), any());
 
@@ -106,7 +108,8 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -129,7 +132,8 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", MODEL_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).deleteModel(any(String.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteModelStepTests.java
@@ -67,7 +67,7 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, modelId), "workflowId", "nodeId")),
             Map.of("step_1", MODEL_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         verify(machineLearningNodeClient).deleteModel(any(String.class), any());
 
@@ -92,7 +92,7 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, modelId), "workflowId", "nodeId")),
             Map.of("step_1", MODEL_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         verify(machineLearningNodeClient).deleteModel(any(String.class), any());
 
@@ -109,7 +109,7 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -133,7 +133,7 @@ public class DeleteModelStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", MODEL_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).deleteModel(any(String.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteSearchPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteSearchPipelineStepTests.java
@@ -72,7 +72,8 @@ public class DeleteSearchPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, pipelineId), "workflowId", "nodeId")),
             Map.of("step_1", PIPELINE_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         verify(clusterAdminClient).deleteSearchPipeline(any(DeleteSearchPipelineRequest.class), any());
 
@@ -88,7 +89,8 @@ public class DeleteSearchPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -111,7 +113,8 @@ public class DeleteSearchPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", PIPELINE_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(clusterAdminClient).deleteSearchPipeline(any(DeleteSearchPipelineRequest.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeleteSearchPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeleteSearchPipelineStepTests.java
@@ -73,7 +73,7 @@ public class DeleteSearchPipelineStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, pipelineId), "workflowId", "nodeId")),
             Map.of("step_1", PIPELINE_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         verify(clusterAdminClient).deleteSearchPipeline(any(DeleteSearchPipelineRequest.class), any());
 
@@ -90,7 +90,7 @@ public class DeleteSearchPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -114,7 +114,7 @@ public class DeleteSearchPipelineStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(PIPELINE_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", PIPELINE_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(clusterAdminClient).deleteSearchPipeline(any(DeleteSearchPipelineRequest.class), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
@@ -144,7 +144,7 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         future.actionGet();
@@ -172,7 +172,7 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).deploy(eq("modelId"), actionListenerCaptor.capture());
@@ -213,7 +213,7 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());

--- a/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/DeployModelStepTests.java
@@ -143,7 +143,8 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         future.actionGet();
@@ -170,7 +171,8 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).deploy(eq("modelId"), actionListenerCaptor.capture());
@@ -210,7 +212,8 @@ public class DeployModelStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());

--- a/src/test/java/org/opensearch/flowframework/workflow/NoOpStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/NoOpStepTests.java
@@ -31,7 +31,8 @@ public class NoOpStepTests extends OpenSearchTestCase {
             WorkflowData.EMPTY,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
     }
@@ -46,7 +47,8 @@ public class NoOpStepTests extends OpenSearchTestCase {
             delayData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         // Sleep isn't exactly accurate so leave 100ms of roundoff
@@ -68,7 +70,8 @@ public class NoOpStepTests extends OpenSearchTestCase {
                     delayData,
                     Collections.emptyMap(),
                     Collections.emptyMap(),
-                    Collections.emptyMap()
+                    Collections.emptyMap(),
+                    "fakeTenantId"
                 );
                 try {
                     future.actionGet();
@@ -102,7 +105,7 @@ public class NoOpStepTests extends OpenSearchTestCase {
 
         Exception ex = assertThrows(
             WorkflowStepException.class,
-            () -> noopStep.execute("nodeId", delayData, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap())
+            () -> noopStep.execute("nodeId", delayData, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),"fakeTenantId")
         );
         assertEquals("failed to parse setting [delay] with value [foo] as a time value: unit is missing or unrecognized", ex.getMessage());
     }

--- a/src/test/java/org/opensearch/flowframework/workflow/NoOpStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/NoOpStepTests.java
@@ -32,7 +32,7 @@ public class NoOpStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
     }
@@ -48,7 +48,7 @@ public class NoOpStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         // Sleep isn't exactly accurate so leave 100ms of roundoff
@@ -71,7 +71,7 @@ public class NoOpStepTests extends OpenSearchTestCase {
                     Collections.emptyMap(),
                     Collections.emptyMap(),
                     Collections.emptyMap(),
-                    "fakeTenantId"
+                    null
                 );
                 try {
                     future.actionGet();
@@ -105,7 +105,7 @@ public class NoOpStepTests extends OpenSearchTestCase {
 
         Exception ex = assertThrows(
             WorkflowStepException.class,
-            () -> noopStep.execute("nodeId", delayData, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),"fakeTenantId")
+            () -> noopStep.execute("nodeId", delayData, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),null)
         );
         assertEquals("failed to parse setting [delay] with value [foo] as a time value: unit is missing or unrecognized", ex.getMessage());
     }

--- a/src/test/java/org/opensearch/flowframework/workflow/NoOpStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/NoOpStepTests.java
@@ -105,7 +105,7 @@ public class NoOpStepTests extends OpenSearchTestCase {
 
         Exception ex = assertThrows(
             WorkflowStepException.class,
-            () -> noopStep.execute("nodeId", delayData, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),null)
+            () -> noopStep.execute("nodeId", delayData, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), null)
         );
         assertEquals("failed to parse setting [delay] with value [foo] as a time value: unit is missing or unrecognized", ex.getMessage());
     }

--- a/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
@@ -75,7 +75,8 @@ public class ProcessNodeTests extends OpenSearchTestCase {
                 WorkflowData currentNodeInputs,
                 Map<String, WorkflowData> outputs,
                 Map<String, String> previousNodeInputs,
-                Map<String, String> params
+                Map<String, String> params,
+                String tenantId
             ) {
                 PlainActionFuture<WorkflowData> f = PlainActionFuture.newFuture();
                 f.onResponse(new WorkflowData(Map.of("test", "output"), "test-id", "test-node-id"));
@@ -93,7 +94,8 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             List.of(successfulNode),
             testThreadPool,
             PROVISION_WORKFLOW_THREAD_POOL,
-            TimeValue.timeValueMillis(50)
+            TimeValue.timeValueMillis(50),
+            "fakeTenantId"
         );
         assertEquals("A", nodeA.id());
         assertEquals("test", nodeA.workflowStep().getName());
@@ -121,7 +123,8 @@ public class ProcessNodeTests extends OpenSearchTestCase {
                 WorkflowData currentNodeInputs,
                 Map<String, WorkflowData> outputs,
                 Map<String, String> previousNodeInputs,
-                Map<String, String> params
+                Map<String, String> params,
+                String tenantId
             ) {
                 PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
                 testThreadPool.schedule(
@@ -143,7 +146,8 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             Collections.emptyList(),
             testThreadPool,
             PROVISION_WORKFLOW_THREAD_POOL,
-            TimeValue.timeValueMillis(500)
+            TimeValue.timeValueMillis(500),
+            "fakeTenantId"
         );
         assertEquals("B", nodeB.id());
         assertEquals("test", nodeB.workflowStep().getName());
@@ -165,7 +169,8 @@ public class ProcessNodeTests extends OpenSearchTestCase {
                 WorkflowData currentNodeInputs,
                 Map<String, WorkflowData> outputs,
                 Map<String, String> previousNodeInputs,
-                Map<String, String> params
+                Map<String, String> params,
+                String tenantId
             ) {
                 PlainActionFuture<WorkflowData> future = PlainActionFuture.newFuture();
                 testThreadPool.schedule(
@@ -187,7 +192,8 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             Collections.emptyList(),
             testThreadPool,
             PROVISION_WORKFLOW_THREAD_POOL,
-            TimeValue.timeValueMillis(100)
+            TimeValue.timeValueMillis(100),
+            "fakeTenantId"
         );
         assertEquals("Zzz", nodeZ.id());
         assertEquals("sleepy", nodeZ.workflowStep().getName());
@@ -210,7 +216,8 @@ public class ProcessNodeTests extends OpenSearchTestCase {
                 WorkflowData currentNodeInputs,
                 Map<String, WorkflowData> outputs,
                 Map<String, String> previousNodeInputs,
-                Map<String, String> params
+                Map<String, String> params,
+                String tenantId
             ) {
                 PlainActionFuture<WorkflowData> f = PlainActionFuture.newFuture();
                 f.onResponse(WorkflowData.EMPTY);
@@ -228,7 +235,8 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             List.of(successfulNode, failedNode),
             testThreadPool,
             PROVISION_WORKFLOW_THREAD_POOL,
-            TimeValue.timeValueSeconds(15)
+            TimeValue.timeValueSeconds(15),
+            "fakeTenantId"
         );
         assertEquals("E", nodeE.id());
         assertEquals("test", nodeE.workflowStep().getName());

--- a/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
@@ -95,7 +95,7 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             testThreadPool,
             PROVISION_WORKFLOW_THREAD_POOL,
             TimeValue.timeValueMillis(50),
-            "fakeTenantId"
+            null
         );
         assertEquals("A", nodeA.id());
         assertEquals("test", nodeA.workflowStep().getName());
@@ -147,7 +147,7 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             testThreadPool,
             PROVISION_WORKFLOW_THREAD_POOL,
             TimeValue.timeValueMillis(500),
-            "fakeTenantId"
+            null
         );
         assertEquals("B", nodeB.id());
         assertEquals("test", nodeB.workflowStep().getName());
@@ -193,7 +193,7 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             testThreadPool,
             PROVISION_WORKFLOW_THREAD_POOL,
             TimeValue.timeValueMillis(100),
-            "fakeTenantId"
+            null
         );
         assertEquals("Zzz", nodeZ.id());
         assertEquals("sleepy", nodeZ.workflowStep().getName());
@@ -236,7 +236,7 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             testThreadPool,
             PROVISION_WORKFLOW_THREAD_POOL,
             TimeValue.timeValueSeconds(15),
-            "fakeTenantId"
+            null
         );
         assertEquals("E", nodeE.id());
         assertEquals("test", nodeE.workflowStep().getName());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -118,7 +118,7 @@ public class RegisterAgentTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());
@@ -152,7 +152,7 @@ public class RegisterAgentTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -117,7 +117,8 @@ public class RegisterAgentTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());
@@ -150,7 +151,8 @@ public class RegisterAgentTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -165,7 +165,7 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         future.actionGet();
@@ -201,7 +201,7 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         future.actionGet();
@@ -273,7 +273,7 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -295,7 +295,7 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -337,7 +337,7 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -352,7 +352,7 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
@@ -399,7 +399,7 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -164,7 +164,8 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         future.actionGet();
@@ -199,7 +200,8 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             boolStringWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         future.actionGet();
@@ -270,7 +272,8 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             boolStringWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -291,7 +294,8 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -332,7 +336,8 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -346,7 +351,8 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id"),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
@@ -392,7 +398,8 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
             boolStringWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
@@ -158,7 +158,7 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         future.actionGet();
@@ -188,7 +188,7 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         future.actionGet();
@@ -214,7 +214,7 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -256,7 +256,7 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -271,7 +271,7 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
@@ -303,7 +303,7 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
@@ -157,7 +157,8 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         future.actionGet();
@@ -186,7 +187,8 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             boolStringWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         future.actionGet();
@@ -211,7 +213,8 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -252,7 +255,8 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -266,7 +270,8 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id"),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
@@ -297,7 +302,8 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
             boolStringWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
@@ -161,7 +161,7 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         future.actionGet();
@@ -193,7 +193,7 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         future.actionGet();
@@ -219,7 +219,7 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -261,7 +261,7 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -276,7 +276,7 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
@@ -310,7 +310,7 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStepTests.java
@@ -160,7 +160,8 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         future.actionGet();
@@ -191,7 +192,8 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             boolStringWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         future.actionGet();
@@ -216,7 +218,8 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -257,7 +260,8 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -271,7 +275,8 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id"),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
@@ -304,7 +309,8 @@ public class RegisterLocalSparseEncodingModelStepTests extends OpenSearchTestCas
             boolStringWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterModelGroupStepTests.java
@@ -121,7 +121,8 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
@@ -135,7 +136,8 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
             boolStringInputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -160,7 +162,8 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
@@ -180,7 +183,8 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
             inputDataWithNoName,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -197,7 +201,8 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
             badBoolInputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterModelGroupStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterModelGroupStepTests.java
@@ -122,7 +122,7 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
@@ -137,7 +137,7 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -163,7 +163,7 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).registerModelGroup(any(MLRegisterModelGroupInput.class), actionListenerCaptor.capture());
@@ -184,7 +184,7 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -202,7 +202,7 @@ public class RegisterModelGroupStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -105,7 +105,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(mlNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
@@ -158,7 +159,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             deployWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(mlNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
@@ -190,7 +192,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             deployWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(mlNodeClient, times(2)).register(any(MLRegisterModelInput.class), any());
@@ -220,7 +223,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -263,7 +267,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             deployWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -313,7 +318,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             deployWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -346,7 +352,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             incorrectWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -366,7 +373,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             workflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -381,7 +389,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             new WorkflowData(Collections.emptyMap(), "test-id", "test-node-id"),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
@@ -410,7 +419,8 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             deployWorkflowData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -106,7 +106,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(mlNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
@@ -160,7 +160,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(mlNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
@@ -193,7 +193,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(mlNodeClient, times(2)).register(any(MLRegisterModelInput.class), any());
@@ -224,7 +224,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -268,7 +268,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -319,7 +319,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -353,7 +353,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -374,7 +374,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         ExecutionException ex = expectThrows(ExecutionException.class, () -> future.get().getClass());
@@ -390,7 +390,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
@@ -420,7 +420,7 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/ReindexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ReindexStepTests.java
@@ -96,7 +96,7 @@ public class ReindexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(client, times(1)).execute(any(), any(ReindexRequest.class), actionListenerCaptor.capture());
@@ -126,7 +126,7 @@ public class ReindexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertFalse(future.isDone());
         verify(client, times(1)).execute(any(), any(ReindexRequest.class), actionListenerCaptor.capture());

--- a/src/test/java/org/opensearch/flowframework/workflow/ReindexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ReindexStepTests.java
@@ -95,7 +95,8 @@ public class ReindexStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(client, times(1)).execute(any(), any(ReindexRequest.class), actionListenerCaptor.capture());
@@ -124,7 +125,8 @@ public class ReindexStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertFalse(future.isDone());
         verify(client, times(1)).execute(any(), any(ReindexRequest.class), actionListenerCaptor.capture());

--- a/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
@@ -88,7 +88,8 @@ public class ToolStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
@@ -99,7 +100,8 @@ public class ToolStepTests extends OpenSearchTestCase {
             boolStringInputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
@@ -114,7 +116,8 @@ public class ToolStepTests extends OpenSearchTestCase {
             badBoolInputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -133,7 +136,8 @@ public class ToolStepTests extends OpenSearchTestCase {
             inputData,
             Map.of(createConnectorNodeId, inputDataWithConnectorId),
             Map.of(createConnectorNodeId, CONNECTOR_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         Object tools = future.get().getContent().get("tools");
@@ -150,7 +154,8 @@ public class ToolStepTests extends OpenSearchTestCase {
             inputData,
             Map.of(createModelNodeId, inputDataWithModelId),
             Map.of(createModelNodeId, MODEL_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         Object tools = future.get().getContent().get("tools");
@@ -167,7 +172,8 @@ public class ToolStepTests extends OpenSearchTestCase {
             inputData,
             Map.of(createAgentNodeId, inputDataWithAgentId),
             Map.of(createAgentNodeId, AGENT_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
         Object tools = future.get().getContent().get("tools");

--- a/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
@@ -89,7 +89,7 @@ public class ToolStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
@@ -101,7 +101,7 @@ public class ToolStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         assertEquals(MLToolSpec.class, future.get().getContent().get("tools").getClass());
@@ -117,7 +117,7 @@ public class ToolStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -137,7 +137,7 @@ public class ToolStepTests extends OpenSearchTestCase {
             Map.of(createConnectorNodeId, inputDataWithConnectorId),
             Map.of(createConnectorNodeId, CONNECTOR_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         Object tools = future.get().getContent().get("tools");
@@ -155,7 +155,7 @@ public class ToolStepTests extends OpenSearchTestCase {
             Map.of(createModelNodeId, inputDataWithModelId),
             Map.of(createModelNodeId, MODEL_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         Object tools = future.get().getContent().get("tools");
@@ -173,7 +173,7 @@ public class ToolStepTests extends OpenSearchTestCase {
             Map.of(createAgentNodeId, inputDataWithAgentId),
             Map.of(createAgentNodeId, AGENT_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
         Object tools = future.get().getContent().get("tools");

--- a/src/test/java/org/opensearch/flowframework/workflow/UndeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UndeployModelStepTests.java
@@ -73,7 +73,8 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, modelId), "workflowId", "nodeId")),
             Map.of("step_1", MODEL_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         verify(machineLearningNodeClient).undeploy(any(String[].class), any(), any());
 
@@ -89,7 +90,8 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -121,7 +123,8 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
             inputData,
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", MODEL_ID),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(machineLearningNodeClient).undeploy(any(String[].class), any(), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/UndeployModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UndeployModelStepTests.java
@@ -74,7 +74,7 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, modelId), "workflowId", "nodeId")),
             Map.of("step_1", MODEL_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         verify(machineLearningNodeClient).undeploy(any(String[].class), any(), any());
 
@@ -91,7 +91,7 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -124,7 +124,7 @@ public class UndeployModelStepTests extends OpenSearchTestCase {
             Map.of("step_1", new WorkflowData(Map.of(MODEL_ID, "test"), "workflowId", "nodeId")),
             Map.of("step_1", MODEL_ID),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(machineLearningNodeClient).undeploy(any(String[].class), any(), any());

--- a/src/test/java/org/opensearch/flowframework/workflow/UpdateIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UpdateIndexStepTests.java
@@ -102,7 +102,8 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             data,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(indicesAdminClient, times(1)).getSettings(any(GetSettingsRequest.class), any());
@@ -162,7 +163,8 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             data,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -188,7 +190,8 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             incorrectData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -238,7 +241,8 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             data,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         verify(indicesAdminClient, times(1)).getSettings(any(GetSettingsRequest.class), any());
@@ -265,7 +269,8 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             incorrectData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -289,7 +294,8 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             incorrectData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());
@@ -341,7 +347,8 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             data,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get());

--- a/src/test/java/org/opensearch/flowframework/workflow/UpdateIndexStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UpdateIndexStepTests.java
@@ -103,7 +103,7 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(indicesAdminClient, times(1)).getSettings(any(GetSettingsRequest.class), any());
@@ -164,7 +164,7 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -191,7 +191,7 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -242,7 +242,7 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         verify(indicesAdminClient, times(1)).getSettings(any(GetSettingsRequest.class), any());
@@ -270,7 +270,7 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -295,7 +295,7 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());
@@ -348,7 +348,7 @@ public class UpdateIndexStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get());

--- a/src/test/java/org/opensearch/flowframework/workflow/UpdateIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UpdateIngestPipelineStepTests.java
@@ -76,7 +76,7 @@ public class UpdateIngestPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertFalse(future.isDone());
@@ -101,7 +101,7 @@ public class UpdateIngestPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertFalse(future.isDone());
@@ -138,7 +138,7 @@ public class UpdateIngestPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/UpdateIngestPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UpdateIngestPipelineStepTests.java
@@ -75,7 +75,8 @@ public class UpdateIngestPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertFalse(future.isDone());
@@ -99,7 +100,8 @@ public class UpdateIngestPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertFalse(future.isDone());
@@ -135,7 +137,8 @@ public class UpdateIngestPipelineStepTests extends OpenSearchTestCase {
             incorrectData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/UpdateSearchPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UpdateSearchPipelineStepTests.java
@@ -75,7 +75,8 @@ public class UpdateSearchPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertFalse(future.isDone());
@@ -100,7 +101,8 @@ public class UpdateSearchPipelineStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertFalse(future.isDone());
@@ -135,7 +137,8 @@ public class UpdateSearchPipelineStepTests extends OpenSearchTestCase {
             incorrectData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
         assertTrue(future.isDone());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/UpdateSearchPipelineStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/UpdateSearchPipelineStepTests.java
@@ -76,7 +76,7 @@ public class UpdateSearchPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertFalse(future.isDone());
@@ -102,7 +102,7 @@ public class UpdateSearchPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertFalse(future.isDone());
@@ -138,7 +138,7 @@ public class UpdateSearchPipelineStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
         assertTrue(future.isDone());
 

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowDataStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowDataStepTests.java
@@ -48,7 +48,7 @@ public class WorkflowDataStepTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
-            "fakeTenantId"
+            null
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowDataStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowDataStepTests.java
@@ -47,7 +47,8 @@ public class WorkflowDataStepTests extends OpenSearchTestCase {
             inputData,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            "fakeTenantId"
         );
 
         assertTrue(future.isDone());

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -81,7 +81,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
 
     // Wrap parser into node list
     private static List<ProcessNode> parseToNodes(String json) throws IOException {
-        return workflowProcessSorter.sortProcessNodes(parseToWorkflow(json), "123", Collections.emptyMap(), "fakeTenantId");
+        return workflowProcessSorter.sortProcessNodes(parseToWorkflow(json), "123", Collections.emptyMap(), null);
     }
 
     // Wrap parser into string list
@@ -437,7 +437,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             List.of(edge1, edge2)
         );
 
-        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), "fakeTenantId");
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), null);
         workflowProcessSorter.validateGraph(sortedProcessNodes);
     }
 
@@ -459,7 +459,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         WorkflowEdge edge = new WorkflowEdge(registerModel.id(), deployModel.id());
         Workflow workflow = new Workflow(Collections.emptyMap(), List.of(registerModel, deployModel), List.of(edge));
 
-        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), "fakeTenantId");
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), null);
         FlowFrameworkException ex = expectThrows(
             FlowFrameworkException.class,
             () -> workflowProcessSorter.validateGraph(sortedProcessNodes)
@@ -481,7 +481,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
 
         FlowFrameworkException ex = expectThrows(
             FlowFrameworkException.class,
-            () -> workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), "fakeTenantId")
+            () -> workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), null)
         );
         assertEquals("The step type [delete_index] for node [workflow_step_1] can not be used in a workflow.", ex.getMessage());
         assertEquals(RestStatus.FORBIDDEN, ex.getRestStatus());
@@ -524,7 +524,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             List.of(createConnector, registerModel, deployModel),
             List.of(edge1, edge2)
         );
-        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), "fakeTenantId");
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), null);
 
         workflowProcessSorter.validatePluginsInstalled(sortedProcessNodes, List.of("opensearch-flow-framework", "opensearch-ml"));
     }
@@ -566,7 +566,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             List.of(createConnector, registerModel, deployModel),
             List.of(edge1, edge2)
         );
-        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), "fakeTenantId");
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), null);
 
         FlowFrameworkException exception = expectThrows(
             FlowFrameworkException.class,

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -81,7 +81,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
 
     // Wrap parser into node list
     private static List<ProcessNode> parseToNodes(String json) throws IOException {
-        return workflowProcessSorter.sortProcessNodes(parseToWorkflow(json), "123", Collections.emptyMap());
+        return workflowProcessSorter.sortProcessNodes(parseToWorkflow(json), "123", Collections.emptyMap(), "fakeTenantId");
     }
 
     // Wrap parser into string list
@@ -437,7 +437,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             List.of(edge1, edge2)
         );
 
-        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap());
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), "fakeTenantId");
         workflowProcessSorter.validateGraph(sortedProcessNodes);
     }
 
@@ -459,7 +459,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         WorkflowEdge edge = new WorkflowEdge(registerModel.id(), deployModel.id());
         Workflow workflow = new Workflow(Collections.emptyMap(), List.of(registerModel, deployModel), List.of(edge));
 
-        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap());
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), "fakeTenantId");
         FlowFrameworkException ex = expectThrows(
             FlowFrameworkException.class,
             () -> workflowProcessSorter.validateGraph(sortedProcessNodes)
@@ -481,7 +481,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
 
         FlowFrameworkException ex = expectThrows(
             FlowFrameworkException.class,
-            () -> workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap())
+            () -> workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), "fakeTenantId")
         );
         assertEquals("The step type [delete_index] for node [workflow_step_1] can not be used in a workflow.", ex.getMessage());
         assertEquals(RestStatus.FORBIDDEN, ex.getRestStatus());
@@ -524,7 +524,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             List.of(createConnector, registerModel, deployModel),
             List.of(edge1, edge2)
         );
-        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap());
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), "fakeTenantId");
 
         workflowProcessSorter.validatePluginsInstalled(sortedProcessNodes, List.of("opensearch-flow-framework", "opensearch-ml"));
     }
@@ -566,7 +566,7 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
             List.of(createConnector, registerModel, deployModel),
             List.of(edge1, edge2)
         );
-        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap());
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), "fakeTenantId");
 
         FlowFrameworkException exception = expectThrows(
             FlowFrameworkException.class,


### PR DESCRIPTION
### Description
Pass the tenantId in the (de-)(re-)provisioning transport actions to the workflow steps that execute the provisioning, and eventually to the respective client calls.

### Related Issues
https://github.com/opensearch-project/flow-framework/issues/987

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
