### PR TITLE
Fixing llm field processing in RegisterAgentStep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Make thread pool sizes configurable ([#1139](https://github.com/opensearch-project/flow-framework/issues/1139))
 
 ### Bug Fixes
+- Fixing llm field processing in RegisterAgentStep ([#1151](https://github.com/opensearch-project/flow-framework/pull/1151))
+
 ### Infrastructure
 - Conditionally include ddb-client dependency only if env variable set ([#1141](https://github.com/opensearch-project/flow-framework/issues/1141))
 

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -180,6 +180,8 @@ public class CommonValue {
     public static final String PIPELINE_ID = "pipeline_id";
     /** Pipeline Configurations */
     public static final String CONFIGURATIONS = "configurations";
+    /** The llm field */
+    public static final String LLM = "llm";
     /** Guardrails field */
     public static final String GUARDRAILS_FIELD = "guardrails";
     /** Delay field */

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
@@ -36,6 +36,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.flowframework.common.CommonValue.CONFIGURATIONS;
 import static org.opensearch.flowframework.common.CommonValue.GUARDRAILS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.LLM;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_ORDER_FIELD;
 import static org.opensearch.flowframework.util.ParseUtils.buildStringToObjectMap;
 import static org.opensearch.flowframework.util.ParseUtils.buildStringToStringMap;
@@ -166,23 +167,27 @@ public class WorkflowNode implements ToXContentObject {
                                 if (GUARDRAILS_FIELD.equals(inputFieldName)) {
                                     userInputs.put(inputFieldName, Guardrails.parse(parser));
                                     break;
-                                } else if (CONFIGURATIONS.equals(inputFieldName) || INTERFACE_FIELD.equals(inputFieldName)) {
-                                    Map<String, Object> configurationsMap = parser.map();
-                                    try {
-                                        String configurationsString = ParseUtils.parseArbitraryStringToObjectMapToString(configurationsMap);
-                                        userInputs.put(inputFieldName, configurationsString);
-                                    } catch (Exception ex) {
-                                        String errorMessage = ParameterizedMessageFactory.INSTANCE.newMessage(
-                                            "Failed to parse {} map",
-                                            inputFieldName
-                                        ).getFormattedMessage();
-                                        logger.error(errorMessage, ex);
-                                        throw new FlowFrameworkException(errorMessage, RestStatus.BAD_REQUEST);
+                                } else if (CONFIGURATIONS.equals(inputFieldName)
+                                    || INTERFACE_FIELD.equals(inputFieldName)
+                                    || LLM.equals(inputFieldName)) {
+                                        Map<String, Object> configurationsMap = parser.map();
+                                        try {
+                                            String configurationsString = ParseUtils.parseArbitraryStringToObjectMapToString(
+                                                configurationsMap
+                                            );
+                                            userInputs.put(inputFieldName, configurationsString);
+                                        } catch (Exception ex) {
+                                            String errorMessage = ParameterizedMessageFactory.INSTANCE.newMessage(
+                                                "Failed to parse {} map",
+                                                inputFieldName
+                                            ).getFormattedMessage();
+                                            logger.error(errorMessage, ex);
+                                            throw new FlowFrameworkException(errorMessage, RestStatus.BAD_REQUEST);
+                                        }
+                                        break;
+                                    } else {
+                                        userInputs.put(inputFieldName, parseStringToStringMap(parser));
                                     }
-                                    break;
-                                } else {
-                                    userInputs.put(inputFieldName, parseStringToStringMap(parser));
-                                }
                                 break;
                             case START_ARRAY:
                                 if (PROCESSORS_FIELD.equals(inputFieldName)) {

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -55,7 +55,6 @@ import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_ORDER_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TYPE;
-import static org.opensearch.flowframework.common.WorkflowResources.MODEL_ID;
 import static org.opensearch.flowframework.exception.WorkflowStepException.getSafeException;
 import static org.opensearch.flowframework.util.ParseUtils.getStringToStringMap;
 
@@ -170,7 +169,7 @@ public class RegisterAgentStep implements WorkflowStep {
                     Object llmParams = llmFieldMap.get(PARAMETERS_FIELD);
 
                     if (llmParams != null) {
-                        llmParameters.putAll(getStringToStringMap(llmParams, PARAMETERS_FIELD));
+                        validateLLMParametersMap(llmParams);
                     }
                 } catch (IllegalArgumentException ex) {
                     String errorMessage = "Failed to parse llm field: " + ex.getMessage();
@@ -310,5 +309,18 @@ public class RegisterAgentStep implements WorkflowStep {
     private Map<String, Object> getParseFieldMap(String llmFieldMapString) throws OpenSearchParseException {
         BytesReference llmFieldBytes = new BytesArray(llmFieldMapString.getBytes(StandardCharsets.UTF_8));
         return XContentHelper.convertToMap(llmFieldBytes, false, MediaTypeRegistry.JSON).v2();
+    }
+
+    private void validateLLMParametersMap(Object llmParams) {
+        String errorMessage = "llm field [" + PARAMETERS_FIELD + "] must be a string to string map";
+        if (!(llmParams instanceof Map)) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+        Map<String, Object> llmParamsMap = (Map<String, Object>) llmParams;
+        for (Map.Entry<String, Object> entry : llmParamsMap.entrySet()) {
+            if (!(entry.getValue() instanceof String)) {
+                throw new IllegalArgumentException(errorMessage);
+            }
+        }
     }
 }

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -174,7 +174,7 @@ public class RegisterAgentStep implements WorkflowStep {
                         llmParameters.putAll(getStringToStringMap(llmParams, PARAMETERS_FIELD));
                     }
                 } catch (Exception ex) {
-                    String errorMessage = "Failed to create llm configuration";
+                    String errorMessage = "Invalid llm field format";
                     logger.error(errorMessage, ex);
                     registerAgentModelFuture.onFailure(new WorkflowStepException(errorMessage, RestStatus.BAD_REQUEST));
                 }

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -163,10 +163,8 @@ public class RegisterAgentStep implements WorkflowStep {
             Map<String, String> llmParameters = new HashMap<>();
             if (llmField != null) {
                 try {
-                    // Convert model interface string to map
-                    BytesReference llmFieldBytes = new BytesArray(llmField.getBytes(StandardCharsets.UTF_8));
-                    Map<String, Object> llmFieldMap = XContentHelper.convertToMap(llmFieldBytes, false, MediaTypeRegistry.JSON).v2();
-
+                    // Convert llm field string to map
+                    Map<String, Object> llmFieldMap = getLLMFieldMap(llmField);
                     llmModelId = (String) llmFieldMap.get(MODEL_ID);
                     Object llmParams = llmFieldMap.get(PARAMETERS_FIELD);
 
@@ -174,7 +172,7 @@ public class RegisterAgentStep implements WorkflowStep {
                         llmParameters.putAll(getStringToStringMap(llmParams, PARAMETERS_FIELD));
                     }
                 } catch (Exception ex) {
-                    String errorMessage = "Invalid llm field format";
+                    String errorMessage = "Invalid register agent llm field format";
                     logger.error(errorMessage, ex);
                     registerAgentModelFuture.onFailure(new WorkflowStepException(errorMessage, RestStatus.BAD_REQUEST));
                 }
@@ -305,5 +303,10 @@ public class RegisterAgentStep implements WorkflowStep {
         }
 
         return builder.build();
+    }
+
+    private Map<String, Object> getLLMFieldMap(String llmFieldMapString) {
+        BytesReference llmFieldBytes = new BytesArray(llmFieldMapString.getBytes(StandardCharsets.UTF_8));
+        return XContentHelper.convertToMap(llmFieldBytes, false, MediaTypeRegistry.JSON).v2();
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -14,6 +14,7 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ApiSpecFetcher;
+import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.agent.LLMSpec;
@@ -73,13 +74,14 @@ public class RegisterAgentTests extends OpenSearchTestCase {
             Map.entry(MLMemorySpec.WINDOW_SIZE_FIELD, 2)
         );
 
+        Map<String, Object> llmFieldMap = Map.ofEntries(Map.entry("model_id", "xyz"), Map.entry("parameters", Collections.emptyMap()));
+
         inputData = new WorkflowData(
             Map.ofEntries(
                 Map.entry("name", "test"),
                 Map.entry("description", "description"),
                 Map.entry("type", MLAgentType.FLOW.name()),
-                Map.entry("llm.model_id", "xyz"),
-                Map.entry("llm.parameters", Collections.emptyMap()),
+                Map.entry("llm", ParseUtils.parseArbitraryStringToObjectMapToString(llmFieldMap)),
                 Map.entry("tools", tools),
                 Map.entry("tools_order", new String[] { "abc", "xyz" }),
                 Map.entry("parameters", Collections.emptyMap()),

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.flowframework.workflow;
 
-import org.opensearch.OpenSearchParseException;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;

--- a/src/test/resources/template/agent-framework.json
+++ b/src/test/resources/template/agent-framework.json
@@ -104,10 +104,12 @@
             "parameters": {
               "hello": "world"
             },
-            "llm.model_id": "ldzS04kBxRPZ5cnWrqpd",
-            "llm.parameters": {
-              "max_iteration": "5",
-              "stop_when_no_tool_found": "true"
+            "llm" : {
+              "model_id": "ldzS04kBxRPZ5cnWrqpd",
+              "parameters": {
+                "max_iteration": "5",
+                "stop_when_no_tool_found": "true"
+              }
             },
             "memory": {
               "type": "conversation_index"
@@ -147,9 +149,11 @@
             "parameters": {
               "hello": "world"
             },
-            "llm.parameters": {
-              "max_iteration": "5",
-              "stop_when_no_tool_found": "true"
+            "llm" : {
+              "parameters": {
+                "max_iteration": "5",
+                "stop_when_no_tool_found": "true"
+              }
             },
             "memory": {
               "type": "conversation_index"


### PR DESCRIPTION
### Description
Resolves llm field input processing for the RegisterAgentStep. Current behavior fails when a model ID is provided, the following json is an example input for the llm field :
```
"llm": {
    "model_id": "<model_id>",
    "parameters": {
      "max_iteration": 5,
      "system_instruction": "You are a helpful assistant.",
      "prompt": "${parameters.question}"
    }
```

### Related Issues
n/a

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
