### PR TITLE
Adding support for plan execute reflect agent type

### DIFF
--- a/src/test/resources/template/plan-execute-reflect-agent.json
+++ b/src/test/resources/template/plan-execute-reflect-agent.json
@@ -1,0 +1,53 @@
+{
+    "name": "chatbot",
+    "use_case": "REGISTER_AGENT",
+    "description": "",
+    "version": {
+      "template": "1.0.0",
+      "compatibility": [
+        "3.0.0"
+      ]
+    },
+    "workflows": {
+      "provision": {
+        "nodes": [
+          {
+            "id": "plan_execute_and_reflect_agent",
+            "type": "register_agent",
+            "previous_node_inputs": {},
+            "user_inputs": {
+              "name": "default_agent",
+              "type": "plan_execute_and_reflect",
+              "description": "",
+              "llm": {
+                "model_id": "J7DfGJcBjIjt_6rk_MOd",
+                "parameters": {
+                  "test": "test"
+                }
+              },
+              "memory": {
+                "type": "conversation_index"
+              },
+              "parameters": {
+                "_llm_interface": "YOUR_LLM_INTERFACE"
+              },
+              "tools": [
+                {
+                  "type": "ListIndexTool"
+                },
+                {
+                  "type": "SearchIndexTool"
+                },
+                {
+                  "type": "IndexMappingTool"
+                }
+              ],
+              "app_type": "os_chat"
+            }
+          }
+        ],
+        "edges": [],
+        "user_params": {}
+      }
+    }
+  }


### PR DESCRIPTION
### Description
Modifies `RegisterAgentStep` tools processing to support tools format for plan_execute_reflect agent type

### Related Issues
Resolves #1158 

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
