### PR TITLE
fix(step): update RegisterLocalCustomModelStep 

### DIFF
--- a/sample-templates/observability-chat-agent-openai-untested.json
+++ b/sample-templates/observability-chat-agent-openai-untested.json
@@ -59,10 +59,15 @@
             "model_content_size_in_bytes": 567691,
             "model_content_hash_value": "b3487da9c58ac90541b720f3b367084f271d280c7f3bdc3e6d9c9a269fb31950",
             "created_time": 1696913667239,
-            "model_type": "sparse",
-            "embedding_dimension": "1",
-            "framework_type": "sentence_transformers",
-            "url": "https://artifacts.opensearch.org/models/ml-models/amazon/neural-sparse/opensearch-neural-sparse-tokenizer-v1/1.0.0/torch_script/opensearch-neural-sparse-tokenizer-v1-1.0.0.zip"
+            "url": "https://artifacts.opensearch.org/models/ml-models/amazon/neural-sparse/opensearch-neural-sparse-tokenizer-v1/1.0.0/torch_script/opensearch-neural-sparse-tokenizer-v1-1.0.0.zip",
+            "model_config": {
+              "model_type": "sparse",
+              "embedding_dimension": "1",
+              "framework_type": "sentence_transformers",
+              "additional_config": {
+                "space_type": "l2"
+              }
+            }
           }
         },
         {

--- a/sample-templates/observability-chat-agent-openai-untested.yml
+++ b/sample-templates/observability-chat-agent-openai-untested.yml
@@ -68,10 +68,13 @@ workflows:
         model_content_size_in_bytes: 567691
         model_content_hash_value: b3487da9c58ac90541b720f3b367084f271d280c7f3bdc3e6d9c9a269fb31950
         created_time: 1696913667239
-        model_type: sparse
-        embedding_dimension: '1'
-        framework_type: sentence_transformers
         url: https://artifacts.opensearch.org/models/ml-models/amazon/neural-sparse/opensearch-neural-sparse-tokenizer-v1/1.0.0/torch_script/opensearch-neural-sparse-tokenizer-v1-1.0.0.zip
+        model_config:
+          model_type: sparse
+          embedding_dimension: '1'
+          framework_type: sentence_transformers
+          additional_config:
+            space_type: l2
     - id: deploy_sparse_model
       type: deploy_model
       previous_node_inputs:

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -151,6 +151,10 @@ public class CommonValue {
     public static final String URL = "url";
     /** Model config field */
     public static final String MODEL_CONFIG = "model_config";
+    /** Additional config field */
+    public static final String ADDITIONAL_CONFIG = "additional_config";
+    /** Space type field */
+    public static final String SPACE_TYPE = "space_type";
     /** Model type field */
     public static final String MODEL_TYPE = "model_type";
     /** Embedding dimension field */

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
@@ -26,10 +26,8 @@ import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.model.BaseModelConfig;
 import org.opensearch.ml.common.model.MLModelFormat;
-import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
-import org.opensearch.ml.common.model.TextEmbeddingModelConfig.FrameworkType;
-import org.opensearch.ml.common.model.TextEmbeddingModelConfig.TextEmbeddingModelConfigBuilder;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
 import org.opensearch.threadpool.ThreadPool;
@@ -37,15 +35,14 @@ import org.opensearch.threadpool.ThreadPool;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
+import static org.opensearch.flowframework.common.CommonValue.ADDITIONAL_CONFIG;
 import static org.opensearch.flowframework.common.CommonValue.ALL_CONFIG;
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.EMBEDDING_DIMENSION;
-import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
 import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_CONFIG;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
@@ -114,14 +111,10 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
             String functionName = (String) inputs.get(FUNCTION_NAME);
             String modelContentHashValue = (String) inputs.get(MODEL_CONTENT_HASH_VALUE);
             String url = (String) inputs.get(URL);
-            String modelType = (String) inputs.get(MODEL_TYPE);
-            String embeddingDimension = (String) inputs.get(EMBEDDING_DIMENSION);
-            String frameworkType = (String) inputs.get(FRAMEWORK_TYPE);
 
             // Extract optional fields
             String description = (String) inputs.get(DESCRIPTION_FIELD);
             String modelGroupId = (String) inputs.get(MODEL_GROUP_ID);
-            String allConfig = (String) inputs.get(ALL_CONFIG);
             String modelInterface = (String) inputs.get(INTERFACE_FIELD);
             final Boolean deploy = ParseUtils.parseIfExists(inputs, DEPLOY_FIELD, Boolean.class);
 
@@ -140,16 +133,23 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
             if (url != null) {
                 mlInputBuilder.url(url);
             }
-            if (Stream.of(modelType, embeddingDimension, frameworkType).allMatch(x -> x != null)) {
-                TextEmbeddingModelConfigBuilder mlConfigBuilder = TextEmbeddingModelConfig.builder()
-                    .modelType(modelType)
-                    .embeddingDimension(Integer.valueOf(embeddingDimension))
-                    .frameworkType(FrameworkType.from(frameworkType));
-                if (allConfig != null) {
-                    mlConfigBuilder.allConfig(allConfig);
-                }
-                mlInputBuilder.modelConfig(mlConfigBuilder.build());
+
+            // Handle model_config if present
+            Map<String, Object> modelConfig = (Map<String, Object>) inputs.get(MODEL_CONFIG);
+            if (modelConfig != null) {
+                Map<String, Object> additionalConfig = modelConfig.containsKey(ADDITIONAL_CONFIG)
+                    ? (Map<String, Object>) modelConfig.get(ADDITIONAL_CONFIG)
+                    : null;
+
+                BaseModelConfig baseModelConfig = BaseModelConfig.baseModelConfigBuilder()
+                    .modelType((String) modelConfig.get(MODEL_TYPE))
+                    .additionalConfig(additionalConfig)
+                    .allConfig((String) modelConfig.get(ALL_CONFIG))
+                    .build();
+
+                mlInputBuilder.modelConfig(baseModelConfig);
             }
+
             if (description != null) {
                 mlInputBuilder.description(description);
             }

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStep.java
@@ -19,13 +19,10 @@ import java.util.Set;
 import static org.opensearch.flowframework.common.CommonValue.ALL_CONFIG;
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.EMBEDDING_DIMENSION;
-import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
-import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;import static org.opensearch.flowframework.common.CommonValue.MODEL_CONFIG;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
-import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.URL;
 import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
@@ -57,17 +54,7 @@ public class RegisterLocalCustomModelStep extends AbstractRegisterLocalModelStep
 
     @Override
     protected Set<String> getRequiredKeys() {
-        return Set.of(
-            NAME_FIELD,
-            VERSION_FIELD,
-            MODEL_FORMAT,
-            FUNCTION_NAME,
-            MODEL_CONTENT_HASH_VALUE,
-            URL,
-            MODEL_TYPE,
-            EMBEDDING_DIMENSION,
-            FRAMEWORK_TYPE
-        );
+        return Set.of(NAME_FIELD, VERSION_FIELD, MODEL_FORMAT, FUNCTION_NAME, MODEL_CONTENT_HASH_VALUE, URL, MODEL_CONFIG);
     }
 
     @Override

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -116,10 +116,20 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
                 Map.entry("model_format", "TORCH_SCRIPT"),
                 Map.entry(MODEL_GROUP_ID, "abcdefg"),
                 Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
-                Map.entry("model_type", "bert"),
-                Map.entry("embedding_dimension", "384"),
-                Map.entry("framework_type", "sentence_transformers"),
-                Map.entry("url", "something.com")
+                Map.entry("url", "something.com"),
+                Map.entry(
+                    "model_config",
+                    Map.of(
+                        "model_type",
+                        "bert",
+                        "embedding_dimension",
+                        "384",
+                        "framework_type",
+                        "sentence_transformers",
+                        "additional_config",
+                        Map.of("space_type", "l2")
+                    )
+                )
             ),
             "test-id",
             "test-node-id"
@@ -187,10 +197,20 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
                 Map.entry("model_format", "TORCH_SCRIPT"),
                 Map.entry(MODEL_GROUP_ID, "abcdefg"),
                 Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
-                Map.entry("model_type", "bert"),
-                Map.entry("embedding_dimension", "384"),
-                Map.entry("framework_type", "sentence_transformers"),
                 Map.entry("url", "something.com"),
+                Map.entry(
+                    "model_config",
+                    Map.of(
+                        "model_type",
+                        "bert",
+                        "embedding_dimension",
+                        "384",
+                        "framework_type",
+                        "sentence_transformers",
+                        "additional_config",
+                        Map.of("space_type", "l2")
+                    )
+                ),
                 Map.entry(DEPLOY_FIELD, "false")
             ),
             "test-id",
@@ -260,10 +280,20 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
                 Map.entry("model_format", "TORCH_SCRIPT"),
                 Map.entry(MODEL_GROUP_ID, "abcdefg"),
                 Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
-                Map.entry("model_type", "bert"),
-                Map.entry("embedding_dimension", "384"),
-                Map.entry("framework_type", "sentence_transformers"),
                 Map.entry("url", "something.com"),
+                Map.entry(
+                    "model_config",
+                    Map.of(
+                        "model_type",
+                        "bert",
+                        "embedding_dimension",
+                        "384",
+                        "framework_type",
+                        "sentence_transformers",
+                        "additional_config",
+                        Map.of("space_type", "l2")
+                    )
+                ),
                 Map.entry(DEPLOY_FIELD, "true")
             ),
             "test-id",
