### PR TITLE
Include exception type in WorkflowState error field even if no cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Bug Fixes
 - Fixing llm field processing in RegisterAgentStep ([#1151](https://github.com/opensearch-project/flow-framework/pull/1151))
+- Include exception type in WorkflowState error field even if no cause ([#1154](https://github.com/opensearch-project/flow-framework/pull/1154))
 - Pass llm spec params to builder ([#1155](https://github.com/opensearch-project/flow-framework/pull/1155))
 
 ### Infrastructure

--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -447,15 +447,20 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
             );
         } catch (Exception ex) {
             RestStatus status;
+            String message;
             if (ex instanceof FlowFrameworkException) {
                 status = ((FlowFrameworkException) ex).getRestStatus();
+                message = ", " + ex.getMessage();
             } else {
                 status = ExceptionsHelper.status(ex);
+                message = "";
             }
             logger.error("Provisioning failed for workflow {} during step {}.", workflowId, currentStepId, ex);
-            String errorMessage = (ex.getCause() == null ? ex.getMessage() : ex.getCause().getClass().getName())
+            Throwable cause = ex.getCause() == null ? ex : ex.getCause();
+            String errorMessage = cause.getClass().getSimpleName()
                 + " during step "
                 + currentStepId
+                + message
                 + ", restStatus: "
                 + status.toString();
             flowFrameworkIndicesHandler.updateFlowFrameworkSystemIndexDoc(


### PR DESCRIPTION
### Description

Always prepends the exception type to Workflow State error field.

### Related Issues

Fixes #1153

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
