### PR TITLE
Updating local pretrained model version to fix integration test

### DIFF
--- a/src/main/resources/defaults/hybrid-search-with-local-model-defaults.json
+++ b/src/main/resources/defaults/hybrid-search-with-local-model-defaults.json
@@ -5,7 +5,7 @@
   "register_local_pretrained_model.description": "This is a sentence transformer model",
   "register_local_pretrained_model.model_format": "TORCH_SCRIPT",
   "register_local_pretrained_model.deploy": "true",
-  "register_local_pretrained_model.version": "1.0.1",
+  "register_local_pretrained_model.version": "1.0.2",
   "create_ingest_pipeline.pipeline_id": "nlp-ingest-pipeline",
   "create_ingest_pipeline.description": "A text embedding pipeline",
   "create_ingest_pipeline.model_id": "123",

--- a/src/main/resources/defaults/semantic-search-with-local-model-defaults.json
+++ b/src/main/resources/defaults/semantic-search-with-local-model-defaults.json
@@ -5,7 +5,7 @@
   "register_local_pretrained_model.description": "This is a sentence transformer model",
   "register_local_pretrained_model.model_format": "TORCH_SCRIPT",
   "register_local_pretrained_model.deploy": "true",
-  "register_local_pretrained_model.version": "1.0.1",
+  "register_local_pretrained_model.version": "1.0.2",
   "create_ingest_pipeline.pipeline_id": "nlp-ingest-pipeline",
   "create_ingest_pipeline.description": "A text embedding pipeline",
   "text_embedding.field_map.input": "passage_text",

--- a/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/FlowFrameworkRestApiIT.java
@@ -820,7 +820,7 @@ public class FlowFrameworkRestApiIT extends FlowFrameworkRestTestCase {
         }
         Map<String, Object> defaults = new HashMap<>();
         defaults.put("register_local_pretrained_model.name", "huggingface/sentence-transformers/all-MiniLM-L6-v2");
-        defaults.put("register_local_pretrained_model.version", "1.0.1");
+        defaults.put("register_local_pretrained_model.version", "1.0.2");
         defaults.put("text_embedding.field_map.output.dimension", 384);
 
         Response response = createAndProvisionWorkflowWithUseCaseWithContent(client(), "semantic_search_with_local_model", defaults);


### PR DESCRIPTION
### Description
Updates end-to-end integration test local model version from `1.0.1` to `1.0.2`.

Based on https://docs.opensearch.org/docs/latest/ml-commons-plugin/pretrained-models/, seems that the hugging face model version has been updated from 1.0.1 to 1.0.2 as part of the 3.0.0 major release, invalidating the previous model used for our integration tests

### Related Issues
n/a

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
