### PR TITLE
Make thread pool sizes configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,11 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased 3.x](https://github.com/opensearch-project/flow-framework/compare/3.0...HEAD)
+## [Unreleased 3.1](https://github.com/opensearch-project/flow-framework/compare/3.0...HEAD)
 ### Features
 ### Enhancements
-### Bug Fixes
-### Infrastructure
-### Documentation
-### Maintenance
-### Refactoring
+- Make thread pool sizes configurable ([#1139](https://github.com/opensearch-project/flow-framework/issues/1139))
 
-## [Unreleased 2.x](https://github.com/opensearch-project/flow-framework/compare/2.18...2.x)
-### Features
-### Enhancements
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
@@ -110,7 +110,7 @@ public class FlowFrameworkPluginTests extends OpenSearchTestCase {
             assertEquals(9, ffp.getRestHandlers(settings, null, null, null, null, null, null).size());
             assertEquals(10, ffp.getActions().size());
             assertEquals(3, ffp.getExecutorBuilders(settings).size());
-            assertEquals(13, ffp.getSettings().size());
+            assertEquals(16, ffp.getSettings().size());
 
             Collection<SystemIndexDescriptor> systemIndexDescriptors = ffp.getSystemIndexDescriptors(Settings.EMPTY);
             assertEquals(3, systemIndexDescriptors.size());

--- a/src/test/java/org/opensearch/flowframework/common/FlowFrameworkSettingsTests.java
+++ b/src/test/java/org/opensearch/flowframework/common/FlowFrameworkSettingsTests.java
@@ -45,7 +45,10 @@ public class FlowFrameworkSettingsTests extends OpenSearchTestCase {
                 FlowFrameworkSettings.MAX_WORKFLOWS,
                 FlowFrameworkSettings.WORKFLOW_REQUEST_TIMEOUT,
                 FlowFrameworkSettings.FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED,
+                FlowFrameworkSettings.WORKFLOW_THREAD_POOL_SIZE,
+                FlowFrameworkSettings.PROVISION_THREAD_POOL_SIZE,
                 FlowFrameworkSettings.MAX_ACTIVE_PROVISIONS_PER_TENANT,
+                FlowFrameworkSettings.DEPROVISION_THREAD_POOL_SIZE,
                 FlowFrameworkSettings.MAX_ACTIVE_DEPROVISIONS_PER_TENANT
             )
         ).collect(Collectors.toSet());
@@ -67,7 +70,10 @@ public class FlowFrameworkSettingsTests extends OpenSearchTestCase {
         assertEquals(Optional.of(1000), Optional.ofNullable(flowFrameworkSettings.getMaxWorkflows()));
         assertEquals(Optional.of(TimeValue.timeValueSeconds(10)), Optional.ofNullable(flowFrameworkSettings.getRequestTimeout()));
         assertFalse(flowFrameworkSettings.isMultiTenancyEnabled());
+        assertEquals(Optional.of(4), Optional.ofNullable(flowFrameworkSettings.getWorkflowThreadPoolSize()));
+        assertEquals(Optional.of(8), Optional.ofNullable(flowFrameworkSettings.getProvisionThreadPoolSize()));
         assertEquals(Optional.of(2), Optional.ofNullable(flowFrameworkSettings.getMaxActiveProvisionsPerTenant()));
+        assertEquals(Optional.of(4), Optional.ofNullable(flowFrameworkSettings.getDeprovisionThreadPoolSize()));
         assertEquals(Optional.of(1), Optional.ofNullable(flowFrameworkSettings.getMaxActiveDeprovisionsPerTenant()));
     }
 }


### PR DESCRIPTION
### Description

Allows configuration of thread pool sizes at startup using a static setting.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).
  - https://github.com/opensearch-project/documentation-website/pull/9881

Reviewers please provide tech review of above doc PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
