### PR TITLE
Force checkstyle to latest released version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,19 @@ allprojects {
     // Default to the apache license
     project.ext.licenseName = 'The Apache Software License, Version 2.0'
     project.ext.licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+
+    checkstyle {
+        toolVersion = "latest.release"
+    }
+
+    // Avoid jar hell and other CVEs
+    configurations.checkstyle {
+        exclude group: 'org.apache.httpcomponents.client5', module: 'httpclient5'
+        exclude group: 'org.apache.httpcomponents.core5', module: 'httpcore5'
+        exclude group: 'org.apache.httpcomponents', module: 'httpcore'
+        exclude group: 'org.apache.commons', module: 'commons-lang3'
+        exclude group: 'org.codehaus.plexus', module: 'plexus-utils'
+    }
 }
 
 publishing {


### PR DESCRIPTION
### Description

Force checkstyle to the latest version to resolve [CVE-2025-48734](https://www.mend.io/vulnerability-database/CVE-2025-48734).  Also introduce transitive exclusions needed to avoid introducing another CVE, see https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/205

### Related Issues
Resolves failing mend check on 2.19 branch bump (once backported)

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
