### PR TITLE
replace deprecated space-assignment syntax for Gradle 8.x+ compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,10 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        maven { url = "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
-        maven { url 'https://jitpack.io' }
+        maven { url = "https://plugins.gradle.org/m2/" }
+        maven { url = 'https://jitpack.io' }
     }
 
     dependencies {
@@ -79,11 +79,11 @@ def pluginClassName = 'FlowFrameworkPlugin'
 group = "org.opensearch.flowframework"
 
 opensearchplugin {
-    name pluginName
-    description pluginDescription
-    classname "${projectPath}.${pathToPlugin}.${pluginClassName}"
-    licenseFile rootProject.file('LICENSE')
-    noticeFile rootProject.file('NOTICE')
+    name = pluginName
+    description = pluginDescription
+    classname = "${projectPath}.${pathToPlugin}.${pluginClassName}"
+    licenseFile = rootProject.file('LICENSE')
+    noticeFile = rootProject.file('NOTICE')
 }
 
 dependencyLicenses.enabled = false
@@ -137,8 +137,8 @@ publishing {
             name = "Snapshots"
             url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
             credentials {
-                username "$System.env.SONATYPE_USERNAME"
-                password "$System.env.SONATYPE_PASSWORD"
+                username = "$System.env.SONATYPE_USERNAME"
+                password = "$System.env.SONATYPE_PASSWORD"
             }
         }
     }
@@ -156,9 +156,9 @@ java {
 
 repositories {
     mavenLocal()
-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+    maven { url = "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
-    maven { url "https://plugins.gradle.org/m2/" }
+    maven { url = "https://plugins.gradle.org/m2/" }
 }
 
 configurations {
@@ -167,46 +167,47 @@ configurations {
 }
 
 dependencies {
-    implementation "org.opensearch:opensearch:${opensearch_version}"
-    api group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
-    api(group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${opensearch_version}") {
+    implementation("org.opensearch:opensearch:${opensearch_version}")
+    api("org.opensearch:opensearch-ml-client:${opensearch_build}")
+    api("org.opensearch.client:opensearch-rest-client:${opensearch_version}") {
         exclude group: "org.apache.httpcomponents.client5", module: "httpclient5"
     }
-    implementation "org.apache.commons:commons-lang3:${versions.commonslang}"
-    implementation "org.opensearch:common-utils:${common_utils_version}"
-    implementation "com.amazonaws:aws-encryption-sdk-java:3.0.1"
-    implementation "software.amazon.cryptography:aws-cryptographic-material-providers:1.9.0"
-    implementation "org.dafny:DafnyRuntime:4.10.0"
-    implementation "software.amazon.smithy.dafny:conversion:0.1.1"
-    // needed by aws-encryption-sdk-java
-    implementation "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
-    api "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
-    implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
-    implementation "org.glassfish:jakarta.json:2.0.1"
-    implementation "org.eclipse:yasson:3.0.4"
-    implementation "com.google.code.gson:gson:2.12.1"
+    implementation("org.apache.commons:commons-lang3:${versions.commonslang}")
+    implementation("org.opensearch:common-utils:${common_utils_version}")
+    implementation("com.amazonaws:aws-encryption-sdk-java:3.0.1")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.9.0")
+    implementation("org.dafny:DafnyRuntime:4.10.0")
+    implementation("software.amazon.smithy.dafny:conversion:0.1.1")
+    implementation("org.bouncycastle:bc-fips:${versions.bouncycastle_jce}")
+    api("org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}")
+    implementation("jakarta.json.bind:jakarta.json.bind-api:3.0.1")
+    implementation("org.glassfish:jakarta.json:2.0.1")
+    implementation("org.eclipse:yasson:3.0.4")
+    implementation("com.google.code.gson:gson:2.12.1")
+
     // Swagger-Parser dependencies for API consistency tests
-    implementation "io.swagger.core.v3:swagger-models:${swaggerCoreVersion}"
-    implementation "io.swagger.core.v3:swagger-core:${swaggerCoreVersion}"
-    implementation "io.swagger.parser.v3:swagger-parser-core:${swaggerVersion}"
-    implementation "io.swagger.parser.v3:swagger-parser:${swaggerVersion}"
-    implementation "io.swagger.parser.v3:swagger-parser-v3:${swaggerVersion}"
+    implementation("io.swagger.core.v3:swagger-models:${swaggerCoreVersion}")
+    implementation("io.swagger.core.v3:swagger-core:${swaggerCoreVersion}")
+    implementation("io.swagger.parser.v3:swagger-parser-core:${swaggerVersion}")
+    implementation("io.swagger.parser.v3:swagger-parser:${swaggerVersion}")
+    implementation("io.swagger.parser.v3:swagger-parser-v3:${swaggerVersion}")
+
     // Multi-tenant SDK Client
-    implementation ("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}") {
+    implementation("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}") {
         exclude group: "org.apache.httpcomponents.client5", module: "httpclient5"
     }
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.12.1'
-    testImplementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
-    testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}"
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.12.1")
+    testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
+    testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}")
 
     // ZipArchive dependencies used for integration tests
-    // Check the order in case of transitive dependencies
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
-    zipArchive group: 'org.opensearch.plugin', name:'neural-search', version: "${opensearch_build}"
-    secureIntegTestPluginArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
+    zipArchive("org.opensearch.plugin:opensearch-job-scheduler:${opensearch_build}")
+    zipArchive("org.opensearch.plugin:opensearch-ml-plugin:${opensearch_build}")
+    zipArchive("org.opensearch.plugin:opensearch-knn:${opensearch_build}")
+    zipArchive("org.opensearch.plugin:neural-search:${opensearch_build}")
+    secureIntegTestPluginArchive("org.opensearch.plugin:opensearch-security:${opensearch_build}")
 
     configurations.all {
         resolutionStrategy {
@@ -214,6 +215,7 @@ dependencies {
         }
     }
 }
+
 
 
 def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absoluteFile


### PR DESCRIPTION
### Description

This PR removes all deprecated Groovy DSL space-assignment syntax to ensure compatibility with Gradle 10.

### Related Issues
Resolves #1061

- Replaced all usages of deprecated space-assignment syntax in the `dependencies` block
- Ensured consistency and readability by using the `propertyName(...)` style throughout
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
