### PR TITLE
feat(util): Add JsonToJson Recommender as a utility function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased 3.1](https://github.com/opensearch-project/flow-framework/compare/3.0...HEAD)
 ### Features
+
+- Add JsonToJson Recommender as a utility function ([#1167](https://github.com/opensearch-project/flow-framework/issues/1167))([#1168](https://github.com/opensearch-project/flow-framework/pull/1168))
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/build.gradle
+++ b/build.gradle
@@ -235,9 +235,11 @@ dependencies {
         implementation("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}")
     }
 
+    // Jackson dependencies
+    implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+    implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
+
     testImplementation("org.junit.jupiter:junit-jupiter:${junitJupiterVersion}")
-    testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
-    testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}")
 
     // ZipArchive dependencies used for integration tests

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -9,6 +9,7 @@
 package org.opensearch.flowframework.common;
 
 import org.opensearch.Version;
+import org.opensearch.common.xcontent.XContentContraints;
 
 /**
  * Representation of common values that are used across project
@@ -56,6 +57,12 @@ public class CommonValue {
     public static final String LAST_UPDATED_TIME_FIELD = "last_updated_time";
     /** The last provisioned time field */
     public static final String LAST_PROVISIONED_TIME_FIELD = "last_provisioned_time";
+    /** Maximum allowed JSON size in bytes (~50MB). */
+    public static final int MAX_JSON_SIZE = XContentContraints.DEFAULT_MAX_STRING_LEN; // 50000000
+    /** Maximum allowed name length for JSON keys(50000b). */
+    public static final int MAX_JSON_NAME_LENGTH = XContentContraints.DEFAULT_MAX_NAME_LEN; // 50000
+    /** Maximum allowed nesting depth for JSON structures. */
+    public static final int MAX_JSON_NESTING_DEPTH = XContentContraints.DEFAULT_MAX_DEPTH; // 1000
 
     /*
      * Constants associated with Rest or Transport actions

--- a/src/main/java/org/opensearch/flowframework/util/JsonToJsonRecommender.java
+++ b/src/main/java/org/opensearch/flowframework/util/JsonToJsonRecommender.java
@@ -1,0 +1,694 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.flowframework.common.CommonValue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for analyzing and mapping relationships between input and
+ * output JSON structures.
+ *
+ * Builds an inverted index from input JSON values to their paths, then uses
+ * output JSON values
+ * to find matching input paths, producing a mapping from input paths to output
+ * fields.
+ *
+ * Supports nested objects and arrays, and generates both detailed field
+ * mappings and generalized
+ * JSONPath transformation patterns.
+ *
+ * All methods are static and stateless. This class is thread-safe.
+ */
+public class JsonToJsonRecommender {
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     * All methods are static and should be accessed directly.
+     */
+    private JsonToJsonRecommender() {
+        // Utility class, not meant to be instantiated
+    }
+
+    /**
+     * ObjectMapper instance used for parsing JSON strings and formatting output.
+     */
+    private static final ObjectMapper MAPPER;
+    static {
+        StreamReadConstraints constraints = StreamReadConstraints.builder()
+            .maxNestingDepth(CommonValue.MAX_JSON_NESTING_DEPTH)
+            .maxStringLength(CommonValue.MAX_JSON_SIZE)
+            .maxNameLength(CommonValue.MAX_JSON_NAME_LENGTH)
+            .build();
+
+        MAPPER = new ObjectMapper();
+        MAPPER.getFactory().setStreamReadConstraints(constraints);
+    }
+
+    /**
+     * Generates mapping data with default settings.
+     * This method generates both detailed field mappings and generalized
+     * JSONPath transformation patterns.
+     *
+     * @param inputJson  Input JSON string to analyze
+     * @param outputJson Output JSON string to map against
+     * @return StringFormatResult containing transformation recommendations
+     * @throws IllegalArgumentException if input validation fails
+     * @throws JsonProcessingException  if JSON parsing fails
+     */
+    public static StringFormatResult getRecommendationInStringFormat(String inputJson, String outputJson) throws IllegalArgumentException,
+        JsonProcessingException {
+        // Input validation
+        validateInputStrings(inputJson, outputJson);
+
+        JsonNode inputNode = MAPPER.readTree(inputJson);
+        JsonNode outputNode = MAPPER.readTree(outputJson);
+
+        MapFormatResult result = getRecommendationInMapFormat(inputNode, outputNode, false);
+
+        String detailedJsonPathString = WriteMappedPathAsString(result.detailedJsonPath);
+        String generalizedJsonPathString = WriteMappedPathAsString(result.generalizedJsonPath);
+
+        return new StringFormatResult(detailedJsonPathString, generalizedJsonPathString);
+    }
+
+    /**
+     * Core method that generates mapping recommendations from JsonNode inputs.
+     * This is a convenience method that calls
+     * {@link #getRecommendationInMapFormat(JsonNode, JsonNode, boolean)}
+     * with needValidation set to true.
+     *
+     * @param inputNode  Input JSON node to analyze
+     * @param outputNode Output JSON node to map against
+     * @return MapFormatResult containing both detailed and generalized mappings
+     * @throws IllegalArgumentException if input validation fails
+     */
+    public static MapFormatResult getRecommendationInMapFormat(JsonNode inputNode, JsonNode outputNode) throws IllegalArgumentException {
+        return getRecommendationInMapFormat(inputNode, outputNode, true);
+    }
+
+    /**
+     * Core method that generates mapping recommendations from JsonNode inputs.
+     * This is the main internal method for getting transformation recommendations
+     * from input and output JSON structures.
+     *
+     * @param inputNode      Input JSON node to analyze
+     * @param outputNode     Output JSON node to map against
+     * @param needValidation If true, validates the nesting depth and key lengths of JsonNodes;
+     *                       otherwise skips validation
+     * @return MapFormatResult containing both detailed and generalized mappings as nested objects
+     * @throws IllegalArgumentException if input validation fails
+     */
+    public static MapFormatResult getRecommendationInMapFormat(JsonNode inputNode, JsonNode outputNode, boolean needValidation)
+        throws IllegalArgumentException {
+        if (needValidation) {
+            // Validate nesting depth and key length for both input and output nodes
+            validateInputJsonNode(inputNode, "Input JSON Node");
+            validateInputJsonNode(outputNode, "Output JSON Node");
+        }
+
+        Map<String, String> inputIndex = createInvertedIndex(inputNode);
+        return generateMappings(outputNode, inputIndex, "$");
+    }
+
+    /**
+     * Generates detailed field-to-field mappings for JsonNode inputs
+     *
+     * @param inputNode  Input JSON node to analyze
+     * @param outputNode Output JSON node to map against
+     * @return Detailed field-to-field mappings as a nested object structure
+     * @throws IllegalArgumentException if input validation fails
+     */
+    public static Map<String, Object> getRecommendationDetailedInMapFormat(JsonNode inputNode, JsonNode outputNode)
+        throws IllegalArgumentException {
+        return getRecommendationInMapFormat(inputNode, outputNode).detailedJsonPath;
+    }
+
+    /**
+     * Generates generalized JSONPath suggestions for JsonNode inputs
+     *
+     * @param inputNode  Input JSON node to analyze
+     * @param outputNode Output JSON node to map against
+     * @return Generalized JSONPath suggestions as a nested object structure
+     * @throws IllegalArgumentException if input validation fails
+     */
+    public static Map<String, Object> getRecommendationGeneralizedInMapFormat(JsonNode inputNode, JsonNode outputNode)
+        throws IllegalArgumentException {
+        return getRecommendationInMapFormat(inputNode, outputNode).generalizedJsonPath;
+    }
+
+    /**
+     * Writes a nested mapped path structure as a pretty JSON string.
+     *
+     * @param mappedPath The nested mapped path structure to write
+     * @return The mapped path as a pretty JSON string
+     * @throws JsonProcessingException if JSON processing fails
+     */
+    public static String WriteMappedPathAsString(Map<String, Object> mappedPath) throws JsonProcessingException {
+        return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(mappedPath);
+    }
+
+    /**
+     * Generates detailed field-to-field mappings for a given input and output JSON
+     *
+     * @param inputJson  Input JSON string to analyze
+     * @param outputJson Output JSON string to map against
+     * @return Detailed field-to-field mappings as a formatted JSON string
+     * @throws IllegalArgumentException if input validation fails
+     * @throws JsonProcessingException  if JSON parsing fails
+     */
+    public static String getRecommendationDetailedInStringFormat(String inputJson, String outputJson) throws IllegalArgumentException,
+        JsonProcessingException {
+        return getRecommendationInStringFormat(inputJson, outputJson).detailedJsonPathString;
+    }
+
+    /**
+     * Generates generalized JSONPath suggestions for a given input and output JSON
+     *
+     * @param inputJson  Input JSON string to analyze
+     * @param outputJson Output JSON string to map against
+     * @return Generalized JSONPath suggestions as a formatted JSON string
+     * @throws IllegalArgumentException if input validation fails
+     * @throws JsonProcessingException  if JSON parsing fails
+     */
+    public static String getRecommendationGeneralizedInStringFormat(String inputJson, String outputJson) throws IllegalArgumentException,
+        JsonProcessingException {
+        return getRecommendationInStringFormat(inputJson, outputJson).generalizedJsonPathString;
+    }
+
+    /**
+     * Validates input JSON strings for null values, empty strings, and size limits.
+     *
+     * @param inputJson  Input JSON string to validate
+     * @param outputJson Output JSON string to validate
+     * @throws IllegalArgumentException if validation fails
+     */
+    private static void validateInputStrings(String inputJson, String outputJson) throws IllegalArgumentException {
+        if (inputJson == null || outputJson == null) {
+            throw new IllegalArgumentException("Input and output JSON strings cannot be null");
+        }
+
+        if (inputJson.trim().isEmpty() || outputJson.trim().isEmpty()) {
+            throw new IllegalArgumentException("Input and output JSON strings cannot be empty");
+        }
+
+        // Check if JSON is empty map (ignoring whitespace)
+        String trimmedInputJson = inputJson.replaceAll("\\s", "");
+        String trimmedOutputJson = outputJson.replaceAll("\\s", "");
+
+        if ("{}".equals(trimmedInputJson) || "{}".equals(trimmedOutputJson)) {
+            throw new IllegalArgumentException("JSON cannot be an empty map");
+        }
+
+    }
+
+    /**
+     * Validates a JsonNode to ensure it doesn't exceed the maximum allowed depth
+     * and that all keys don't exceed the maximum allowed length (50000 characters).
+     *
+     * @param node     The JsonNode to validate
+     * @param nodeType A descriptive name for the node type (e.g., "Input JSON Node",
+     *                 "Output JSON Node")
+     * @throws IllegalArgumentException if the nesting depth or key length exceeds the maximum
+     *                                  limit
+     */
+    private static void validateInputJsonNode(JsonNode node, String nodeType) throws IllegalArgumentException {
+        if (node == null) {
+            throw new IllegalArgumentException(nodeType + " cannot be null");
+        }
+        // Validate nesting depth
+        int maxDepth = getJsonNodeNestingDepth(node);
+        if (maxDepth > CommonValue.MAX_JSON_NESTING_DEPTH) {
+            throw new IllegalArgumentException(
+                nodeType
+                    + " nesting depth ("
+                    + maxDepth
+                    + ") exceeds the maximum allowed depth ("
+                    + CommonValue.MAX_JSON_NESTING_DEPTH
+                    + ")"
+            );
+        }
+
+        // Validate key lengths
+        validateJsonNodeKeyLengths(node, nodeType);
+    }
+
+    /**
+     * Validates that all keys in a JsonNode don't exceed the maximum allowed length (50000 characters) and calculate the maximum nesting depth.
+     *
+     * @param node     The JsonNode to validate
+     * @param nodeType A descriptive name for the node type (e.g., "Input JSON Node",
+     *                 "Output JSON Node")
+     * @throws IllegalArgumentException if any key length exceeds the maximum limit (50000 characters)
+     */
+    private static void validateJsonNodeKeyLengths(JsonNode node, String nodeType) throws IllegalArgumentException {
+        if (node == null) {
+            return;
+        }
+
+        if (node.isObject()) {
+            var fields = node.fields();
+            while (fields.hasNext()) {
+                var entry = fields.next();
+                String key = entry.getKey();
+                if (key.length() > 50000) {
+                    throw new IllegalArgumentException(
+                        nodeType + " contains a key with length (" + key.length() + ") that exceeds the maximum allowed length (50000)"
+                    );
+                }
+                // Recursively validate nested objects
+                validateJsonNodeKeyLengths(entry.getValue(), nodeType);
+            }
+        } else if (node.isArray()) {
+            // Validate all array elements
+            for (JsonNode arrayElement : node) {
+                validateJsonNodeKeyLengths(arrayElement, nodeType);
+            }
+        }
+    }
+
+    /**
+     * Calculates the maximum nesting depth of a JsonNode.
+     *
+     * @param node The JsonNode to analyze
+     * @return The maximum nesting depth
+     */
+    private static int getJsonNodeNestingDepth(JsonNode node) {
+        if (node == null || node.isValueNode()) {
+            return 0;
+        }
+
+        int maxDepth = 0;
+        if (node.isObject()) {
+            var fields = node.fields();
+            while (fields.hasNext()) {
+                var entry = fields.next();
+                int childDepth = getJsonNodeNestingDepth(entry.getValue());
+                maxDepth = Math.max(maxDepth, childDepth);
+            }
+        } else if (node.isArray()) {
+            for (JsonNode arrayElement : node) {
+                int childDepth = getJsonNodeNestingDepth(arrayElement);
+                maxDepth = Math.max(maxDepth, childDepth);
+            }
+        }
+
+        return maxDepth + 1;
+    }
+
+    /**
+     * Builds an inverted index for a given JSON node.
+     * Each unique value is mapped to a single JSON path where it appears.
+     * For duplicate values, only the first occurrence path is stored.
+     *
+     * @param node The JSON node to process
+     * @return A map of values to their JSON paths
+     */
+    private static Map<String, String> createInvertedIndex(JsonNode node) {
+        Map<String, String> invertedIndex = new HashMap<>();
+        createIndexRecursive(node, "$", invertedIndex);
+        return invertedIndex;
+    }
+
+    /**
+     * Recursively traverses the JSON node to build the inverted index.
+     * This method handles objects, arrays, and primitive values differently to
+     * create comprehensive path mappings.
+     *
+     * @param node          The current JSON node being processed
+     * @param path          The JSON path leading to this node
+     * @param invertedIndex The inverted index to populate with value-to-path
+     *                      mappings
+     */
+    private static void createIndexRecursive(JsonNode node, String path, Map<String, String> invertedIndex) {
+        if (node.isObject()) {
+            // Process object properties recursively
+            var fields = node.fields();
+            while (fields.hasNext()) {
+                var entry = fields.next();
+                String newPath = path.isEmpty() ? entry.getKey() : path + "." + entry.getKey();
+                createIndexRecursive(entry.getValue(), newPath, invertedIndex);
+            }
+        } else if (node.isArray()) {
+            // Process each array element with indexed path
+            for (int i = 0; i < node.size(); i++) {
+                createIndexRecursive(node.get(i), path + "[" + i + "]", invertedIndex);
+            }
+        } else {
+            // Store primitive values with their paths
+            String value = node.asText();
+            invertedIndex.putIfAbsent(value, path); // Only store the first occurrence of a value
+        }
+    }
+
+    /**
+     * Generates output-to-input mappings by recursively traversing the output JSON
+     * node and correlating values with the input index. Creates both detailed and
+     * generalized mappings as nested object structures, with special handling for
+     * arrays to provide useful transformation patterns.
+     *
+     * @param outputNode The output JSON node to traverse
+     * @param inputIndex The inverted index of input JSON values to paths
+     * @param path       The current JSON path being processed (typically starts
+     *                   with "$")
+     * @return MapFormatResult containing detailed and generalized mappings as nested objects
+     */
+    private static MapFormatResult generateMappings(JsonNode outputNode, Map<String, String> inputIndex, String path) {
+        Map<String, String> detailed = new LinkedHashMap<>();
+        Map<String, String> generalized = new LinkedHashMap<>();
+
+        generateMappingsRecursive(outputNode, inputIndex, path, detailed, generalized);
+
+        return new MapFormatResult(toNestedMapping(detailed), toNestedMapping(generalized));
+    }
+
+    /**
+     * Recursively processes JSON nodes to build output-to-input mappings.
+     * Handles special array processing logic where array indices are generalized
+     * when elements have similar structures.
+     *
+     * @param node        The current JSON node being processed
+     * @param inputIndex  The inverted index of input JSON values to paths
+     * @param path        The current JSON path
+     * @param detailed    The detailed mapping accumulator
+     * @param generalized The generalized mapping accumulator
+     */
+    private static void generateMappingsRecursive(
+        JsonNode node,
+        Map<String, String> inputIndex,
+        String path,
+        Map<String, String> detailed,
+        Map<String, String> generalized
+    ) {
+
+        if (node.isObject()) {
+            // Process object nodes recursively
+            var fields = node.fields();
+            while (fields.hasNext()) {
+                var entry = fields.next();
+                String newPath = path.equals("$") ? "$." + entry.getKey() : path + "." + entry.getKey();
+                generateMappingsRecursive(entry.getValue(), inputIndex, newPath, detailed, generalized);
+            }
+
+        } else if (node.isArray()) {
+            // Process array nodes with special logic for generalization
+            List<Map<String, String>> arrayDetailedMappings = new ArrayList<>();
+            List<Map<String, String>> arrayGeneralizedMappings = new ArrayList<>();
+
+            // Collect mappings for each array element
+            for (int i = 0; i < node.size(); i++) {
+                String arrayElementPath = path + "[" + i + "]";
+                Map<String, String> elementDetailed = new LinkedHashMap<>();
+                Map<String, String> elementGeneralized = new LinkedHashMap<>();
+
+                generateMappingsRecursive(node.get(i), inputIndex, arrayElementPath, elementDetailed, elementGeneralized);
+
+                arrayDetailedMappings.add(elementDetailed);
+                arrayGeneralizedMappings.add(elementGeneralized);
+            }
+
+            // Check if array elements have similar structure (only array indices differ)
+            if (arrayGeneralizedMappings.size() > 1 && areArrayMappingsSimilar(arrayGeneralizedMappings)) {
+                // Add all detailed mappings
+                for (Map<String, String> elementMapping : arrayDetailedMappings) {
+                    detailed.putAll(elementMapping);
+                }
+
+                // Add generalized mapping with smart array index replacement
+                Map<String, String> firstElementGeneralized = arrayGeneralizedMappings.get(0);
+                for (Map.Entry<String, String> entry : firstElementGeneralized.entrySet()) {
+                    // Collect all corresponding keys for this entry across array elements
+                    Set<String> allKeys = new HashSet<>();
+                    Set<String> allValues = new HashSet<>();
+
+                    for (Map<String, String> mapping : arrayGeneralizedMappings) {
+                        for (Map.Entry<String, String> e : mapping.entrySet()) {
+                            if (e.getKey().replaceAll("\\[\\d+\\]", "[*]").equals(entry.getKey().replaceAll("\\[\\d+\\]", "[*]"))) {
+                                allKeys.add(e.getKey());
+                                allValues.add(e.getValue());
+                            }
+                        }
+                    }
+
+                    String generalizedKey = generalizeVaryingArrayIndices(allKeys);
+                    String generalizedValue = generalizeVaryingArrayIndices(allValues);
+                    generalized.put(generalizedKey, generalizedValue);
+                }
+            } else {
+                // Array elements have different structures, add all mappings to both detailed
+                // and generalized
+                for (int i = 0; i < arrayDetailedMappings.size(); i++) {
+                    detailed.putAll(arrayDetailedMappings.get(i));
+                    generalized.putAll(arrayGeneralizedMappings.get(i));
+                }
+            }
+
+        } else {
+            // Process leaf values by finding matching input paths
+            String value = node.asText();
+            String matchingInputPath = inputIndex.get(value);
+
+            if (matchingInputPath != null && !matchingInputPath.isEmpty()) {
+                detailed.put(path, matchingInputPath);
+                generalized.put(path, matchingInputPath);
+            }
+        }
+    }
+
+    /**
+     * Checks if array mappings are similar (only differing in array indices).
+     * This determines whether to use generalized array notation or treat each
+     * element separately, which is crucial for creating useful transformation
+     * patterns.
+     *
+     * @param arrayMappings List of generalized mappings for array elements
+     * @return true if mappings have similar structure with only index differences
+     */
+    private static boolean areArrayMappingsSimilar(List<Map<String, String>> arrayMappings) {
+        if (arrayMappings.size() <= 1) return true;
+
+        Map<String, String> firstMapping = arrayMappings.get(0);
+        Set<String> firstKeys = firstMapping.keySet().stream().map(key -> key.replaceAll("\\[\\d+\\]", "[*]")).collect(Collectors.toSet());
+
+        for (int i = 1; i < arrayMappings.size(); i++) {
+            Map<String, String> currentMapping = arrayMappings.get(i);
+            Set<String> currentKeys = currentMapping.keySet()
+                .stream()
+                .map(key -> key.replaceAll("\\[\\d+\\]", "[*]"))
+                .collect(Collectors.toSet());
+
+            if (!firstKeys.equals(currentKeys)) {
+                return false;
+            }
+
+            // Check if the values also have similar structure when generalized
+            for (String generalizedKey : firstKeys) {
+                String firstValue = firstMapping.entrySet()
+                    .stream()
+                    .filter(e -> e.getKey().replaceAll("\\[\\d+\\]", "[*]").equals(generalizedKey))
+                    .map(e -> e.getValue().replaceAll("\\[\\d+\\]", "[*]"))
+                    .findFirst()
+                    .orElse("");
+
+                String currentValue = currentMapping.entrySet()
+                    .stream()
+                    .filter(e -> e.getKey().replaceAll("\\[\\d+\\]", "[*]").equals(generalizedKey))
+                    .map(e -> e.getValue().replaceAll("\\[\\d+\\]", "[*]"))
+                    .findFirst()
+                    .orElse("");
+
+                if (!firstValue.equals(currentValue)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Generalizes array indices by replacing only varying indices with [*].
+     * This method intelligently identifies which array indices are varying
+     * across similar paths and generalizes only those positions.
+     *
+     * @param paths Set of paths to analyze and generalize
+     * @return Generalized path with [*] only for varying array indices
+     */
+    private static String generalizeVaryingArrayIndices(Set<String> paths) {
+        if (paths.isEmpty()) return "";
+        if (paths.size() == 1) return paths.iterator().next();
+
+        List<String[]> split = paths.stream().map(p -> p.split("(?<=]\\.)|(?=\\[)|\\.")).collect(Collectors.toList());
+
+        StringBuilder sb = new StringBuilder();
+        int max = split.stream().mapToInt(a -> a.length).max().orElse(0);
+
+        for (int i = 0; i < max; i++) {
+            int index = i;
+            Set<String> parts = split.stream().map(arr -> index < arr.length ? arr[index] : "").collect(Collectors.toSet());
+
+            // Add separator if needed
+            if (i > 0 && sb.length() > 0 && !sb.toString().endsWith(".") && !parts.iterator().next().startsWith("[")) {
+                sb.append('.');
+            }
+
+            if (parts.size() == 1) {
+                // All paths have the same part at this position, keep it unchanged
+                sb.append(parts.iterator().next());
+            } else if (parts.stream().anyMatch(p -> p.matches("\\[\\d+]"))) {
+                // Array indices vary at this position, replace with [*]
+                sb.append("[*]");
+            } else {
+                // Other variations, keep the first one
+                sb.append(parts.iterator().next());
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Safely retrieves or creates a nested Map<String, Object>
+     * under a given key.
+     * This method ensures type safety when building nested structures and provides
+     * clear error messages when there are structural conflicts.
+     *
+     * @param parent The parent map to get or create the child map in
+     * @param key    The key under which to get or create the child map
+     * @return The existing or newly created child map
+     * @throws IllegalStateException if there's a type conflict at the specified key
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> getOrCreateChildMap(Map<String, Object> parent, String key) {
+        Object value = parent.get(key);
+        if (value == null) {
+            Map<String, Object> child = new LinkedHashMap<>();
+            parent.put(key, child);
+            return child;
+        } else if (value instanceof Map) {
+            return (Map<String, Object>) value;
+        } else {
+            throw new IllegalStateException(
+                "Conflict at key '" + key + "': expected a nested object but found " + value.getClass().getSimpleName()
+            );
+        }
+    }
+
+    /**
+     * Converts a flat Map with dot-separated paths into a nested Map structure.
+     * This transformation makes it easier to understand the hierarchical
+     * relationship of the mappings and can be used for generating configuration
+     * files or templates.
+     *
+     * Example transformation:
+     * Input: "allocDetails[*].team.product.id" =>
+     * "$.item.allocDetails.items[*].team.product.id"
+     * Output: Nested map structure representing the hierarchy
+     *
+     * @param flatMap The flat mapping with dot-separated keys and string values
+     * @return A nested Map representing the hierarchical structure with object values
+     */
+    private static Map<String, Object> toNestedMapping(Map<String, String> flatMap) {
+        Map<String, Object> result = new LinkedHashMap<>();
+
+        for (Map.Entry<String, String> entry : flatMap.entrySet()) {
+            String keyPath = entry.getKey();
+
+            // Remove leading "$." if present for cleaner processing
+            if (keyPath.startsWith("$.")) {
+                keyPath = keyPath.substring(2);
+            }
+
+            String[] parts = keyPath.split("\\.");
+
+            // Filter out empty parts to handle edge cases
+            List<String> validParts = new ArrayList<>();
+            for (String part : parts) {
+                if (!part.isEmpty()) {
+                    validParts.add(part);
+                }
+            }
+
+            Map<String, Object> current = result;
+
+            // Build nested structure
+            for (int i = 0; i < validParts.size(); i++) {
+                String key = validParts.get(i);
+                boolean isLast = (i == validParts.size() - 1);
+
+                if (isLast) {
+                    current.put(key, entry.getValue());
+                } else {
+                    current = getOrCreateChildMap(current, key);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Class representing the mapping result, containing detailed mappings and
+     * JSONPath suggestions. This provides both granular field-to-field mappings
+     * and generalized transformation patterns as nested object structures.
+     */
+    public static class MapFormatResult {
+        /** Detailed field-to-field mappings with input paths as nested object structure */
+        public final Map<String, Object> detailedJsonPath;
+
+        /** Simplified JSONPath transformation suggestions as nested object structure */
+        public final Map<String, Object> generalizedJsonPath;
+
+        /**
+         * Constructs a new MapFormatResult with the provided mappings.
+         *
+         * @param detailedJsonPath    The detailed mapping as nested object structure
+         * @param generalizedJsonPath The generalized mapping as nested object structure
+         */
+        public MapFormatResult(Map<String, Object> detailedJsonPath, Map<String, Object> generalizedJsonPath) {
+            this.detailedJsonPath = detailedJsonPath;
+            this.generalizedJsonPath = generalizedJsonPath;
+        }
+    }
+
+    /**
+     * Container class for the final mapping output in string format.
+     * Provides the transformation recommendations as formatted JSON strings
+     * that can be easily consumed by other systems or displayed to users.
+     */
+    public static class StringFormatResult {
+        /** Detailed mapping as a formatted JSON string */
+        public final String detailedJsonPathString;
+
+        /** Generalized JSONPath suggestions as a formatted JSON string */
+        public final String generalizedJsonPathString;
+
+        /**
+         * Constructs a new StringFormatResult with the provided mapping strings.
+         *
+         * @param detailedJsonPathString    The detailed mapping as JSON string
+         * @param generalizedJsonPathString The generalized mapping as JSON string
+         */
+        public StringFormatResult(String detailedJsonPathString, String generalizedJsonPathString) {
+            this.detailedJsonPathString = detailedJsonPathString;
+            this.generalizedJsonPathString = generalizedJsonPathString;
+        }
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/util/JsonToJsonRecommenderTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/JsonToJsonRecommenderTests.java
@@ -1,0 +1,919 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.flowframework.common.CommonValue;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for JsonToJsonRecommender methods.
+ * Tests the main entry points for getting JSON transformation recommendations,
+ * including both string-based and JsonNode-based APIs with various validation options.
+ */
+public class JsonToJsonRecommenderTests extends OpenSearchTestCase {
+    /**
+     * ObjectMapper instance used for parsing JSON strings and formatting output in tests.
+     * Configured with relaxed constraints to allow testing edge cases.
+     */
+    private static final ObjectMapper MAPPER;
+    static {
+        StreamReadConstraints constraints = StreamReadConstraints.builder()
+            .maxNestingDepth(CommonValue.MAX_JSON_NESTING_DEPTH + 10)
+            .maxStringLength(CommonValue.MAX_JSON_SIZE)
+            .maxNameLength(CommonValue.MAX_JSON_NAME_LENGTH + 10)
+            .build();
+
+        MAPPER = new ObjectMapper();
+        MAPPER.getFactory().setStreamReadConstraints(constraints);
+    }
+
+    public void testSimpleNestedStructures() throws JsonProcessingException, IllegalArgumentException {
+        String inputJson = """
+            {
+              "level1": {
+                "level2": {
+                  "level3": {
+                    "data": "deep_value"
+                  }
+                }
+              }
+            }
+            """;
+
+        String outputJson = """
+            {
+              "result": {
+                "nested": {
+                  "info": {
+                    "value": "deep_value"
+                  }
+                }
+              }
+            }
+            """;
+
+        JsonToJsonRecommender.StringFormatResult output = JsonToJsonRecommender.getRecommendationInStringFormat(inputJson, outputJson);
+
+        // Verify that the actual output contains the expected structure (ignoring
+        // whitespace differences)
+        assertTrue(
+            "Detailed JSON should contain expected mapping",
+            output.detailedJsonPathString.contains("\"value\" : \"$.level1.level2.level3.data\"")
+        );
+        assertTrue(
+            "Generalized JSON should contain expected mapping",
+            output.generalizedJsonPathString.contains("\"value\" : \"$.level1.level2.level3.data\"")
+        );
+    }
+
+    public void testArrayToArrayWithGeneralized() throws JsonProcessingException, IllegalArgumentException {
+        String inputJson = """
+            {"numbers": [1, 2, 3, 4, 5]}
+            """;
+
+        String outputJson = """
+            {"values": [1, 2, 3, 4, 5]}
+            """;
+
+        JsonToJsonRecommender.StringFormatResult output = JsonToJsonRecommender.getRecommendationInStringFormat(inputJson, outputJson);
+
+        /*
+         * Expected detailed output should contain:
+         * {
+         * "values[0]" : "$.numbers[0]",
+         * "values[1]" : "$.numbers[1]",
+         * "values[2]" : "$.numbers[2]",
+         * "values[3]" : "$.numbers[3]",
+         * "values[4]" : "$.numbers[4]"
+         * }
+         */
+
+        /*
+         * Expected generalized output should contain:
+         * {
+         * "values[*]" : "$.numbers[*]"
+         * }
+         */
+
+        // Verify that the actual output contains expected mappings (ignoring formatting
+        // differences)
+        assertTrue(
+            "Detailed JSON should contain individual array mappings",
+            output.detailedJsonPathString.contains("\"values[0]\" : \"$.numbers[0]\"")
+        );
+        assertTrue(
+            "Detailed JSON should contain all array elements",
+            output.detailedJsonPathString.contains("\"values[4]\" : \"$.numbers[4]\"")
+        );
+        assertTrue(
+            "Generalized JSON should contain wildcard mapping",
+            output.generalizedJsonPathString.contains("\"values[*]\" : \"$.numbers[*]\"")
+        );
+    }
+
+    public void testArrayToArrayCannotBeGeneralized() throws JsonProcessingException, IllegalArgumentException {
+        String inputJson = """
+            {"numbers": [1, 2, 3, 4, 5]}
+            """;
+
+        String outputJson = """
+            {"values": [1, 2, 3, 4, 6]}
+            """;
+
+        JsonToJsonRecommender.StringFormatResult output = JsonToJsonRecommender.getRecommendationInStringFormat(inputJson, outputJson);
+
+        // Verify that the actual output contains expected mappings (ignoring formatting
+        // differences)
+        assertTrue(
+            "Detailed JSON should contain individual array mappings",
+            output.detailedJsonPathString.contains("\"values[0]\" : \"$.numbers[0]\"")
+        );
+        assertTrue(
+            "Detailed JSON should contain mapped elements",
+            output.detailedJsonPathString.contains("\"values[3]\" : \"$.numbers[3]\"")
+        );
+        assertTrue("Detailed JSON should not contain unmapped elements", !output.detailedJsonPathString.contains("\"values[4]\""));
+
+        // Since arrays cannot be generalized (different values), both outputs should be
+        // the same
+        assertTrue(
+            "Generalized JSON should also contain individual mappings",
+            output.generalizedJsonPathString.contains("\"values[0]\" : \"$.numbers[0]\"")
+        );
+        assertTrue("Generalized JSON should not contain wildcard patterns", !output.generalizedJsonPathString.contains("\"values[*]\""));
+    }
+
+    public void testOneToManyMapping() throws JsonProcessingException, IllegalArgumentException {
+        String inputJson = """
+            {
+                "user": {
+                    "id": "u123",
+                    "skills": ["Java", "Python", "Go"]
+                }
+            }
+            """;
+
+        String outputJson = """
+            {
+                "skills" : [
+                    {
+                        "user_id": "u123",
+                        "skill": "Java"
+                    },
+                    {
+                        "user_id": "u123",
+                        "skill": "Python"
+                    },
+                    {
+                        "user_id": "u123",
+                        "skill": "Go"
+                    }
+                ]
+            }
+            """;
+
+        JsonToJsonRecommender.StringFormatResult output = JsonToJsonRecommender.getRecommendationInStringFormat(inputJson, outputJson);
+
+        // Verify that the actual output contains expected mappings (ignoring formatting
+        // differences)
+        assertTrue("Detailed JSON should contain user_id mapping", output.detailedJsonPathString.contains("\"user_id\" : \"$.user.id\""));
+        assertTrue(
+            "Detailed JSON should contain skills array mappings",
+            output.detailedJsonPathString.contains("\"skill\" : \"$.user.skills[0]\"")
+        );
+        assertTrue("Detailed JSON should contain multiple skill elements", output.detailedJsonPathString.contains("\"skills[2]\""));
+
+        assertTrue(
+            "Generalized JSON should contain wildcard user_id mapping",
+            output.generalizedJsonPathString.contains("\"user_id\" : \"$.user.id\"")
+        );
+        assertTrue(
+            "Generalized JSON should contain wildcard skills mapping",
+            output.generalizedJsonPathString.contains("\"skill\" : \"$.user.skills[*]\"")
+        );
+        assertTrue("Generalized JSON should use wildcard pattern", output.generalizedJsonPathString.contains("\"skills[*]\""));
+    }
+
+    public void testManyToOneMapping() throws JsonProcessingException, IllegalArgumentException {
+        String inputJson = """
+            [
+                {
+                    "hits": [
+                        {
+                            "_source": {
+                                "books": { "name": "To Kill a Mockingbird" },
+                                "songs": { "name": "Pocketful of Sunshine" }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "hits": [
+                        {
+                            "_source": {
+                                "books": { "name": "Where the Crawdads Sing" },
+                                "songs": { "name": "If" }
+                            }
+                        }
+                    ]
+                }
+            ]
+            """;
+
+        String outputJson = """
+            {
+                "book_name": ["To Kill a Mockingbird", "Where the Crawdads Sing"],
+                "song_name": ["Pocketful of Sunshine", "If"]
+            }
+            """;
+
+        JsonToJsonRecommender.StringFormatResult output = JsonToJsonRecommender.getRecommendationInStringFormat(inputJson, outputJson);
+
+        // Verify that the actual output contains expected mappings (ignoring formatting
+        // differences)
+        assertTrue(
+            "Detailed JSON should contain book mappings",
+            output.detailedJsonPathString.contains("\"book_name[0]\" : \"$[0].hits[0]._source.books.name\"")
+        );
+        assertTrue(
+            "Detailed JSON should contain song mappings",
+            output.detailedJsonPathString.contains("\"song_name[0]\" : \"$[0].hits[0]._source.songs.name\"")
+        );
+        assertTrue("Detailed JSON should contain multiple array elements", output.detailedJsonPathString.contains("\"book_name[1]\""));
+
+        assertTrue(
+            "Generalized JSON should contain wildcard book mapping",
+            output.generalizedJsonPathString.contains("\"book_name[*]\" : \"$[*].hits[0]._source.books.name\"")
+        );
+        assertTrue(
+            "Generalized JSON should contain wildcard song mapping",
+            output.generalizedJsonPathString.contains("\"song_name[*]\" : \"$[*].hits[0]._source.songs.name\"")
+        );
+    }
+
+    public void testComplexArrayToArray() throws JsonProcessingException, IllegalArgumentException {
+        String inputJson = """
+            {
+              "item": {
+                "id": "abcde",
+                "name": "Champak Kumar",
+                "allocDetails": {
+                  "useful": {
+                    "updatedAt": "2020-08-10T14:26:48-07:00",
+                    "token": 1134,
+                    "items": [
+                      {
+                        "allocation": 0.2,
+                        "team": {
+                          "id": 90,
+                          "name": "Some Team Name 1",
+                          "createdAt": "2010-01-19T10:52:52-07:00"
+                        }
+                      },
+                      {
+                        "allocation": 0.9,
+                        "team": {
+                          "id": 80,
+                          "name": "Some Team Name 2",
+                          "createdAt": "2010-01-19T10:52:52-07:00"
+                        }
+                      },
+                      {
+                        "allocation": 0.1,
+                        "team": {
+                          "id": 10,
+                          "name": "Some Team Name 3",
+                          "createdAt": "2010-01-19T10:52:52-07:00"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        String outputJson = """
+            {
+              "name": "Champak Kumar",
+              "allocDetails": [
+                {
+                  "allocation": 0.2,
+                  "team": {
+                    "id": 90,
+                    "name": "Some Team Name 1"
+                  }
+                },
+                {
+                  "allocation": 0.9,
+                  "team": {
+                    "id": 80,
+                    "name": "Some Team Name 2"
+                  }
+                },
+                {
+                  "allocation": 0.1,
+                  "team": {
+                    "id": 10,
+                    "name": "Some Team Name 3"
+                  }
+                }
+              ]
+            }
+            """;
+
+        JsonToJsonRecommender.StringFormatResult output = JsonToJsonRecommender.getRecommendationInStringFormat(inputJson, outputJson);
+
+        // Verify that the actual output contains expected mappings (ignoring formatting
+        // differences)
+        assertTrue("Detailed JSON should contain name mapping", output.detailedJsonPathString.contains("\"name\" : \"$.item.name\""));
+        assertTrue(
+            "Detailed JSON should contain allocation mappings",
+            output.detailedJsonPathString.contains("\"allocation\" : \"$.item.allocDetails.useful.items[0].allocation\"")
+        );
+        assertTrue(
+            "Detailed JSON should contain team id mappings",
+            output.detailedJsonPathString.contains("\"id\" : \"$.item.allocDetails.useful.items[0].team.id\"")
+        );
+        assertTrue(
+            "Detailed JSON should contain team name mappings",
+            output.detailedJsonPathString.contains("\"name\" : \"$.item.allocDetails.useful.items[0].team.name\"")
+        );
+
+        assertTrue("Generalized JSON should contain name mapping", output.generalizedJsonPathString.contains("\"name\" : \"$.item.name\""));
+        assertTrue(
+            "Generalized JSON should contain wildcard allocation mappings",
+            output.generalizedJsonPathString.contains("\"allocation\" : \"$.item.allocDetails.useful.items[*].allocation\"")
+        );
+        assertTrue(
+            "Generalized JSON should use wildcard pattern for arrays",
+            output.generalizedJsonPathString.contains("\"allocDetails[*]\"")
+        );
+    }
+
+    public void testComplexArrayToArrayWithPartialInputGeneralization() throws JsonProcessingException, IllegalArgumentException {
+        String inputJson = """
+            {
+              "item": {
+                "id": "abcde",
+                "name": "Champak Kumar",
+                "allocDetails": [
+                  {
+                    "useful": {
+                      "updatedAt": "2020-08-10T14:26:48-07:00",
+                      "token": 1134,
+                      "items": [
+                        {
+                          "allocation": 0.2,
+                          "team": {
+                            "id": 90,
+                            "name": "Some Team Name 1",
+                            "createdAt": "2010-01-19T10:52:52-07:00"
+                          }
+                        },
+                        {
+                          "allocation": 0.9,
+                          "team": {
+                            "id": 80,
+                            "name": "Some Team Name 2",
+                            "createdAt": "2010-01-19T10:52:52-07:00"
+                          }
+                        },
+                        {
+                          "allocation": 0.1,
+                          "team": {
+                            "id": 10,
+                            "name": "Some Team Name 3",
+                            "createdAt": "2010-01-19T10:52:52-07:00"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "useless": {
+                      "aa": "bb"
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        String outputJson = """
+            {
+              "name": "Champak Kumar",
+              "allocDetails": [
+                {
+                  "allocation": 0.2,
+                  "team": {
+                    "id": 90,
+                    "name": "Some Team Name 1"
+                  }
+                },
+                {
+                  "allocation": 0.9,
+                  "team": {
+                    "id": 80,
+                    "name": "Some Team Name 2"
+                  }
+                },
+                {
+                  "allocation": 0.1,
+                  "team": {
+                    "id": 10,
+                    "name": "Some Team Name 3"
+                  }
+                }
+              ]
+            }
+            """;
+
+        JsonToJsonRecommender.StringFormatResult output = JsonToJsonRecommender.getRecommendationInStringFormat(inputJson, outputJson);
+
+        // Verify that the actual output contains expected mappings (ignoring formatting
+        // differences)
+        assertTrue("Detailed JSON should contain name mapping", output.detailedJsonPathString.contains("\"name\" : \"$.item.name\""));
+        assertTrue(
+            "Detailed JSON should contain allocation mapping with array index",
+            output.detailedJsonPathString.contains("\"allocation\" : \"$.item.allocDetails[0].useful.items[0].allocation\"")
+        );
+        assertTrue(
+            "Detailed JSON should contain team mappings with array indices",
+            output.detailedJsonPathString.contains("\"id\" : \"$.item.allocDetails[0].useful.items[0].team.id\"")
+        );
+
+        assertTrue("Generalized JSON should contain name mapping", output.generalizedJsonPathString.contains("\"name\" : \"$.item.name\""));
+        assertTrue(
+            "Generalized JSON should contain partial wildcard mapping",
+            output.generalizedJsonPathString.contains("\"allocation\" : \"$.item.allocDetails[0].useful.items[*].allocation\"")
+        );
+        assertTrue(
+            "Generalized JSON should use wildcard for output arrays",
+            output.generalizedJsonPathString.contains("\"allocDetails[*]\"")
+        );
+    }
+
+    public void testComplexArrayToArrayWithPartialOutputGeneralization() throws JsonProcessingException, IllegalArgumentException {
+        String inputJson = """
+            {
+              "item": {
+                "id": "abcde",
+                "name": "Champak Kumar",
+                "allocDetails": {
+                  "useful": {
+                    "updatedAt": "2020-08-10T14:26:48-07:00",
+                    "token": 1134,
+                    "items": [
+                      {
+                        "allocation": 0.2,
+                        "team": {
+                          "id": 90,
+                          "name": "Some Team Name 1",
+                          "createdAt": "2010-01-19T10:52:52-07:00"
+                        }
+                      },
+                      {
+                        "allocation": 0.9,
+                        "team": {
+                          "id": 80,
+                          "name": "Some Team Name 2",
+                          "createdAt": "2010-01-19T10:52:52-07:00"
+                        }
+                      },
+                      {
+                        "allocation": 0.1,
+                        "team": {
+                          "id": 10,
+                          "name": "Some Team Name 3",
+                          "createdAt": "2010-01-19T10:52:52-07:00"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        String outputJson = """
+            {
+              "name": "Champak Kumar",
+              "temp": [
+                {
+                  "allocDetails": [
+                    {
+                      "allocation": 0.2,
+                      "team": {
+                        "id": 90,
+                        "name": "Some Team Name 1"
+                      }
+                    },
+                    {
+                      "allocation": 0.9,
+                      "team": {
+                        "id": 80,
+                        "name": "Some Team Name 2"
+                      }
+                    },
+                    {
+                      "allocation": 0.1,
+                      "team": {
+                        "id": 10,
+                        "name": "Some Team Name 3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "unuseful": "haha"
+                }
+              ]
+            }
+            """;
+
+        JsonToJsonRecommender.StringFormatResult output = JsonToJsonRecommender.getRecommendationInStringFormat(inputJson, outputJson);
+
+        // Verify that the actual output contains expected mappings (ignoring formatting
+        // differences)
+        assertTrue("Detailed JSON should contain name mapping", output.detailedJsonPathString.contains("\"name\" : \"$.item.name\""));
+        assertTrue("Detailed JSON should contain temp[0] structure", output.detailedJsonPathString.contains("\"temp[0]\""));
+        assertTrue(
+            "Detailed JSON should contain allocation mappings",
+            output.detailedJsonPathString.contains("\"allocation\" : \"$.item.allocDetails.useful.items[0].allocation\"")
+        );
+        assertTrue(
+            "Detailed JSON should contain team mappings",
+            output.detailedJsonPathString.contains("\"id\" : \"$.item.allocDetails.useful.items[0].team.id\"")
+        );
+
+        // Verify generalized JSON contains specific temp array elements
+        assertTrue("Generalized JSON should contain name mapping", output.generalizedJsonPathString.contains("\"name\" : \"$.item.name\""));
+        assertTrue(
+            "Generalized JSON should contain temp[0] with wildcard allocDetails",
+            output.generalizedJsonPathString.contains("\"temp[0]\"") && output.generalizedJsonPathString.contains("\"allocDetails[*]\"")
+        );
+        assertTrue(
+            "Generalized JSON should contain wildcard allocation mappings in temp[0]",
+            output.generalizedJsonPathString.contains("\"allocation\" : \"$.item.allocDetails.useful.items[*].allocation\"")
+        );
+    }
+
+    public void testComplexArrayToArrayWithPartialOutputAndInputGeneralization() throws JsonProcessingException, IllegalArgumentException {
+        String inputJson = """
+            {
+              "item": {
+                "id": "abcde",
+                "name": "Champak Kumar",
+                "allocDetails": [
+                  {
+                    "useful": {
+                      "updatedAt": "2020-08-10T14:26:48-07:00",
+                      "token": 1134,
+                      "items": [
+                        {
+                          "allocation": 0.2,
+                          "team": {
+                            "id": 90,
+                            "name": "Some Team Name 1",
+                            "createdAt": "2010-01-19T10:52:52-07:00"
+                          }
+                        },
+                        {
+                          "allocation": 0.9,
+                          "team": {
+                            "id": 80,
+                            "name": "Some Team Name 2",
+                            "createdAt": "2010-01-19T10:52:52-07:00"
+                          }
+                        },
+                        {
+                          "allocation": 0.1,
+                          "team": {
+                            "id": 10,
+                            "name": "Some Team Name 3",
+                            "createdAt": "2010-01-19T10:52:52-07:00"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "useless": {
+                      "aa": "bb"
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        String outputJson = """
+            {
+              "name": "Champak Kumar",
+              "temp": [
+                {
+                  "allocDetails": [
+                    {
+                      "allocation": 0.2,
+                      "team": {
+                        "id": 90,
+                        "name": "Some Team Name 1"
+                      }
+                    },
+                    {
+                      "allocation": 0.9,
+                      "team": {
+                        "id": 80,
+                        "name": "Some Team Name 2"
+                      }
+                    },
+                    {
+                      "allocation": 0.1,
+                      "team": {
+                        "id": 10,
+                        "name": "Some Team Name 3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "allocDetails2": {
+                    "allocation": 0.2,
+                    "team": {
+                      "id": 90,
+                      "name": "Some Team Name 1"
+                    }
+                  }
+                },
+                {
+                  "unuseful": "haha"
+                }
+              ]
+            }
+            """;
+
+        JsonToJsonRecommender.StringFormatResult output = JsonToJsonRecommender.getRecommendationInStringFormat(inputJson, outputJson);
+
+        // Verify that the actual output contains expected mappings (ignoring formatting
+        // differences)
+        assertTrue("Detailed JSON should contain name mapping", output.detailedJsonPathString.contains("\"name\" : \"$.item.name\""));
+        assertTrue("Detailed JSON should contain temp[0] structure", output.detailedJsonPathString.contains("\"temp[0]\""));
+        assertTrue("Detailed JSON should contain temp[1] structure", output.detailedJsonPathString.contains("\"temp[1]\""));
+        assertTrue(
+            "Detailed JSON should contain allocation mappings",
+            output.detailedJsonPathString.contains("\"allocation\" : \"$.item.allocDetails[0].useful.items[0].allocation\"")
+        );
+        assertTrue("Detailed JSON should contain allocDetails2 mapping", output.detailedJsonPathString.contains("\"allocDetails2\""));
+
+        // Verify generalized JSON contains specific temp array elements
+        assertTrue("Generalized JSON should contain name mapping", output.generalizedJsonPathString.contains("\"name\" : \"$.item.name\""));
+        assertTrue(
+            "Generalized JSON should contain temp[0] with wildcard allocDetails",
+            output.generalizedJsonPathString.contains("\"temp[0]\"") && output.generalizedJsonPathString.contains("\"allocDetails[*]\"")
+        );
+        assertTrue(
+            "Generalized JSON should contain temp[1] with allocDetails2",
+            output.generalizedJsonPathString.contains("\"temp[1]\"") && output.generalizedJsonPathString.contains("\"allocDetails2\"")
+        );
+        assertTrue(
+            "Generalized JSON should contain partial wildcard mapping for temp[0]",
+            output.generalizedJsonPathString.contains("\"allocation\" : \"$.item.allocDetails[0].useful.items[*].allocation\"")
+        );
+        assertTrue(
+            "Generalized JSON should contain specific mapping for temp[1]",
+            output.generalizedJsonPathString.contains("\"allocation\" : \"$.item.allocDetails[0].useful.items[0].allocation\"")
+        );
+    }
+
+    public void testGetRecommendationErrorHandlingForNullInputs() {
+        // Test null inputs
+        expectThrows(IllegalArgumentException.class, () -> JsonToJsonRecommender.getRecommendationInStringFormat(null, "{}"));
+
+        expectThrows(IllegalArgumentException.class, () -> JsonToJsonRecommender.getRecommendationInStringFormat("{}", null));
+
+        expectThrows(IllegalArgumentException.class, () -> JsonToJsonRecommender.getRecommendationInMapFormat(null, MAPPER.readTree("{}")));
+
+        expectThrows(IllegalArgumentException.class, () -> JsonToJsonRecommender.getRecommendationInMapFormat(MAPPER.readTree("{}"), null));
+
+    }
+
+    public void testGetRecommendationErrorHandlingForEmptyInputs() {
+        // Test empty inputs
+        expectThrows(IllegalArgumentException.class, () -> JsonToJsonRecommender.getRecommendationInStringFormat("", "{}"));
+
+        expectThrows(IllegalArgumentException.class, () -> JsonToJsonRecommender.getRecommendationInStringFormat("{}", ""));
+
+        expectThrows(IllegalArgumentException.class, () -> JsonToJsonRecommender.getRecommendationInStringFormat("   ", "{}"));
+
+        expectThrows(IllegalArgumentException.class, () -> JsonToJsonRecommender.getRecommendationInStringFormat("{}", "   "));
+
+        expectThrows(IllegalArgumentException.class, () -> JsonToJsonRecommender.getRecommendationInStringFormat("{}", "{}"));
+    }
+
+    public void testGetRecommendationWithInvalidJson() {
+        String invalidJson = "{invalid json}";
+        String validJson = "{\"test_key\": \"test_value\"}";
+
+        // Should throw JsonProcessingException for invalid input JSON
+        expectThrows(JsonProcessingException.class, () -> JsonToJsonRecommender.getRecommendationInStringFormat(invalidJson, validJson));
+
+        // Should throw JsonProcessingException for invalid output JSON
+        expectThrows(JsonProcessingException.class, () -> JsonToJsonRecommender.getRecommendationInStringFormat(validJson, invalidJson));
+    }
+
+    public void testGetRecommendationWithOversizedJson() {
+        // Create a large JSON string that exceeds the StreamReadConstraints limit
+        // (50MB)
+        StringBuilder largeJsonBuilder = new StringBuilder("{\"data\": \"");
+        // Create a string larger than 50MB (50,000,000 characters)
+        for (int i = 0; i < 50_043_091; i++) {
+            largeJsonBuilder.append("a");
+        }
+        largeJsonBuilder.append("\"}");
+        String largeJson = largeJsonBuilder.toString();
+        String validJson = "{\"result\": \"test_value\"}";
+
+        // Should throw JsonProcessingException for oversized input JSON
+        JsonProcessingException inputException = expectThrows(
+            JsonProcessingException.class,
+            () -> JsonToJsonRecommender.getRecommendationInStringFormat(largeJson, validJson)
+        );
+        assertTrue(
+            "Exception message should mention string value length exceeds maximum",
+            inputException.getMessage().contains("String value length")
+                && inputException.getMessage().contains("exceeds the maximum allowed")
+                && inputException.getMessage().contains("StreamReadConstraints.getMaxStringLength()")
+        );
+
+        // Should throw JsonProcessingException for oversized output JSON
+        JsonProcessingException outputException = expectThrows(
+            JsonProcessingException.class,
+            () -> JsonToJsonRecommender.getRecommendationInStringFormat(validJson, largeJson)
+        );
+        assertTrue(
+            "Exception message should mention string value length exceeds maximum",
+            outputException.getMessage().contains("String value length")
+                && outputException.getMessage().contains("exceeds the maximum allowed")
+                && outputException.getMessage().contains("StreamReadConstraints.getMaxStringLength()")
+        );
+    }
+
+    public void testGetRecommendationWithOversizedFieldName() throws JsonProcessingException {
+        // Create a JSON string with field name that exceeds the MAX_NAME_LEN limit
+        // (50000 characters)
+        StringBuilder longFieldNameBuilder = new StringBuilder();
+        // Create a field name longer than 50000 characters
+        for (int i = 0; i < 50001; i++) {
+            longFieldNameBuilder.append("a");
+        }
+        String longFieldName = longFieldNameBuilder.toString();
+        String inputJsonWithLongFieldName = "{\"" + longFieldName + "\": \"test_value\"}";
+        String validJson = "{\"result\": \"test_value\"}";
+
+        // Should throw JsonProcessingException for oversized field name in input JSON
+        JsonProcessingException inputException = expectThrows(
+            JsonProcessingException.class,
+            () -> JsonToJsonRecommender.getRecommendationInStringFormat(inputJsonWithLongFieldName, validJson)
+        );
+        assertTrue(
+            "Exception message should mention field name length exceeds maximum",
+            inputException.getMessage().contains("Name length")
+                && inputException.getMessage().contains("exceeds the maximum allowed")
+                && inputException.getMessage().contains("StreamReadConstraints.getMaxNameLength()")
+        );
+
+        // Should throw JsonProcessingException for oversized field name in output JSON
+        JsonProcessingException outputException = expectThrows(
+            JsonProcessingException.class,
+            () -> JsonToJsonRecommender.getRecommendationInStringFormat(validJson, inputJsonWithLongFieldName)
+        );
+        assertTrue(
+            "Exception message should mention field name length exceeds maximum",
+            outputException.getMessage().contains("Name length")
+                && outputException.getMessage().contains("exceeds the maximum allowed")
+                && outputException.getMessage().contains("StreamReadConstraints.getMaxNameLength()")
+        );
+
+        // Add test for oversized field name in JsonNode format in input Node
+        JsonNode inputNode = MAPPER.readTree(inputJsonWithLongFieldName);
+        JsonNode outputNode = MAPPER.readTree(validJson);
+        IllegalArgumentException inputNodeException = expectThrows(
+            IllegalArgumentException.class,
+            () -> JsonToJsonRecommender.getRecommendationInMapFormat(inputNode, outputNode)
+        );
+        assertTrue(
+            "Exception message should mention field name length exceeds maximum",
+            inputNodeException.getMessage().contains("Input JSON Node")
+                && inputNodeException.getMessage().contains("contains a key with length")
+                && inputNodeException.getMessage().contains("exceeds the maximum allowed")
+        );
+
+        // Add test for oversized field name in JsonNode format in output Node
+        IllegalArgumentException outputNodeException = expectThrows(
+            IllegalArgumentException.class,
+            () -> JsonToJsonRecommender.getRecommendationInMapFormat(outputNode, inputNode)
+        );
+        assertTrue(
+            "Exception message should mention field name length exceeds maximum",
+            outputNodeException.getMessage().contains("Output JSON Node")
+                && outputNodeException.getMessage().contains("contains a key with length")
+                && outputNodeException.getMessage().contains("exceeds the maximum allowed")
+        );
+    }
+
+    public void testGetRecommendationWithDeeplyNestedJson() throws JsonProcessingException {
+        // Create a deeply nested JSON that exceeds the nesting limit (1000 levels)
+        StringBuilder deepJsonBuilder = new StringBuilder();
+        for (int i = 0; i < 1001; i++) { // Exceed the limit of 1000
+            deepJsonBuilder.append("{\"level").append(i).append("\":");
+        }
+        deepJsonBuilder.append("\"deep_value\"");
+        for (int i = 0; i < 1001; i++) {
+            deepJsonBuilder.append("}");
+        }
+        String deepJson = deepJsonBuilder.toString();
+        String validJson = "{\"result\": \"deep_value\"}";
+
+        // Should throw JsonProcessingException for deeply nested input JSON
+        JsonProcessingException inputException = expectThrows(
+            JsonProcessingException.class,
+            () -> JsonToJsonRecommender.getRecommendationInStringFormat(deepJson, validJson)
+        );
+        assertTrue(
+            inputException.getMessage(),
+            inputException.getMessage().contains("Document nesting depth")
+                && inputException.getMessage().contains("exceeds the maximum allowed")
+                && inputException.getMessage().contains("StreamReadConstraints.getMaxNestingDepth()")
+        );
+
+        // Should throw JsonProcessingException for deeply nested output JSON
+        JsonProcessingException outputException = expectThrows(
+            JsonProcessingException.class,
+            () -> JsonToJsonRecommender.getRecommendationInStringFormat(validJson, deepJson)
+        );
+        assertTrue(
+            "Exception message should mention document nesting depth exceeds maximum",
+            outputException.getMessage().contains("Document nesting depth")
+                && outputException.getMessage().contains("exceeds the maximum allowed")
+                && outputException.getMessage().contains("StreamReadConstraints.getMaxNestingDepth()")
+        );
+
+        // Add test for deeply nested JsonNode format in input Node
+        JsonNode inputNode = MAPPER.readTree(deepJson);
+        JsonNode outputNode = MAPPER.readTree(validJson);
+        IllegalArgumentException inputNodeException = expectThrows(
+            IllegalArgumentException.class,
+            () -> JsonToJsonRecommender.getRecommendationInMapFormat(inputNode, outputNode)
+        );
+        assertTrue(
+            "Exception message should mention document nesting depth exceeds maximum",
+            inputNodeException.getMessage().contains("Input JSON Node")
+                && inputNodeException.getMessage().contains("nesting depth")
+                && inputNodeException.getMessage().contains("exceeds the maximum allowed")
+        );
+
+        // Add test for deeply nested JsonNode format in output Node
+        IllegalArgumentException outputNodeException = expectThrows(
+            IllegalArgumentException.class,
+            () -> JsonToJsonRecommender.getRecommendationInMapFormat(outputNode, inputNode)
+        );
+        assertTrue(
+            "Exception message should mention document nesting depth exceeds maximum",
+            outputNodeException.getMessage().contains("Output JSON Node")
+                && outputNodeException.getMessage().contains("nesting depth")
+                && outputNodeException.getMessage().contains("exceeds the maximum allowed")
+        );
+    }
+
+    public void testGetRecommendationWithValidSizeAndNesting() throws JsonProcessingException, IllegalArgumentException {
+        // Test JSON that's within both size and nesting limits
+        StringBuilder validNestedJson = new StringBuilder();
+        for (int i = 0; i < 999; i++) { // Well within the limit of 1000
+            validNestedJson.append("{\"level").append(i).append("\":");
+        }
+        validNestedJson.append("\"test_value\"");
+        for (int i = 0; i < 999; i++) {
+            validNestedJson.append("}");
+        }
+
+        String inputJson = validNestedJson.toString();
+        String outputJson = "{\"result\": \"test_value\"}";
+
+        // Should not throw any exception
+        JsonToJsonRecommender.StringFormatResult output = JsonToJsonRecommender.getRecommendationInStringFormat(inputJson, outputJson);
+        assertNotNull("Should have detailed mapping", output.detailedJsonPathString);
+        assertNotNull("Should have generalized mapping", output.generalizedJsonPathString);
+    }
+}


### PR DESCRIPTION
### Description
This PR adds a utility class `JsonToJsonRecommender` under `util` that can infer JSONPath mappings based on example input and output JSON objects.

This utility is intended as a core component for implementing automatic field-level mapping in scenarios like inference-based pipeline configuration or input/output transformation logic.

The unit tests include example input-output pairs and cover relevant cases.

### Related Issues
Resolves #1167
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