@@ -364,13 +394,11 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
         for (String s : new String[] {
             "model_format",
             "name",
-            "model_type",
-            "embedding_dimension",
-            "framework_type",
             "version",
             "url",
             "model_content_hash_value",
-            "function_name" }) {
+            "function_name",
+            "model_config" }) {
             assertTrue(ex.getCause().getMessage().contains(s));
         }
         assertTrue(ex.getCause().getMessage().endsWith("] in workflow [test-id] node [test-node-id]"));
@@ -386,10 +414,20 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
                 Map.entry("model_format", "TORCH_SCRIPT"),
                 Map.entry(MODEL_GROUP_ID, "abcdefg"),
                 Map.entry("model_content_hash_value", "aiwoeifjoaijeofiwe"),
-                Map.entry("model_type", "bert"),
-                Map.entry("embedding_dimension", "384"),
-                Map.entry("framework_type", "sentence_transformers"),
                 Map.entry("url", "something.com"),
+                Map.entry(
+                    "model_config",
+                    Map.of(
+                        "model_type",
+                        "bert",
+                        "embedding_dimension",
+                        "384",
+                        "framework_type",
+                        "sentence_transformers",
+                        "additional_config",
+                        Map.of("space_type", "l2")
+                    )
+                ),
                 Map.entry(DEPLOY_FIELD, "no")
             ),
             "test-id",


### PR DESCRIPTION


### Description
The OpenSearch 3.1+ RegisterModelInput API requires model_type, embedding_dimension, and framework_type to be nested under the model_config field. This step update ensures compatibility by constructing TextEmbeddingModelConfig from user input.

Also adds support for additional_config.space_type required for semantic fields.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
