### PR TITLE
Only run Daily API Consistency Test on opensearch-project repo

### DIFF
--- a/.github/workflows/test-api-consistency.yml
+++ b/.github/workflows/test-api-consistency.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   API-consistency-test:
+    if: github.repository == 'opensearch-project/flow-framework'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
### Description

Stops running the daily API workflow on forks.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
