### PR TITLE
Add Apache commons-text as we can't access ML Commons plugin classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ buildscript {
         junitJupiterVersion = "5.13.3"
         jakartaJsonBindVersion = "3.0.1"
         jakartaJsonVersion = "2.0.1"
+        commonsTextVersion = "1.10.0"
         yassonVersion = "3.0.4"
         parssonVersion = "1.1.7"
         swaggerVersion = "2.1.30"
@@ -124,6 +125,7 @@ allprojects {
         exclude group: 'org.apache.httpcomponents.core5', module: 'httpcore5'
         exclude group: 'org.apache.httpcomponents', module: 'httpcore'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
+        exclude group: 'org.apache.commons', module: 'commons-text'
         exclude group: 'org.codehaus.plexus', module: 'plexus-utils'
     }
 }
@@ -195,13 +197,14 @@ configurations {
 dependencies {
     implementation("org.opensearch:opensearch:${opensearch_version}")
     api("org.opensearch:opensearch-ml-client:${opensearch_build}")
-    // json and jsonpath are required by MLClient but must be provided by calling plugins
+    // json, jsonpath, and commons-text are required by MLClient but must be provided by calling plugins
     implementation('org.json:json:20231013')
     implementation('com.jayway.jsonpath:json-path:2.9.0') {
         // conflicts with OpenSearch versions
         exclude group: 'org.slf4j', module: 'slf4j-api'
         exclude group: 'net.minidev', module: 'json-smart'
     }
+    implementation("org.apache.commons:commons-text:${commonsTextVersion}")
     api("org.opensearch.client:opensearch-rest-client:${opensearch_version}") {
         exclude group: "org.apache.httpcomponents.client5", module: "httpclient5"
     }


### PR DESCRIPTION
### Description

Adds Apache commons-text as a dependency.

`org.apache.commons.text.StringSubstitutor` is used by ML Commons Connector validation done using `CreateConnectorInput` class that we consume in the ML Client.  

However, plugin ClassLoaders are isolated from each other, so Flow Framework does not have the correct import and fails executing the create connector step ([example](https://github.com/opensearch-project/flow-framework/actions/runs/16332997058/job/46139593794?pr=1178)).

The commit in this PR was cherry-picked from one previously applied to the version bump PR #1178 which resulted in passing tests, however, a force push by automation [overwrote the change](https://github.com/opensearch-project/flow-framework/compare/6128796eaabad7126fe439bdd29d056053a167ba..bb97fb0807eaccd6a4ce9bdcc63ca7c5c040cc3b) so I'm sumitting as a separate PR.

### Related Issues

Caused by https://github.com/opensearch-project/ml-commons/pull/3579 
Relates to https://github.com/opensearch-project/ml-commons/pull/3860
See https://github.com/opensearch-project/flow-framework/pull/1178#issuecomment-3076663303

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
