### PR TITLE
Fix Config parser does not handle tenant_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 ### Bug Fixes
 - Change REST status codes for RBAC and provisioning ([#1083](https://github.com/opensearch-project/flow-framework/pull/1083))
-
+- Fix Config parser does not handle tenant_id field ([#1096](https://github.com/opensearch-project/flow-framework/pull/1096))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 - Change REST status codes for RBAC and provisioning ([#1083](https://github.com/opensearch-project/flow-framework/pull/1083))
 - Fix Config parser does not handle tenant_id field ([#1096](https://github.com/opensearch-project/flow-framework/pull/1096))
+
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/flowframework/model/Config.java
+++ b/src/main/java/org/opensearch/flowframework/model/Config.java
@@ -8,8 +8,6 @@
  */
 package org.opensearch.flowframework.model;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -60,7 +58,7 @@ public class Config implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         XContentBuilder xContentBuilder = builder.startObject();
-        if(tenantId != null) {
+        if (tenantId != null) {
             xContentBuilder.field(TENANT_ID_FIELD, this.tenantId);
         }
         xContentBuilder.field(MASTER_KEY, this.masterKey);

--- a/src/main/java/org/opensearch/flowframework/model/Config.java
+++ b/src/main/java/org/opensearch/flowframework/model/Config.java
@@ -28,10 +28,8 @@ import static org.opensearch.flowframework.common.CommonValue.TENANT_ID_FIELD;
 /**
  * Flow Framework Configuration
  */
-
 public class Config implements ToXContentObject {
 
-    private static final Logger logger = LogManager.getLogger(Config.class);
     private final String masterKey;
     private final Instant createTime;
     private final String tenantId;
@@ -56,13 +54,15 @@ public class Config implements ToXContentObject {
      * @param createTime The config creation time
      */
     public Config(String masterKey, Instant createTime) {
-        this(masterKey, createTime, "");
+        this(masterKey, createTime, null);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         XContentBuilder xContentBuilder = builder.startObject();
-        xContentBuilder.field(TENANT_ID_FIELD, this.tenantId);
+        if(tenantId != null) {
+            xContentBuilder.field(TENANT_ID_FIELD, this.tenantId);
+        }
         xContentBuilder.field(MASTER_KEY, this.masterKey);
         xContentBuilder.field(CREATE_TIME, this.createTime.toEpochMilli());
         return xContentBuilder.endObject();
@@ -84,10 +84,9 @@ public class Config implements ToXContentObject {
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             String fieldName = parser.currentName();
             parser.nextToken();
-            logger.info("Parsing field: {}, token: {}, value: {}", fieldName, parser.currentToken(), parser.text());
             switch (fieldName) {
                 case TENANT_ID_FIELD:
-                    tenantId = parser.text();
+                    tenantId = (String) parser.objectText();
                     break;
                 case MASTER_KEY:
                     masterKey = parser.text();
@@ -120,5 +119,12 @@ public class Config implements ToXContentObject {
      */
     public Instant createTime() {
         return createTime;
+    }
+
+    /**
+     * @return the tenantId
+     */
+    public Object tenantId() {
+        return this.tenantId;
     }
 }

--- a/src/test/java/org/opensearch/flowframework/model/ConfigTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/ConfigTests.java
@@ -78,4 +78,57 @@ public class ConfigTests extends OpenSearchTestCase {
         }
     }
 
+    public void testTenantIdVariants() throws IOException {
+        String masterKey = "foo";
+        Instant createTime = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+        // Case 1: tenant_id is present and non-null
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.startObject()
+                    .field("master_key", masterKey)
+                    .field("create_time", createTime.toEpochMilli())
+                    .field("tenant_id", "tenant-123")
+                    .endObject();
+
+            BytesReference bytesRef = BytesReference.bytes(builder);
+            try (XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, bytesRef)) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                Config config = Config.parse(parser);
+                assertEquals("tenant-123", config.tenantId());
+            }
+        }
+
+        // Case 2: tenant_id is explicitly null
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.startObject()
+                    .field("master_key", masterKey)
+                    .field("create_time", createTime.toEpochMilli())
+                    .nullField("tenant_id")
+                    .endObject();
+
+            BytesReference bytesRef = BytesReference.bytes(builder);
+            try (XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, bytesRef)) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                Config config = Config.parse(parser);
+                assertNull(config.tenantId());
+            }
+        }
+
+        // Case 3: tenant_id is absent
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.startObject()
+                    .field("master_key", masterKey)
+                    .field("create_time", createTime.toEpochMilli())
+                    .endObject();
+
+            BytesReference bytesRef = BytesReference.bytes(builder);
+            try (XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, bytesRef)) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                Config config = Config.parse(parser);
+                assertNull(config.tenantId());
+            }
+        }
+    }
+
+
 }

--- a/src/test/java/org/opensearch/flowframework/model/ConfigTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/ConfigTests.java
@@ -85,10 +85,10 @@ public class ConfigTests extends OpenSearchTestCase {
         // Case 1: tenant_id is present and non-null
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             builder.startObject()
-                    .field("master_key", masterKey)
-                    .field("create_time", createTime.toEpochMilli())
-                    .field("tenant_id", "tenant-123")
-                    .endObject();
+                .field("master_key", masterKey)
+                .field("create_time", createTime.toEpochMilli())
+                .field("tenant_id", "tenant-123")
+                .endObject();
 
             BytesReference bytesRef = BytesReference.bytes(builder);
             try (XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, bytesRef)) {
@@ -101,10 +101,10 @@ public class ConfigTests extends OpenSearchTestCase {
         // Case 2: tenant_id is explicitly null
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             builder.startObject()
-                    .field("master_key", masterKey)
-                    .field("create_time", createTime.toEpochMilli())
-                    .nullField("tenant_id")
-                    .endObject();
+                .field("master_key", masterKey)
+                .field("create_time", createTime.toEpochMilli())
+                .nullField("tenant_id")
+                .endObject();
 
             BytesReference bytesRef = BytesReference.bytes(builder);
             try (XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, bytesRef)) {
@@ -116,10 +116,7 @@ public class ConfigTests extends OpenSearchTestCase {
 
         // Case 3: tenant_id is absent
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
-            builder.startObject()
-                    .field("master_key", masterKey)
-                    .field("create_time", createTime.toEpochMilli())
-                    .endObject();
+            builder.startObject().field("master_key", masterKey).field("create_time", createTime.toEpochMilli()).endObject();
 
             BytesReference bytesRef = BytesReference.bytes(builder);
             try (XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, bytesRef)) {
@@ -129,6 +126,5 @@ public class ConfigTests extends OpenSearchTestCase {
             }
         }
     }
-
 
 }


### PR DESCRIPTION
### Description
> When parsing, add a case to the switch statement read the tenant_id field and call parser.text() but ignore it (probably the fastest, I'd recommend)

Used this recommend option to fix this edge case.

### Related Issues
Resolves #1095 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
