### PR TITLE
Add per-tenant provisioning throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/flow-framework/compare/2.x...HEAD)
 ### Features
+- Add per-tenant provisioning throttling ([#1074](https://github.com/opensearch-project/flow-framework/pull/1074))
+
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -90,10 +90,10 @@ import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW
 import static org.opensearch.flowframework.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_THREAD_POOL;
+import static org.opensearch.flowframework.common.FlowFrameworkSettings.*;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED;
-import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOWS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOW_STEPS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.REMOTE_METADATA_ENDPOINT;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.REMOTE_METADATA_REGION;
@@ -240,6 +240,8 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin, SystemI
             TASK_REQUEST_RETRY_DURATION,
             FILTER_BY_BACKEND_ROLES,
             FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED,
+            MAX_ACTIVE_PROVISIONS_PER_TENANT,
+            MAX_ACTIVE_DEPROVISIONS_PER_TENANT,
             REMOTE_METADATA_TYPE,
             REMOTE_METADATA_ENDPOINT,
             REMOTE_METADATA_REGION,

--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -90,10 +90,12 @@ import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW
 import static org.opensearch.flowframework.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_THREAD_POOL;
-import static org.opensearch.flowframework.common.FlowFrameworkSettings.*;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED;
+import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_ACTIVE_DEPROVISIONS_PER_TENANT;
+import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_ACTIVE_PROVISIONS_PER_TENANT;
+import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOWS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOW_STEPS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.REMOTE_METADATA_ENDPOINT;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.REMOTE_METADATA_REGION;

--- a/src/main/java/org/opensearch/flowframework/common/FlowFrameworkSettings.java
+++ b/src/main/java/org/opensearch/flowframework/common/FlowFrameworkSettings.java
@@ -33,6 +33,10 @@ public class FlowFrameworkSettings {
     protected volatile TimeValue requestTimeout;
     /** Whether multitenancy is enabled */
     private final Boolean isMultiTenancyEnabled;
+    /** Max simultaneous provision requests */
+    private volatile Integer maxActiveProvisionsPerTenant;
+    /** Max simultaneous deprovision requests */
+    private volatile Integer maxActiveDeprovisionsPerTenant;
 
     /** The upper limit of max workflows that can be created  */
     public static final int MAX_WORKFLOWS_LIMIT = 10000;
@@ -129,6 +133,25 @@ public class FlowFrameworkSettings {
         Setting.Property.NodeScope
     );
 
+    /** This setting sets max workflows that can be simultaneously provisioned, or reprovisioned by the same tenant */
+    public static final Setting<Integer> MAX_ACTIVE_PROVISIONS_PER_TENANT = Setting.intSetting(
+        "plugins.flow_framework.max_active_provisions_per_tenant",
+        2,
+        1,
+        4,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /** This setting sets max workflows that can be simultaneously deprovisioned by the same tenant */
+    public static final Setting<Integer> MAX_ACTIVE_DEPROVISIONS_PER_TENANT = Setting.intSetting(
+        "plugins.flow_framework.max_active_deprovisions_per_tenant",
+        1,
+        1,
+        2,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
     /** This setting sets the remote metadata type */
     public static final Setting<String> REMOTE_METADATA_TYPE = Setting.simpleString(
         "plugins.flow_framework." + REMOTE_METADATA_TYPE_KEY,
@@ -172,11 +195,17 @@ public class FlowFrameworkSettings {
         this.maxWorkflows = MAX_WORKFLOWS.get(settings);
         this.requestTimeout = WORKFLOW_REQUEST_TIMEOUT.get(settings);
         this.isMultiTenancyEnabled = FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED.get(settings);
+        this.maxActiveProvisionsPerTenant = MAX_ACTIVE_PROVISIONS_PER_TENANT.get(settings);
+        this.maxActiveDeprovisionsPerTenant = MAX_ACTIVE_DEPROVISIONS_PER_TENANT.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(FLOW_FRAMEWORK_ENABLED, it -> isFlowFrameworkEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(TASK_REQUEST_RETRY_DURATION, it -> retryDuration = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_WORKFLOW_STEPS, it -> maxWorkflowSteps = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_WORKFLOWS, it -> maxWorkflows = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(WORKFLOW_REQUEST_TIMEOUT, it -> requestTimeout = it);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(MAX_ACTIVE_PROVISIONS_PER_TENANT, it -> maxActiveProvisionsPerTenant = it);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(MAX_ACTIVE_DEPROVISIONS_PER_TENANT, it -> maxActiveDeprovisionsPerTenant = it);
     }
 
     /**
@@ -225,5 +254,21 @@ public class FlowFrameworkSettings {
      */
     public boolean isMultiTenancyEnabled() {
         return isMultiTenancyEnabled;
+    }
+
+    /**
+     * Getter for max active provisions per tenant
+     * @return max active provisions
+     */
+    public Integer getMaxActiveProvisionsPerTenant() {
+        return maxActiveProvisionsPerTenant;
+    }
+
+    /**
+     * Getter for max active deprovisions per tenant
+     * @return max active deprovisions
+     */
+    public Integer getMaxActiveDeprovisionsPerTenant() {
+        return maxActiveDeprovisionsPerTenant;
     }
 }

--- a/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportAction.java
@@ -136,7 +136,7 @@ public class DeprovisionWorkflowTransportAction extends HandledTransportAction<W
         )) {
             return;
         }
-        ActionListener<WorkflowResponse> listener = TenantAwareHelper.releaseDeprovisionOnFailureListener(tenantId, workflowListener);
+        ActionListener<WorkflowResponse> listener = TenantAwareHelper.releaseDeprovisionListener(tenantId, workflowListener);
         String workflowId = request.getWorkflowId();
         User user = getUserContext(client);
 

--- a/src/main/java/org/opensearch/flowframework/util/TenantAwareHelper.java
+++ b/src/main/java/org/opensearch/flowframework/util/TenantAwareHelper.java
@@ -167,7 +167,6 @@ public class TenantAwareHelper {
         if (tenantId == null) {
             return true; // No throttling for null tenantId
         }
-
         AtomicInteger count = executionsMap.computeIfAbsent(tenantId, k -> new AtomicInteger(0));
         if (count.incrementAndGet() <= maxExecutions) {
             return true;
@@ -193,6 +192,12 @@ public class TenantAwareHelper {
         }
     }
 
+    /**
+     * Create an action listener that releases provision throttle on failure only
+     * @param tenantId The tenant ID
+     * @param delegate the wrapped listener
+     * @return a listener wrapping the delegate that calls {@link #releaseProvision(String)} on failure of the wrapped listener.
+     */
     public static ActionListener<WorkflowResponse> releaseProvisionOnFailureListener(
         String tenantId,
         ActionListener<WorkflowResponse> delegate
@@ -214,6 +219,12 @@ public class TenantAwareHelper {
         });
     }
 
+    /**
+     * Create an action listener that releases deprovision throttle
+     * @param tenantId The tenant ID
+     * @param delegate the wrapped listener
+     * @return a listener wrapping the delegate that calls {@link #releaseDeprovision(String)} on the wrapped listener.
+     */
     public static ActionListener<WorkflowResponse> releaseDeprovisionListener(String tenantId, ActionListener<WorkflowResponse> delegate) {
         return ActionListener.notifyOnce(new ActionListener<>() {
             @Override

--- a/src/main/java/org/opensearch/flowframework/util/TenantAwareHelper.java
+++ b/src/main/java/org/opensearch/flowframework/util/TenantAwareHelper.java
@@ -12,16 +12,22 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.common.CommonValue;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.transport.WorkflowResponse;
 import org.opensearch.rest.RestRequest;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Helper class for tenant ID validation
  */
 public class TenantAwareHelper {
+
+    private static final ConcurrentHashMap<String, AtomicInteger> activeProvisionsPerTenant = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, AtomicInteger> activeDeprovisionsPerTenant = new ConcurrentHashMap<>();
 
     private TenantAwareHelper() {}
 
@@ -87,5 +93,103 @@ public class TenantAwareHelper {
         }
 
         return tenantId;
+    }
+
+    /**
+     * Attempts to acquire a provision slot for the given tenant.
+     *
+     * @param maxExecutions The maximum number of simultaneous provisions allowed per tenant.
+     * @param tenantId The ID of the tenant requesting the provision.
+     * @param workflowListener The listener to notify in case of failure.
+     * @return true if the provision slot was acquired, false otherwise.
+     */
+    public static boolean tryAcquireProvision(int maxExecutions, String tenantId, ActionListener<WorkflowResponse> workflowListener) {
+        if (!tryAcquire(tenantId, activeProvisionsPerTenant, maxExecutions)) {
+            workflowListener.onFailure(
+                new FlowFrameworkException(
+                    "Exceeded max simultaneous provisioning requests: " + maxExecutions,
+                    RestStatus.TOO_MANY_REQUESTS
+                )
+            );
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Attempts to acquire a deprovision slot for the given tenant.
+     *
+     * @param maxExecutions The maximum number of simultaneous deprovisions allowed per tenant.
+     * @param tenantId The ID of the tenant requesting the deprovision.
+     * @param workflowListener The listener to notify in case of failure.
+     * @return true if the deprovision slot was acquired, false otherwise.
+     */
+    public static boolean tryAcquireDeprovision(int maxExecutions, String tenantId, ActionListener<WorkflowResponse> workflowListener) {
+        if (!tryAcquire(tenantId, activeDeprovisionsPerTenant, maxExecutions)) {
+            workflowListener.onFailure(
+                new FlowFrameworkException(
+                    "Exceeded max simultaneous deprovisioning requests: " + maxExecutions,
+                    RestStatus.TOO_MANY_REQUESTS
+                )
+            );
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Releases a provision slot for the given tenant.
+     *
+     * @param tenantId The ID of the tenant for which to release the provision slot.
+     */
+    public static void releaseProvision(String tenantId) {
+        release(tenantId, activeProvisionsPerTenant);
+    }
+
+    /**
+     * Releases a deprovision slot for the given tenant.
+     *
+     * @param tenantId The ID of the tenant for which to release the deprovision slot.
+     */
+    public static void releaseDeprovision(String tenantId) {
+        release(tenantId, activeDeprovisionsPerTenant);
+    }
+
+    /**
+     * Attempts to acquire an execution slot for the given tenant.
+     *
+     * @param tenantId The ID of the tenant requesting the execution slot.
+     * @param executionsMap The map tracking the number of active executions per tenant.
+     * @param maxExecutions The maximum number of simultaneous executions allowed per tenant.
+     * @return true if the execution slot was acquired, false otherwise.
+     */
+    private static boolean tryAcquire(String tenantId, ConcurrentHashMap<String, AtomicInteger> executionsMap, int maxExecutions) {
+        if (tenantId == null) {
+            return true; // No throttling for null tenantId
+        }
+
+        AtomicInteger count = executionsMap.computeIfAbsent(tenantId, k -> new AtomicInteger(0));
+        if (count.incrementAndGet() <= maxExecutions) {
+            return true;
+        } else {
+            count.decrementAndGet(); // Rollback the increment
+            return false;
+        }
+    }
+
+    /**
+     * Releases an execution slot for the given tenant.
+     *
+     * @param tenantId The ID of the tenant for which to release the execution slot.
+     * @param executionsMap The map tracking the number of active executions per tenant.
+     */
+    private static void release(String tenantId, ConcurrentHashMap<String, AtomicInteger> executionsMap) {
+        if (tenantId == null) {
+            return; // No throttling for null tenantId
+        }
+        AtomicInteger count = executionsMap.get(tenantId);
+        if (count != null) {
+            count.decrementAndGet();
+        }
     }
 }

--- a/src/main/java/org/opensearch/flowframework/util/TenantAwareHelper.java
+++ b/src/main/java/org/opensearch/flowframework/util/TenantAwareHelper.java
@@ -214,14 +214,15 @@ public class TenantAwareHelper {
         });
     }
 
-    public static ActionListener<WorkflowResponse> releaseDeprovisionOnFailureListener(
-        String tenantId,
-        ActionListener<WorkflowResponse> delegate
-    ) {
+    public static ActionListener<WorkflowResponse> releaseDeprovisionListener(String tenantId, ActionListener<WorkflowResponse> delegate) {
         return ActionListener.notifyOnce(new ActionListener<>() {
             @Override
             public void onResponse(WorkflowResponse response) {
-                delegate.onResponse(response);
+                try {
+                    releaseDeprovision(tenantId);
+                } finally {
+                    delegate.onResponse(response);
+                }
             }
 
             @Override

--- a/src/main/java/org/opensearch/flowframework/util/TenantAwareHelper.java
+++ b/src/main/java/org/opensearch/flowframework/util/TenantAwareHelper.java
@@ -192,4 +192,46 @@ public class TenantAwareHelper {
             count.decrementAndGet();
         }
     }
+
+    public static ActionListener<WorkflowResponse> releaseProvisionOnFailureListener(
+        String tenantId,
+        ActionListener<WorkflowResponse> delegate
+    ) {
+        return ActionListener.notifyOnce(new ActionListener<>() {
+            @Override
+            public void onResponse(WorkflowResponse response) {
+                delegate.onResponse(response);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                try {
+                    releaseProvision(tenantId);
+                } finally {
+                    delegate.onFailure(e);
+                }
+            }
+        });
+    }
+
+    public static ActionListener<WorkflowResponse> releaseDeprovisionOnFailureListener(
+        String tenantId,
+        ActionListener<WorkflowResponse> delegate
+    ) {
+        return ActionListener.notifyOnce(new ActionListener<>() {
+            @Override
+            public void onResponse(WorkflowResponse response) {
+                delegate.onResponse(response);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                try {
+                    releaseDeprovision(tenantId);
+                } finally {
+                    delegate.onFailure(e);
+                }
+            }
+        });
+    }
 }

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
@@ -31,6 +31,8 @@ import java.util.stream.Stream;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_ENABLED;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED;
+import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_ACTIVE_DEPROVISIONS_PER_TENANT;
+import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_ACTIVE_PROVISIONS_PER_TENANT;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOWS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOW_STEPS;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.REMOTE_METADATA_ENDPOINT;
@@ -80,6 +82,8 @@ public class FlowFrameworkPluginTests extends OpenSearchTestCase {
                 TASK_REQUEST_RETRY_DURATION,
                 FILTER_BY_BACKEND_ROLES,
                 FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED,
+                MAX_ACTIVE_PROVISIONS_PER_TENANT,
+                MAX_ACTIVE_DEPROVISIONS_PER_TENANT,
                 REMOTE_METADATA_TYPE,
                 REMOTE_METADATA_ENDPOINT,
                 REMOTE_METADATA_REGION,
@@ -106,7 +110,7 @@ public class FlowFrameworkPluginTests extends OpenSearchTestCase {
             assertEquals(9, ffp.getRestHandlers(settings, null, null, null, null, null, null).size());
             assertEquals(10, ffp.getActions().size());
             assertEquals(3, ffp.getExecutorBuilders(settings).size());
-            assertEquals(11, ffp.getSettings().size());
+            assertEquals(13, ffp.getSettings().size());
 
             Collection<SystemIndexDescriptor> systemIndexDescriptors = ffp.getSystemIndexDescriptors(Settings.EMPTY);
             assertEquals(3, systemIndexDescriptors.size());

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkTenantAwareRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkTenantAwareRestTestCase.java
@@ -177,6 +177,10 @@ public abstract class FlowFrameworkTenantAwareRestTestCase extends FlowFramework
         assertTrue(List.of(RestStatus.OK.getStatus(), RestStatus.ACCEPTED.getStatus()).contains(response.getStatusLine().getStatusCode()));
     }
 
+    protected static void assertTooManyRequests(Response response) {
+        assertEquals(RestStatus.TOO_MANY_REQUESTS.getStatus(), response.getStatusLine().getStatusCode());
+    }
+
     /**
      * Delete the specified document and wait until a search matches only the specified number of hits
      * @param tenantId The tenant ID to filter the search by

--- a/src/test/java/org/opensearch/flowframework/TestHelpers.java
+++ b/src/test/java/org/opensearch/flowframework/TestHelpers.java
@@ -16,6 +16,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.WarningsHandler;
 import org.opensearch.common.settings.ClusterSettings;
@@ -126,6 +127,9 @@ public class TestHelpers {
         }
         try {
             return client.performRequest(request);
+        } catch (ResponseException e) {
+            // Make sure response exceptions aren't retried
+            throw e;
         } catch (IOException e) {
             // In restricted resource cluster, initialization of REST clients on other nodes takes time
             // Wait 10 seconds and try again

--- a/src/test/java/org/opensearch/flowframework/common/FlowFrameworkSettingsTests.java
+++ b/src/test/java/org/opensearch/flowframework/common/FlowFrameworkSettingsTests.java
@@ -44,7 +44,9 @@ public class FlowFrameworkSettingsTests extends OpenSearchTestCase {
                 FlowFrameworkSettings.MAX_WORKFLOW_STEPS,
                 FlowFrameworkSettings.MAX_WORKFLOWS,
                 FlowFrameworkSettings.WORKFLOW_REQUEST_TIMEOUT,
-                FlowFrameworkSettings.FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED
+                FlowFrameworkSettings.FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED,
+                FlowFrameworkSettings.MAX_ACTIVE_PROVISIONS_PER_TENANT,
+                FlowFrameworkSettings.MAX_ACTIVE_DEPROVISIONS_PER_TENANT
             )
         ).collect(Collectors.toSet());
         clusterSettings = new ClusterSettings(settings, settingsSet);
@@ -65,5 +67,7 @@ public class FlowFrameworkSettingsTests extends OpenSearchTestCase {
         assertEquals(Optional.of(1000), Optional.ofNullable(flowFrameworkSettings.getMaxWorkflows()));
         assertEquals(Optional.of(TimeValue.timeValueSeconds(10)), Optional.ofNullable(flowFrameworkSettings.getRequestTimeout()));
         assertFalse(flowFrameworkSettings.isMultiTenancyEnabled());
+        assertEquals(Optional.of(2), Optional.ofNullable(flowFrameworkSettings.getMaxActiveProvisionsPerTenant()));
+        assertEquals(Optional.of(1), Optional.ofNullable(flowFrameworkSettings.getMaxActiveDeprovisionsPerTenant()));
     }
 }

--- a/src/test/java/org/opensearch/flowframework/rest/RestWorkflowProvisionTenantAwareIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestWorkflowProvisionTenantAwareIT.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.rest;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.flowframework.FlowFrameworkTenantAwareRestTestCase;
+import org.opensearch.flowframework.TestHelpers;
+import org.opensearch.flowframework.model.Template;
+import org.opensearch.flowframework.model.Workflow;
+import org.opensearch.flowframework.model.WorkflowNode;
+import org.opensearch.rest.RestRequest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_ID;
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
+
+public class RestWorkflowProvisionTenantAwareIT extends FlowFrameworkTenantAwareRestTestCase {
+
+    private static final String WORKFLOW_PATH = WORKFLOW_URI + "/";
+    private static final String PROVISION = "/_provision";
+    private static final String DEPROVISION = "/_deprovision";
+    private static final String STATUS_ALL = "/_status?all=true";
+
+    public void testWorkflowProvisionThrottle() throws Exception {
+        boolean multiTenancyEnabled = isMultiTenancyEnabled();
+
+        /*
+         * Setup
+         */
+        Response response = TestHelpers.makeRequest(
+            client(),
+            "PUT",
+            "_cluster/settings",
+            null,
+            "{\"persistent\":{\"plugins.flow_framework.max_active_provisions_per_tenant\":1,\"plugins.flow_framework.max_active_deprovisions_per_tenant\":1}}",
+            List.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+        );
+        assertOK(response);
+
+        /*
+        * Create
+        */
+        // Create a workflow with a tenant id
+        RestRequest createWorkflowRequest = getRestRequestWithHeadersAndContent(tenantId, createNoOpTemplateWithDelayNodes(1));
+        response = makeRequest(createWorkflowRequest, POST, WORKFLOW_PATH);
+        assertOK(response);
+        Map<String, Object> map = responseToMap(response);
+        assertTrue(map.containsKey(WORKFLOW_ID));
+        String workflowId1 = map.get(WORKFLOW_ID).toString();
+
+        // Create a second workflow with a tenant id
+        response = makeRequest(createWorkflowRequest, POST, WORKFLOW_PATH);
+        assertOK(response);
+        map = responseToMap(response);
+        assertTrue(map.containsKey(WORKFLOW_ID));
+        String workflowId2 = map.get(WORKFLOW_ID).toString();
+
+        // Create a workflow with other tenant id
+        RestRequest otherWorkflowRequest = getRestRequestWithHeadersAndContent(otherTenantId, createNoOpTemplateWithDelayNodes(1));
+        response = makeRequest(otherWorkflowRequest, POST, WORKFLOW_PATH);
+        assertOK(response);
+        map = responseToMap(response);
+        assertTrue(map.containsKey(WORKFLOW_ID));
+        String otherWorkflowId = map.get(WORKFLOW_ID).toString();
+
+        /*
+         * Provision
+         */
+        // Kick off a provisioning
+        response = makeRequest(tenantRequest, POST, WORKFLOW_PATH + workflowId1 + PROVISION);
+        assertOK(response);
+        map = responseToMap(response);
+        assertTrue(map.containsKey(WORKFLOW_ID));
+        assertEquals(workflowId1, map.get(WORKFLOW_ID).toString());
+        // During the 12 second async provisioning, try another one
+        // Another workflow should be fine
+        response = makeRequest(otherTenantRequest, POST, WORKFLOW_PATH + otherWorkflowId + PROVISION);
+        assertOK(response);
+        map = responseToMap(response);
+        assertTrue(map.containsKey(WORKFLOW_ID));
+        assertEquals(otherWorkflowId, map.get(WORKFLOW_ID).toString());
+
+        if (multiTenancyEnabled) {
+            // Same workflow should throttle
+            ResponseException ex = assertThrows(
+                ResponseException.class,
+                () -> makeRequest(tenantRequest, POST, WORKFLOW_PATH + workflowId2 + PROVISION)
+            );
+            response = ex.getResponse();
+            map = responseToMap(response);
+            assertTooManyRequests(response);
+
+            // Wait for workflow 1 completion
+            assertBusy(() -> {
+                // Verify state completed
+                Response restResponse = makeRequest(tenantRequest, GET, WORKFLOW_PATH + workflowId1 + STATUS_ALL);
+                assertOK(restResponse);
+                Map<String, Object> stateMap = responseToMap(restResponse);
+                assertEquals("COMPLETED", stateMap.get("state"));
+            }, 20, TimeUnit.SECONDS);
+
+            // Provision should work now
+            response = makeRequest(tenantRequest, POST, WORKFLOW_PATH + workflowId2 + PROVISION);
+            assertOK(response);
+            map = responseToMap(response);
+            assertTrue(map.containsKey(WORKFLOW_ID));
+            assertEquals(workflowId2, map.get(WORKFLOW_ID).toString());
+        } else {
+            // No throttling at all without multitenancy
+            response = makeRequest(tenantRequest, POST, WORKFLOW_PATH + workflowId2 + PROVISION);
+            assertOK(response);
+            map = responseToMap(response);
+            assertTrue(map.containsKey(WORKFLOW_ID));
+            assertEquals(workflowId2, map.get(WORKFLOW_ID).toString());
+
+            // Wait for workflow 1 completion
+            assertBusy(() -> {
+                // Verify state completed
+                Response restResponse = makeRequest(tenantRequest, GET, WORKFLOW_PATH + workflowId1 + STATUS_ALL);
+                assertOK(restResponse);
+                Map<String, Object> stateMap = responseToMap(restResponse);
+                assertEquals("COMPLETED", stateMap.get("state"));
+            }, 20, TimeUnit.SECONDS);
+        }
+
+        // Wait for other workflow completion
+        assertBusy(() -> {
+            // Verify state completed
+            Response restResponse = makeRequest(otherTenantRequest, GET, WORKFLOW_PATH + otherWorkflowId + STATUS_ALL);
+            assertOK(restResponse);
+            Map<String, Object> stateMap = responseToMap(restResponse);
+            assertEquals("COMPLETED", stateMap.get("state"));
+        }, 20, TimeUnit.SECONDS);
+
+        // Wait for workflow 2 completion
+        assertBusy(() -> {
+            // Verify state completed
+            Response restResponse = makeRequest(tenantRequest, GET, WORKFLOW_PATH + workflowId2 + STATUS_ALL);
+            assertOK(restResponse);
+            Map<String, Object> stateMap = responseToMap(restResponse);
+            assertEquals("COMPLETED", stateMap.get("state"));
+        }, 20, TimeUnit.SECONDS);
+
+        /*
+         * Reprovision
+         */
+        // Reprovision a workflow with a tenant id
+        RestRequest updateWorkflowRequest = getRestRequestWithHeadersAndContent(tenantId, createNoOpTemplateWithDelayNodes(2));
+        response = makeRequest(updateWorkflowRequest, PUT, WORKFLOW_PATH + workflowId1 + "?reprovision=true");
+        assertOK(response);
+        map = responseToMap(response);
+        assertTrue(map.containsKey(WORKFLOW_ID));
+        assertEquals(workflowId1, map.get(WORKFLOW_ID).toString());
+
+        // During the 12 second async reprovisioning, try another one
+        // Another workflow should be fine
+        otherWorkflowRequest = getRestRequestWithHeadersAndContent(otherTenantId, createNoOpTemplateWithDelayNodes(2));
+        response = makeRequest(otherWorkflowRequest, PUT, WORKFLOW_PATH + otherWorkflowId + "?reprovision=true");
+        assertOK(response);
+        map = responseToMap(response);
+        assertTrue(map.containsKey(WORKFLOW_ID));
+        assertEquals(otherWorkflowId, map.get(WORKFLOW_ID).toString());
+
+        if (multiTenancyEnabled) {
+            // Same workflow should throttle
+            ResponseException ex = assertThrows(
+                ResponseException.class,
+                () -> makeRequest(updateWorkflowRequest, PUT, WORKFLOW_PATH + workflowId2 + "?reprovision=true")
+            );
+            response = ex.getResponse();
+            map = responseToMap(response);
+            assertTooManyRequests(response);
+
+            // Wait for workflow 1 completion
+            assertBusy(() -> {
+                // Verify state completed
+                Response restResponse = makeRequest(tenantRequest, GET, WORKFLOW_PATH + workflowId1 + STATUS_ALL);
+                assertOK(restResponse);
+                Map<String, Object> stateMap = responseToMap(restResponse);
+                assertEquals("COMPLETED", stateMap.get("state"));
+            }, 20, TimeUnit.SECONDS);
+
+            // Reprovision should work now
+            response = makeRequest(updateWorkflowRequest, PUT, WORKFLOW_PATH + workflowId2 + "?reprovision=true");
+            assertOK(response);
+            map = responseToMap(response);
+            assertTrue(map.containsKey(WORKFLOW_ID));
+            assertEquals(workflowId2, map.get(WORKFLOW_ID).toString());
+        } else {
+            // No throttling at all without multitenancy
+            response = makeRequest(updateWorkflowRequest, PUT, WORKFLOW_PATH + workflowId2 + "?reprovision=true");
+            assertOK(response);
+            map = responseToMap(response);
+            assertTrue(map.containsKey(WORKFLOW_ID));
+            assertEquals(workflowId2, map.get(WORKFLOW_ID).toString());
+
+            // Wait for workflow 1 completion
+            assertBusy(() -> {
+                // Verify state completed
+                Response restResponse = makeRequest(tenantRequest, GET, WORKFLOW_PATH + workflowId1 + STATUS_ALL);
+                assertOK(restResponse);
+                Map<String, Object> stateMap = responseToMap(restResponse);
+                assertEquals("COMPLETED", stateMap.get("state"));
+            }, 20, TimeUnit.SECONDS);
+        }
+
+        // Wait for other workflow completion
+        assertBusy(() -> {
+            // Verify state completed
+            Response restResponse = makeRequest(otherTenantRequest, GET, WORKFLOW_PATH + otherWorkflowId + STATUS_ALL);
+            assertOK(restResponse);
+            Map<String, Object> stateMap = responseToMap(restResponse);
+            assertEquals("COMPLETED", stateMap.get("state"));
+        }, 20, TimeUnit.SECONDS);
+
+        // Wait for workflow 2 completion
+        assertBusy(() -> {
+            // Verify state completed
+            Response restResponse = makeRequest(tenantRequest, GET, WORKFLOW_PATH + workflowId2 + STATUS_ALL);
+            assertOK(restResponse);
+            Map<String, Object> stateMap = responseToMap(restResponse);
+            assertEquals("COMPLETED", stateMap.get("state"));
+        }, 20, TimeUnit.SECONDS);
+
+        /*
+         * Deprovision
+         */
+        // Deprovision API is synchronous so we have to multithread
+        // Since no-op template doesn't have resources this really only takes as long as the state update
+        CompletableFuture<Response> future1 = CompletableFuture.supplyAsync(() -> {
+            try {
+                return makeRequest(tenantRequest, POST, WORKFLOW_PATH + workflowId1 + DEPROVISION);
+            } catch (IOException e) {
+                throw new CompletionException(e);
+            }
+        });
+        CompletableFuture<Response> future2 = CompletableFuture.supplyAsync(() -> {
+            try {
+                return makeRequest(tenantRequest, POST, WORKFLOW_PATH + workflowId2 + DEPROVISION);
+            } catch (IOException e) {
+                throw new CompletionException(e);
+            }
+        });
+        CompletableFuture<Response> otherFuture = CompletableFuture.supplyAsync(() -> {
+            try {
+                return makeRequest(otherTenantRequest, POST, WORKFLOW_PATH + otherWorkflowId + DEPROVISION);
+            } catch (IOException e) {
+                throw new CompletionException(e);
+            }
+        });
+
+        CompletableFuture<Void> combinedFuture = CompletableFuture.allOf(future1, future2, otherFuture);
+        if (multiTenancyEnabled) {
+            // Wait for all futures to complete, but don't throw exceptions
+            combinedFuture.handle((v, e) -> null).get(20, TimeUnit.SECONDS);
+        } else {
+            // Should not get any exceptions
+            combinedFuture.get(20, TimeUnit.SECONDS);
+        }
+
+        // otherfuture should be successful always.
+        // Expect 200, may be 202
+        assertOkOrAccepted(otherFuture.get());
+        map = responseToMap(otherFuture.get());
+        assertTrue(map.containsKey(WORKFLOW_ID));
+        assertEquals(otherWorkflowId, map.get(WORKFLOW_ID).toString());
+
+        // in multitenancy, at least one of future1/future2 should be OK
+        // no more than one of the other is throttled
+        // otherwise both should be successful
+        int successCount = 0;
+        int throttledCount = 0;
+
+        try {
+            Response response1 = future1.get();
+            assertOkOrAccepted(response1);
+            successCount++;
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof ResponseException) {
+                ResponseException re = (ResponseException) e.getCause();
+                assertTooManyRequests(re.getResponse());
+                throttledCount++;
+            } else {
+                fail("Unexpected exception type");
+            }
+        }
+
+        try {
+            Response response2 = future2.get();
+            assertOkOrAccepted(response2);
+            successCount++;
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof ResponseException) {
+                ResponseException re = (ResponseException) e.getCause();
+                assertTooManyRequests(re.getResponse());
+                throttledCount++;
+            } else {
+                fail("Unexpected exception type");
+            }
+        }
+
+        if (multiTenancyEnabled) {
+            assertTrue(successCount >= 1);
+            assertTrue(throttledCount <= 1);
+        } else {
+            assertEquals(2, successCount);
+            assertEquals(0, throttledCount);
+        }
+
+        /*
+        * Delete
+        */
+        // Delete from tenant
+        response = makeRequest(tenantRequest, DELETE, WORKFLOW_PATH + workflowId1);
+        assertOK(response);
+        map = responseToMap(response);
+        assertEquals(workflowId1, map.get(DOC_ID).toString());
+
+        response = makeRequest(tenantRequest, DELETE, WORKFLOW_PATH + workflowId2);
+        assertOK(response);
+        map = responseToMap(response);
+        assertEquals(workflowId2, map.get(DOC_ID).toString());
+
+        // Delete from other tenant
+        response = makeRequest(otherTenantRequest, DELETE, WORKFLOW_PATH + otherWorkflowId);
+        assertOK(response);
+        map = responseToMap(response);
+        assertEquals(otherWorkflowId, map.get(DOC_ID).toString());
+    }
+
+    private static String createNoOpTemplateWithDelayNodes(int numNodes) throws IOException {
+        List<WorkflowNode> nodes = new ArrayList<>();
+        for (int i = 0; i < numNodes; i++) {
+            // Fun fact: TestHelpers retries failed requests once after 10 seconds so we need a longer delay
+            nodes.add(new WorkflowNode("no-op-" + i, "noop", Collections.emptyMap(), Map.of("delay", "12s")));
+        }
+        Workflow provisionWorkflow = new Workflow(Collections.emptyMap(), nodes, Collections.emptyList());
+        return Template.builder().name("noop").workflows(Map.of("provision", provisionWorkflow)).build().toJson();
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/DeprovisionWorkflowTransportActionTests.java
@@ -98,12 +98,7 @@ public class DeprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
     public void setUp() throws Exception {
         super.setUp();
         this.client = mock(Client.class);
-        this.sdkClient = SdkClientFactory.createSdkClient(
-            client,
-            NamedXContentRegistry.EMPTY,
-            Collections.emptyMap(),
-            threadPool.executor(ThreadPool.Names.SAME)
-        );
+        this.sdkClient = SdkClientFactory.createSdkClient(client, NamedXContentRegistry.EMPTY, Collections.emptyMap());
         ThreadPool clientThreadPool = spy(threadPool);
         when(client.threadPool()).thenReturn(clientThreadPool);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);

--- a/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
@@ -17,6 +17,7 @@ import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
@@ -58,6 +59,7 @@ import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_IND
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -141,6 +143,7 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
 
         when(client.threadPool()).thenReturn(clientThreadPool);
         when(clientThreadPool.getThreadContext()).thenReturn(threadContext);
+        when(clientThreadPool.executor(anyString())).thenReturn(OpenSearchExecutors.newDirectExecutorService());
     }
 
     public void testProvisionWorkflow() {


### PR DESCRIPTION
### Description

Adds settings to control per-tenant limits on simultaneous provision, reprovision, and deprovision.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
