### PR TITLE
Use java-agent Gradle plugin to support phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.yaml-rest-test'
 apply plugin: 'opensearch.pluginzip'
+apply plugin: 'opensearch.java-agent'
 // for formatting and license headers
 apply plugin: 'com.diffplug.spotless'
 apply from: 'formatter/formatting.gradle'


### PR DESCRIPTION
### Description
Since the PR https://github.com/opensearch-project/OpenSearch/pull/17900 is now merged we can just apply the gradle plugin, closing https://github.com/opensearch-project/flow-framework/pull/1105.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
