### PR TITLE
Migrate from BC to BCFIPS libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Infrastructure
 ### Documentation
 ### Maintenance
+- Set bouncycastle version inline ([#1087](https://github.com/opensearch-project/flow-framework/pull/1087))
+
 ### Refactoring
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.18...2.x)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Infrastructure
 ### Documentation
 ### Maintenance
-- Remove unused bouncycastle ([#1087](https://github.com/opensearch-project/flow-framework/pull/1087))
+- Migrate from BC to BCFIPS libraries ([#1087](https://github.com/opensearch-project/flow-framework/pull/1087))
 
 ### Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Infrastructure
 ### Documentation
 ### Maintenance
-- Set bouncycastle version inline ([#1087](https://github.com/opensearch-project/flow-framework/pull/1087))
+- Remove unused bouncycastle ([#1087](https://github.com/opensearch-project/flow-framework/pull/1087))
 
 ### Refactoring
 

--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,8 @@ dependencies {
     implementation "software.amazon.cryptography:aws-cryptographic-material-providers:1.9.0"
     implementation "org.dafny:DafnyRuntime:4.10.0"
     implementation "software.amazon.smithy.dafny:conversion:0.1.1"
+    // needed by aws-encryption-sdk-java
+    implementation "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
     api "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
     implementation "org.glassfish:jakarta.json:2.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ dependencies {
     implementation "software.amazon.cryptography:aws-cryptographic-material-providers:1.9.0"
     implementation "org.dafny:DafnyRuntime:4.10.0"
     implementation "software.amazon.smithy.dafny:conversion:0.1.1"
-    implementation "org.bouncycastle:bcprov-jdk18on:1.80"
+    implementation "org.bouncycastle:bcprov-jdk18on:1.78"
     api "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
     implementation "org.glassfish:jakarta.json:2.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ import java.nio.file.Paths
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "beta1")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
@@ -178,7 +178,7 @@ dependencies {
     implementation "org.dafny:DafnyRuntime:4.10.0"
     implementation "software.amazon.smithy.dafny:conversion:0.1.1"
     // needed by aws-encryption-sdk-java
-    implementation "org.bouncycastle:bc-fips:2.0.0"
+    implementation "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
     api "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
     implementation "org.glassfish:jakarta.json:2.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ dependencies {
     implementation "software.amazon.cryptography:aws-cryptographic-material-providers:1.9.0"
     implementation "org.dafny:DafnyRuntime:4.10.0"
     implementation "software.amazon.smithy.dafny:conversion:0.1.1"
-    implementation "org.bouncycastle:bcprov-jdk18on:${versions.bouncycastle}"
+    implementation "org.bouncycastle:bcprov-jdk18on:1.78"
     api "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
     implementation "org.glassfish:jakarta.json:2.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ dependencies {
     implementation "org.dafny:DafnyRuntime:4.10.0"
     implementation "software.amazon.smithy.dafny:conversion:0.1.1"
     // needed by aws-encryption-sdk-java
-    implementation "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
+    implementation "org.bouncycastle:bc-fips:2.0.0"
     api "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
     implementation "org.glassfish:jakarta.json:2.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ dependencies {
     implementation "software.amazon.cryptography:aws-cryptographic-material-providers:1.9.0"
     implementation "org.dafny:DafnyRuntime:4.10.0"
     implementation "software.amazon.smithy.dafny:conversion:0.1.1"
-    implementation "org.bouncycastle:bcprov-jdk18on:1.78"
+    implementation "org.bouncycastle:bcprov-jdk18on:1.80"
     api "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
     implementation "org.glassfish:jakarta.json:2.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,6 @@ dependencies {
     implementation "software.amazon.cryptography:aws-cryptographic-material-providers:1.9.0"
     implementation "org.dafny:DafnyRuntime:4.10.0"
     implementation "software.amazon.smithy.dafny:conversion:0.1.1"
-    implementation "org.bouncycastle:bcprov-jdk18on:1.78"
     api "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
     implementation "org.glassfish:jakarta.json:2.0.1"


### PR DESCRIPTION
### Description

`bouncycastle` was removed from the gradle version catalog in https://github.com/opensearch-project/OpenSearch/pull/17507/files#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87df.

This PR migrates from BC to BCFIPS libraries for this repo

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
