### PR TITLE
Conditionally include ddb-client dependency only if env variable set 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,6 +107,9 @@ jobs:
         java: [21]
     name: Tenant Aware Integ Test JDK${{ matrix.java }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      # doesn't actually use this client but validates the build
+      REMOTE_METADATA_SDK_IMPL: ddb-client
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased 3.1](https://github.com/opensearch-project/flow-framework/compare/3.0...HEAD)
+## [Unreleased 3.x](https://github.com/opensearch-project/flow-framework/compare/3.0...HEAD)
 ### Features
 ### Enhancements
 - Make thread pool sizes configurable ([#1139](https://github.com/opensearch-project/flow-framework/issues/1139))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased 3.x](https://github.com/opensearch-project/flow-framework/compare/3.0...HEAD)
+## [Unreleased 3.1](https://github.com/opensearch-project/flow-framework/compare/3.0...HEAD)
 ### Features
 ### Enhancements
 - Make thread pool sizes configurable ([#1139](https://github.com/opensearch-project/flow-framework/issues/1139))
 
 ### Bug Fixes
 ### Infrastructure
+- Conditionally include ddb-client dependency only if env variable set ([#1141](https://github.com/opensearch-project/flow-framework/issues/1141))
+
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,18 @@ buildscript {
         bwcFlowFrameworkPath = bwcFilePath + "flowframework/"
 
         isSameMajorVersion = opensearch_version.split("\\.")[0] == bwcVersionShort.split("\\.")[0]
+
+        // Version constants for dependencies
+        awsEncryptionSdkVersion = "3.0.1"
+        awsCryptoMaterialProvidersVersion = "1.10.1"
+        dafnyRuntimeVersion = "4.10.0"
+        smithyDafnyVersion = "0.1.1"
+        gsonVersion = "2.13.1"
+        junitJupiterVersion = "5.12.2"
+        jakartaJsonBindVersion = "3.0.1"
+        jakartaJsonVersion = "2.0.1"
+        yassonVersion = "3.0.4"
+        parssonVersion = "1.1.7"
         swaggerVersion = "2.1.28"
         swaggerCoreVersion = "2.2.32"
     }
@@ -181,16 +193,16 @@ dependencies {
     }
     implementation("org.apache.commons:commons-lang3:${versions.commonslang}")
     implementation("org.opensearch:common-utils:${common_utils_version}")
-    implementation("com.amazonaws:aws-encryption-sdk-java:3.0.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.10.1")
-    implementation("org.dafny:DafnyRuntime:4.10.0")
-    implementation("software.amazon.smithy.dafny:conversion:0.1.1")
+    implementation("com.amazonaws:aws-encryption-sdk-java:${awsEncryptionSdkVersion}")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${awsCryptoMaterialProvidersVersion}")
+    implementation("org.dafny:DafnyRuntime:${dafnyRuntimeVersion}")
+    implementation("software.amazon.smithy.dafny:conversion:${smithyDafnyVersion}")
     implementation("org.bouncycastle:bc-fips:${versions.bouncycastle_jce}")
     api("org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}")
-    implementation("jakarta.json.bind:jakarta.json.bind-api:3.0.1")
-    implementation("org.glassfish:jakarta.json:2.0.1")
-    implementation("org.eclipse:yasson:3.0.4")
-    implementation("com.google.code.gson:gson:2.13.1")
+    implementation("jakarta.json.bind:jakarta.json.bind-api:${jakartaJsonBindVersion}")
+    implementation("org.glassfish:jakarta.json:${jakartaJsonVersion}")
+    implementation("org.eclipse:yasson:${yassonVersion}")
+    implementation("com.google.code.gson:gson:${gsonVersion}")
 
     // Swagger-Parser dependencies for API consistency tests
     implementation("io.swagger.core.v3:swagger-models:${swaggerCoreVersion}")
@@ -200,11 +212,12 @@ dependencies {
     implementation("io.swagger.parser.v3:swagger-parser-v3:${swaggerVersion}")
 
     // Multi-tenant SDK Client
-    implementation("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}") {
-        exclude group: "org.apache.httpcomponents.client5", module: "httpclient5"
+    api("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}")
+    implementation("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}") {
+        exclude group: "jakarta.json", module: "jakarta.json-api"
     }
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:${junitJupiterVersion}")
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}")
@@ -218,12 +231,31 @@ dependencies {
 
     configurations.all {
         resolutionStrategy {
-            force("com.google.guava:guava:33.4.8-jre") // CVE for 31.1, keep to force transitive dependencies
+            force("com.google.guava:guava:${versions.guava}")
+
+            // Jackson dependencies
+            force("com.fasterxml.jackson.core:jackson-core:${versions.jackson}")
+            force("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
+            force("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+            force("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}")
+
+            // OpenSearch client dependencies
+            force("org.opensearch.client:opensearch-rest-client:${opensearch_version}")
+
+            // Jakarta and Eclipse dependencies
+            force("jakarta.json.bind:jakarta.json.bind-api:${jakartaJsonBindVersion}")
+            force("org.eclipse:yasson:${yassonVersion}")
+            force("org.eclipse.parsson:parsson:${parssonVersion}")
+            force("org.glassfish:jakarta.json:${jakartaJsonVersion}")
+
+            // Apache and Commons dependencies
+            force("org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}")
+            force("org.apache.httpcomponents:httpcore:${httpcoreVersion}")
+            force("commons-codec:commons-codec:${commonsCodecVersion}")
+            force("commons-logging:commons-logging:${commonsLoggingVersion}")
         }
     }
 }
-
-
 
 def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absoluteFile
 opensearch_tmp_dir.mkdirs()

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ buildscript {
         opensearch_no_snapshot = opensearch_build.replace("-SNAPSHOT","")
         System.setProperty('tests.security.manager', 'false')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
-        swaggerCoreVersion = "2.2.23"
         bwcVersionShort = "2.12.0"
         bwcVersion = bwcVersionShort + ".0"
         bwcOpenSearchFFDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + bwcVersionShort + '/latest/linux/x64/tar/builds/' +
@@ -253,10 +252,10 @@ dependencies {
             force("org.glassfish:jakarta.json:${jakartaJsonVersion}")
 
             // Apache and Commons dependencies
-            force("org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}")
-            force("org.apache.httpcomponents:httpcore:${httpcoreVersion}")
-            force("commons-codec:commons-codec:${commonsCodecVersion}")
-            force("commons-logging:commons-logging:${commonsLoggingVersion}")
+            force("org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}")
+            force("org.apache.httpcomponents:httpcore:${versions.httpcore}")
+            force("commons-codec:commons-codec:${versions.commonscodec}")
+            force("commons-logging:commons-logging:${versions.commonslogging}")
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -212,9 +212,13 @@ dependencies {
     implementation("io.swagger.parser.v3:swagger-parser-v3:${swaggerVersion}")
 
     // Multi-tenant SDK Client
-    api("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}")
-    implementation("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}") {
-        exclude group: "jakarta.json", module: "jakarta.json-api"
+    if (System.getenv('REMOTE_METADATA_SDK_IMPL') == 'ddb-client') {
+        api("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}")
+        implementation("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}") {
+            exclude group: "jakarta.json", module: "jakarta.json-api"
+        }
+    } else {
+        implementation("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}")
     }
 
     testImplementation("org.junit.jupiter:junit-jupiter:${junitJupiterVersion}")

--- a/build.gradle
+++ b/build.gradle
@@ -234,28 +234,33 @@ dependencies {
 
     configurations.all {
         resolutionStrategy {
+            // Some other plugin dependencies that don't use version catalog conflict here
             force("com.google.guava:guava:${versions.guava}")
 
-            // Jackson dependencies
-            force("com.fasterxml.jackson.core:jackson-core:${versions.jackson}")
-            force("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
-            force("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
-            force("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}")
+            if (System.getenv('REMOTE_METADATA_SDK_IMPL') == 'ddb-client') {
+                // OpenSearch Java client brings in different versions of the below dependencies.
+                // Needed for runtime in SDK but conflict with OpenSearch 3.x test dependencies.
+                // Jackson dependencies
+                force("com.fasterxml.jackson.core:jackson-core:${versions.jackson}")
+                force("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
+                force("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+                force("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}")
 
-            // OpenSearch client dependencies
-            force("org.opensearch.client:opensearch-rest-client:${opensearch_version}")
+                // OpenSearch client dependencies
+                force("org.opensearch.client:opensearch-rest-client:${opensearch_version}")
 
-            // Jakarta and Eclipse dependencies
-            force("jakarta.json.bind:jakarta.json.bind-api:${jakartaJsonBindVersion}")
-            force("org.eclipse:yasson:${yassonVersion}")
-            force("org.eclipse.parsson:parsson:${parssonVersion}")
-            force("org.glassfish:jakarta.json:${jakartaJsonVersion}")
+                // Jakarta and Eclipse dependencies
+                force("jakarta.json.bind:jakarta.json.bind-api:${jakartaJsonBindVersion}")
+                force("org.eclipse:yasson:${yassonVersion}")
+                force("org.eclipse.parsson:parsson:${parssonVersion}")
+                force("org.glassfish:jakarta.json:${jakartaJsonVersion}")
 
-            // Apache and Commons dependencies
-            force("org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}")
-            force("org.apache.httpcomponents:httpcore:${versions.httpcore}")
-            force("commons-codec:commons-codec:${versions.commonscodec}")
-            force("commons-logging:commons-logging:${versions.commonslogging}")
+                // Apache and Commons dependencies
+                force("org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}")
+                force("org.apache.httpcomponents:httpcore:${versions.httpcore}")
+                force("commons-codec:commons-codec:${versions.commonscodec}")
+                force("commons-logging:commons-logging:${versions.commonslogging}")
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

Adds a configuration to include the remote metadata ddb-client dependency if an environment variable is set.

Allows build-time inclusion of the dependency in locations where it is required, and doesn't include extra dependencies in other cases.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
