### PR TITLE
Avoid race condition setting encryption key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Fix ApiSpecFetcher Memory Issues and Exception Handling ([#1185](https://github.com/opensearch-project/flow-framework/pull/1185))
 - Better handling of Workflow Steps with Bad Request status ([#1190](https://github.com/opensearch-project/flow-framework/pull/1190))
 - update RegisterLocalCustomModelStep ([#1194](https://github.com/opensearch-project/flow-framework/pull/1194))
+- Avoid race condition setting encryption key ([#1200](https://github.com/opensearch-project/flow-framework/pull/1200))
 
 ### Infrastructure
 ### Documentation


### PR DESCRIPTION
### Description

If the first two templates created are created simultaneously (in different threads) they may both attempt to initialize the encryption key.  Without the `.overwriteIfExists(false)` setting on the `PutDataObjectRequest`, it is possible for the second thread to find the key doesn't exist, but then attempt to put its own new key _after_ the first thread has just stored it.  This causes the template created by the first thread to fail decryption as it does not have the correct key.

This fixes the issue by adding `.overwriteIfExists(false)` which will produce a RestStatus.CONFLICT in the case of this race condition; in which case we just try to GET the key again since we know it now exists.

### Related Issues

Related to https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/228

### Check List
- [X] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
