### PR TITLE
[Backport 2.19] Fix Config parser does not handle tenant_id field (#1096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,12 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased 3.0](https://github.com/opensearch-project/flow-framework/compare/2.x...HEAD)
+## [Unreleased 2.19.x](https://github.com/opensearch-project/flow-framework/compare/2.18...2.x)
 ### Features
 ### Enhancements
 ### Bug Fixes
-### Infrastructure
-- Set Java target compatibility to JDK 21 ([#730](https://github.com/opensearch-project/flow-framework/pull/730))
+- Fix Config parser does not handle tenant_id field ([#1096](https://github.com/opensearch-project/flow-framework/pull/1096))
 
-### Documentation
-- Add alert summary agent template ([#873](https://github.com/opensearch-project/flow-framework/pull/873))
-- Add alert summary with log pattern agent template ([#945](https://github.com/opensearch-project/flow-framework/pull/945))
-- Add text to visualization agent template ([#936](https://github.com/opensearch-project/flow-framework/pull/936))
-
-### Maintenance
-### Refactoring
-
-## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.18...2.x)
-### Features
-### Enhancements
-### Bug Fixes
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/test/java/org/opensearch/flowframework/model/ConfigTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/ConfigTests.java
@@ -78,4 +78,53 @@ public class ConfigTests extends OpenSearchTestCase {
         }
     }
 
+    public void testTenantIdVariants() throws IOException {
+        String masterKey = "foo";
+        Instant createTime = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+        // Case 1: tenant_id is present and non-null
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.startObject()
+                .field("master_key", masterKey)
+                .field("create_time", createTime.toEpochMilli())
+                .field("tenant_id", "tenant-123")
+                .endObject();
+
+            BytesReference bytesRef = BytesReference.bytes(builder);
+            try (XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, bytesRef)) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                Config config = Config.parse(parser);
+                assertEquals("tenant-123", config.tenantId());
+            }
+        }
+
+        // Case 2: tenant_id is explicitly null
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.startObject()
+                .field("master_key", masterKey)
+                .field("create_time", createTime.toEpochMilli())
+                .nullField("tenant_id")
+                .endObject();
+
+            BytesReference bytesRef = BytesReference.bytes(builder);
+            try (XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, bytesRef)) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                Config config = Config.parse(parser);
+                assertNull(config.tenantId());
+            }
+        }
+
+        // Case 3: tenant_id is absent
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.startObject().field("master_key", masterKey).field("create_time", createTime.toEpochMilli()).endObject();
+
+            BytesReference bytesRef = BytesReference.bytes(builder);
+            try (XContentParser parser = ParseUtils.createXContentParserFromRegistry(xContentRegistry, bytesRef)) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                Config config = Config.parse(parser);
+                assertNull(config.tenantId());
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Backports 72ce8dbbf8566bff6f152e6cf328f369c09d875f from #1096