### PR TITLE
Get bouncycastle dependency version from catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ dependencies {
     implementation "software.amazon.cryptography:aws-cryptographic-material-providers:1.9.0"
     implementation "org.dafny:DafnyRuntime:4.10.0"
     implementation "software.amazon.smithy.dafny:conversion:0.1.1"
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.80'
+    implementation "org.bouncycastle:bcprov-jdk18on:${versions.bouncycastle}"
     api "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
     implementation "org.glassfish:jakarta.json:2.0.1"


### PR DESCRIPTION
### Description

Gets the version of `org.bouncycastle:bcprov-jdk18on` from the OpenSearch version catalog

### Related Issues

Fixes #1072

### Check List
- [x] New functionality includes testing.
- ![ ] New functionality has been documented.!
- ![ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).!
- [x] Commits are signed per the DCO using `--signoff`.
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
