### PR TITLE
Complete action listener on failed synchronous workflow provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 ### Bug Fixes
 - Change REST status codes for RBAC and provisioning ([#1083](https://github.com/opensearch-project/flow-framework/pull/1083))
+- Complete action listener on failed synchronous workflow provisioning ([#1098](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/1098))
 
 ### Infrastructure
 ### Documentation

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -352,11 +352,11 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
 
                     @Override
                     public void onFailure(Exception e) {
-                        WorkflowTimeoutUtility.handleFailure(workflowId, e, isResponseSent, listener);
+                        WorkflowTimeoutUtility.handleFailure(workflowId, e, listener);
                     }
                 }, true);
             } catch (Exception ex) {
-                WorkflowTimeoutUtility.handleFailure(workflowId, ex, isResponseSent, listener);
+                WorkflowTimeoutUtility.handleFailure(workflowId, ex, listener);
             }
         }, client.threadPool().executor(PROVISION_WORKFLOW_THREAD_POOL));
 

--- a/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportAction.java
@@ -355,11 +355,11 @@ public class ReprovisionWorkflowTransportAction extends HandledTransportAction<R
 
                     @Override
                     public void onFailure(Exception e) {
-                        WorkflowTimeoutUtility.handleFailure(workflowId, e, isResponseSent, listener);
+                        WorkflowTimeoutUtility.handleFailure(workflowId, e, listener);
                     }
                 }, true);
             } catch (Exception ex) {
-                WorkflowTimeoutUtility.handleFailure(workflowId, ex, isResponseSent, listener);
+                WorkflowTimeoutUtility.handleFailure(workflowId, ex, listener);
             }
         }, threadPool.executor(PROVISION_WORKFLOW_THREAD_POOL));
         WorkflowTimeoutUtility.scheduleTimeoutHandler(

--- a/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
@@ -314,6 +314,6 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
 
         ArgumentCaptor<FlowFrameworkException> responseCaptor = ArgumentCaptor.forClass(FlowFrameworkException.class);
         verify(listener, times(1)).onFailure(responseCaptor.capture());
-        assertEquals("Failed to execute workflow 1", responseCaptor.getValue().getMessage());
+        assertTrue(responseCaptor.getValue().getMessage().startsWith("Simulated failure during workflow execution"));
     }
 }

--- a/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportActionTests.java
@@ -30,6 +30,7 @@ import org.opensearch.flowframework.util.EncryptorUtils;
 import org.opensearch.flowframework.workflow.ProcessNode;
 import org.opensearch.flowframework.workflow.WorkflowData;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
+import org.opensearch.flowframework.workflow.WorkflowStep;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.remote.metadata.client.SdkClient;
@@ -368,6 +369,9 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
         failedFuture.onFailure(new RuntimeException("Simulated failure during workflow execution"));
         ProcessNode failedProcessNode = mock(ProcessNode.class);
         when(failedProcessNode.execute()).thenReturn(failedFuture);
+        WorkflowStep mockStep = mock(WorkflowStep.class);
+        when(mockStep.getName()).thenReturn("FakeStep");
+        when(failedProcessNode.workflowStep()).thenReturn(mockStep);
 
         // Stub reprovision sequence creation with the failed process node
         when(workflowProcessSorter.createReprovisionSequence(any(), any(), any(), any(), any())).thenReturn(List.of(failedProcessNode));
@@ -392,7 +396,7 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
 
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener, times(1)).onFailure(exceptionCaptor.capture());
-        assertTrue(exceptionCaptor.getValue().getMessage().contains("Failed to execute workflow"));
+        assertTrue(exceptionCaptor.getValue().getMessage().startsWith("Simulated failure during workflow execution"));
     }
 
 }

--- a/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ReprovisionWorkflowTransportActionTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.flowframework.transport;
 
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
@@ -27,6 +28,7 @@ import org.opensearch.flowframework.model.Workflow;
 import org.opensearch.flowframework.model.WorkflowState;
 import org.opensearch.flowframework.util.EncryptorUtils;
 import org.opensearch.flowframework.workflow.ProcessNode;
