### PR TITLE
Fixing connector name in default use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Better handling of Workflow Steps with Bad Request status ([#1190](https://github.com/opensearch-project/flow-framework/pull/1190))
 - update RegisterLocalCustomModelStep ([#1194](https://github.com/opensearch-project/flow-framework/pull/1194))
 - Avoid race condition setting encryption key ([#1200](https://github.com/opensearch-project/flow-framework/pull/1200))
+- Fixing connector name in default use case ([#1205](https://github.com/opensearch-project/flow-framework/pull/1205))
 
 ### Infrastructure
 ### Documentation

--- a/src/main/resources/substitutionTemplates/conversational-search-with-cohere-model-template.json
+++ b/src/main/resources/substitutionTemplates/conversational-search-with-cohere-model-template.json
@@ -16,7 +16,7 @@
           "id": "create_connector",
           "type": "create_connector",
           "user_inputs": {
-            "name": "${{create_connector}}",
+            "name": "${{create_connector.name}}",
             "description": "${{create_connector.description}}",
             "version": "1",
             "protocol": "${{create_connector.protocol}}",

--- a/src/main/resources/substitutionTemplates/deploy-remote-model-chat-template.json
+++ b/src/main/resources/substitutionTemplates/deploy-remote-model-chat-template.json
@@ -16,7 +16,7 @@
           "id": "create_connector",
           "type": "create_connector",
           "user_inputs": {
-            "name": "${{create_connector}}",
+            "name": "${{create_connector.name}}",
             "description": "${{create_connector.description}}",
             "version": "1",
             "protocol": "${{create_connector.protocol}}",

--- a/src/main/resources/substitutionTemplates/deploy-remote-model-template.json
+++ b/src/main/resources/substitutionTemplates/deploy-remote-model-template.json
@@ -16,7 +16,7 @@
           "id": "create_connector",
           "type": "create_connector",
           "user_inputs": {
-            "name": "${{create_connector}}",
+            "name": "${{create_connector.name}}",
             "description": "${{create_connector.description}}",
             "version": "1",
             "protocol": "${{create_connector.protocol}}",


### PR DESCRIPTION
### Description
Fixed 3 default use cases where we accidentally had create_connector instead of create_connector.name in the expected substitution field for connector name.

Testing this out with the same input as in the original issue and everything works:

```
POST _plugins/_flow_framework/workflow?use_case=conversational_search_with_llm_deploy&provision=true
{
  "create_connector.credential.key": "******",
  "create_connector.endpoint": "gateway.example.com",
  "create_connector.model": "base",
  "create_connector.actions.url": "https://${parameters.endpoint}/completions",
  "create_connector.actions.request_body": "{ \"model\": \"${parameters.model}\", \"temperature\": 0.0, \"messages\": ${parameters.messages}, \"chat_template_kwargs\": {\"enable_thinking\": false} }",
  "register_remote_model.name": "Qwen gateway ai base model",
  "register_remote_model.description": "Qwen gateway ai base model",
  "create_search_pipeline.pipeline_id": "rag_gateway_ai_base",
  "create_search_pipeline.retrieval_augmented_generation.tag": "rag_gateway_ai_base_user_prompt",
  "create_search_pipeline.retrieval_augmented_generation.description": "Pipeline to gateway-ai base model",
  "create_search_pipeline.retrieval_augmented_generation.context_field_list": "[\"pageBody\"]",
  "create_search_pipeline.retrieval_augmented_generation.system_prompt": ""
}
```
### Related Issues
resolves #1197 

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
