### PR TITLE
Pass llm spec params to builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Bug Fixes
 - Fixing llm field processing in RegisterAgentStep ([#1151](https://github.com/opensearch-project/flow-framework/pull/1151))
+- Pass llm spec params to builder ([#1155](https://github.com/opensearch-project/flow-framework/pull/1155))
 
 ### Infrastructure
 - Conditionally include ddb-client dependency only if env variable set ([#1141](https://github.com/opensearch-project/flow-framework/issues/1141))

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -170,6 +170,7 @@ public class RegisterAgentStep implements WorkflowStep {
 
                     if (llmParams != null) {
                         validateLLMParametersMap(llmParams);
+                        llmParameters.putAll((Map<String, String>) llmParams);
                     }
                 } catch (IllegalArgumentException ex) {
                     String errorMessage = "Failed to parse llm field: " + ex.getMessage();


### PR DESCRIPTION
### Description
Fixing bug where LLM spec parameters arent passed to the LLM Spec builder in RegisterAgentStep

### Related Issues
n/a

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
