### PR TITLE
Use string-based version parsing to improve portability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Maintenance
 ### Refactoring
+- Use string-based version parsing to improve portability ([#1067](https://github.com/opensearch-project/flow-framework/pull/1067))

--- a/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowRequest.java
@@ -8,12 +8,12 @@
  */
 package org.opensearch.flowframework.transport;
 
-import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.flowframework.common.CommonValue;
 import org.opensearch.flowframework.model.Template;
 
 import java.io.IOException;
@@ -70,7 +70,7 @@ public class ReprovisionWorkflowRequest extends ActionRequest {
         this.workflowId = in.readString();
         this.originalTemplate = Template.parse(in.readString());
         this.updatedTemplate = Template.parse(in.readString());
-        if (in.getVersion().onOrAfter(Version.V_2_19_0)) {
+        if (in.getVersion().onOrAfter(CommonValue.VERSION_2_19_0)) {
             this.waitForCompletionTimeout = in.readTimeValue();
         }
 
@@ -82,7 +82,7 @@ public class ReprovisionWorkflowRequest extends ActionRequest {
         out.writeString(workflowId);
         out.writeString(originalTemplate.toJson());
         out.writeString(updatedTemplate.toJson());
-        if (out.getVersion().onOrAfter(Version.V_2_19_0)) {
+        if (out.getVersion().onOrAfter(CommonValue.VERSION_2_19_0)) {
             out.writeTimeValue(waitForCompletionTimeout);
         }
     }

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowRequest.java
@@ -8,13 +8,13 @@
  */
 package org.opensearch.flowframework.transport;
 
-import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.flowframework.common.CommonValue;
 import org.opensearch.flowframework.model.Template;
 
 import java.io.IOException;
@@ -187,7 +187,7 @@ public class WorkflowRequest extends ActionRequest {
             this.params = Collections.emptyMap();
         }
         this.reprovision = !provision && Boolean.parseBoolean(params.get(REPROVISION_WORKFLOW));
-        if (in.getVersion().onOrAfter(Version.V_2_19_0)) {
+        if (in.getVersion().onOrAfter(CommonValue.VERSION_2_19_0)) {
             this.waitForCompletionTimeout = in.readOptionalTimeValue();
         }
 
@@ -274,7 +274,7 @@ public class WorkflowRequest extends ActionRequest {
         } else if (reprovision) {
             out.writeMap(Map.of(REPROVISION_WORKFLOW, "true"), StreamOutput::writeString, StreamOutput::writeString);
         }
-        if (out.getVersion().onOrAfter(Version.V_2_19_0)) {
+        if (out.getVersion().onOrAfter(CommonValue.VERSION_2_19_0)) {
             out.writeOptionalTimeValue(waitForCompletionTimeout);
         }
     }

--- a/src/main/java/org/opensearch/flowframework/transport/WorkflowResponse.java
+++ b/src/main/java/org/opensearch/flowframework/transport/WorkflowResponse.java
@@ -8,13 +8,13 @@
  */
 package org.opensearch.flowframework.transport;
 
-import org.opensearch.Version;
 import org.opensearch.common.Nullable;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.flowframework.common.CommonValue;
 import org.opensearch.flowframework.model.WorkflowState;
 
 import java.io.IOException;
@@ -49,7 +49,7 @@ public class WorkflowResponse extends ActionResponse implements ToXContentObject
     public WorkflowResponse(StreamInput in) throws IOException {
         super(in);
         this.workflowId = in.readString();
-        if (in.getVersion().onOrAfter(Version.V_2_19_0)) {
+        if (in.getVersion().onOrAfter(CommonValue.VERSION_2_19_0)) {
             this.workflowState = in.readOptionalWriteable(WorkflowState::new);
         }
 
@@ -94,7 +94,7 @@ public class WorkflowResponse extends ActionResponse implements ToXContentObject
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(workflowId);
-        if (out.getVersion().onOrAfter(Version.V_2_19_0)) {
+        if (out.getVersion().onOrAfter(CommonValue.VERSION_2_19_0)) {
             out.writeOptionalWriteable(workflowState);
         }
     }


### PR DESCRIPTION
### Description

Beginning in 2.19.0 we use version checks for some transport request/response for BWC.  

Three such checks [use the `Version` class from upstream OpenSearch](https://github.com/search?q=repo%3Aopensearch-project%2Fflow-framework+V_2_19_0&type=code).

These checks are really just self-documenting code when released in the same version, since that line of code only exists in that version or higher; earlier versions don't even have that conditional and if they did, they would fail due to the lack of corresponding constant in the upstream dependency.

One of our checks using string based parsing:
https://github.com/opensearch-project/flow-framework/blob/f9a878ed7918b54abf699c13810e5551740a0c72/src/main/java/org/opensearch/flowframework/transport/GetWorkflowStateRequest.java#L59

where

https://github.com/opensearch-project/flow-framework/blob/f9a878ed7918b54abf699c13810e5551740a0c72/src/main/java/org/opensearch/flowframework/common/CommonValue.java#L257

In the case where we need to cherry-pick code from these classes elsewhere, particularly in feature branches which may be tracking an earlier release version, this allows the code to compile even if the upstream `Version` class doesn't have the same version constant, and are much preferred.

This PR changes the 3 other checks to conform to this string-based version pattern.

### Related Issues

Similar change in ML Commons to support 2.13-based feature branch with 2.14 code:
 - https://github.com/opensearch-project/ml-commons/issues/2483
 - https://github.com/opensearch-project/ml-commons/pull/2485

### Check List
- [x] New functionality includes testing.
- ~[ ] New functionality has been documented.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