+import org.opensearch.flowframework.workflow.WorkflowData;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
 import org.opensearch.plugins.PluginsService;
@@ -333,6 +335,64 @@ public class ReprovisionWorkflowTransportActionTests extends OpenSearchTestCase 
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener, times(1)).onFailure(exceptionCaptor.capture());
         assertEquals("Failed to get workflow state for workflow 1", exceptionCaptor.getValue().getMessage());
+    }
+
+    public void testReprovisionWorkflowExecutionException() throws Exception {
+        String workflowId = "1";
+
+        Template mockTemplate = mock(Template.class);
+        Workflow mockWorkflow = mock(Workflow.class);
+        Map<String, Workflow> mockWorkflows = new HashMap<>();
+        mockWorkflows.put(PROVISION_WORKFLOW, mockWorkflow);
+
+        // Stub validations
+        when(mockTemplate.workflows()).thenReturn(mockWorkflows);
+        when(workflowProcessSorter.sortProcessNodes(any(), any(), any(), any())).thenReturn(List.of());
+        doNothing().when(workflowProcessSorter).validate(any(), any());
+        when(encryptorUtils.decryptTemplateCredentials(any())).thenReturn(mockTemplate);
+
+        // Stub state and resources created
+        doAnswer(invocation -> {
+            ActionListener<GetWorkflowStateResponse> listener = invocation.getArgument(2);
+            WorkflowState state = mock(WorkflowState.class);
+            ResourceCreated resourceCreated = new ResourceCreated("stepName", workflowId, "resourceType", "resourceId");
+            when(state.getState()).thenReturn(State.COMPLETED.toString());
+            when(state.resourcesCreated()).thenReturn(List.of(resourceCreated));
+            when(state.getError()).thenReturn(null);
+            listener.onResponse(new GetWorkflowStateResponse(state, true));
+            return null;
+        }).when(client).execute(any(), any(GetWorkflowStateRequest.class), any());
+
+        // Create a failed future for the workflow execution
+        PlainActionFuture<WorkflowData> failedFuture = PlainActionFuture.newFuture();
+        failedFuture.onFailure(new RuntimeException("Simulated failure during workflow execution"));
+        ProcessNode failedProcessNode = mock(ProcessNode.class);
+        when(failedProcessNode.execute()).thenReturn(failedFuture);
+
+        // Stub reprovision sequence creation with the failed process node
+        when(workflowProcessSorter.createReprovisionSequence(any(), any(), any(), any(), any())).thenReturn(List.of(failedProcessNode));
+
+        // Bypass updateFlowFrameworkSystemIndexDoc and stub on response
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> actionListener = invocation.getArgument(3);
+            actionListener.onResponse(mock(UpdateResponse.class));
+            return null;
+        }).when(flowFrameworkIndicesHandler).updateFlowFrameworkSystemIndexDoc(any(), nullable(String.class), anyMap(), any());
+
+        @SuppressWarnings("unchecked")
+        ActionListener<WorkflowResponse> listener = mock(ActionListener.class);
+        ReprovisionWorkflowRequest request = new ReprovisionWorkflowRequest(
+            workflowId,
+            mockTemplate,
+            mockTemplate,
+            TimeValue.timeValueSeconds(5)
+        );
+
+        reprovisionWorkflowTransportAction.doExecute(mock(Task.class), request, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener, times(1)).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("Failed to execute workflow"));
     }
 
 }


### PR DESCRIPTION
### Description

During synchronous provisioning (and reprovisioning) the actionListener was never completed on an exception in the workflow steps (which throw an exception on `actionGet()`).  
 - For asynchronous provisioning this was expected, as the listener was already completed.  In the sync case we ended up just failing on the timeout in this case.
 - Also had to handle the case of synchronous provisioning timeout

### Related Issues

Resolves #1097

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
