### PR TITLE
Always succeed hasIndex checks with multiTenancy enabled

### DIFF
--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -142,12 +142,13 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin, SystemI
         Settings settings = environment.settings();
         flowFrameworkSettings = new FlowFrameworkSettings(clusterService, settings);
         MachineLearningNodeClient mlClient = new MachineLearningNodeClient(client);
+        boolean multiTenancyEnabled = FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED.get(settings);
         SdkClient sdkClient = SdkClientFactory.createSdkClient(
             client,
             xContentRegistry,
             // Here we assume remote metadata client is only used with tenant awareness.
             // This may change in the future allowing more options for this map
-            FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED.get(settings)
+            multiTenancyEnabled
                 ? Map.ofEntries(
                     Map.entry(REMOTE_METADATA_TYPE_KEY, REMOTE_METADATA_TYPE.get(settings)),
                     Map.entry(REMOTE_METADATA_ENDPOINT_KEY, REMOTE_METADATA_ENDPOINT.get(settings)),
@@ -160,13 +161,14 @@ public class FlowFrameworkPlugin extends Plugin implements ActionPlugin, SystemI
             // TODO: Find a better thread pool or make one
             client.threadPool().executor(ThreadPool.Names.GENERIC)
         );
-        EncryptorUtils encryptorUtils = new EncryptorUtils(clusterService, client, sdkClient, xContentRegistry);
+        EncryptorUtils encryptorUtils = new EncryptorUtils(clusterService, client, sdkClient, xContentRegistry, multiTenancyEnabled);
         FlowFrameworkIndicesHandler flowFrameworkIndicesHandler = new FlowFrameworkIndicesHandler(
             client,
             sdkClient,
             clusterService,
             encryptorUtils,
-            xContentRegistry
+            xContentRegistry,
+            multiTenancyEnabled
         );
         WorkflowStepFactory workflowStepFactory = new WorkflowStepFactory(
             threadPool,

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -86,6 +86,7 @@ public class FlowFrameworkIndicesHandler {
     private static final Map<String, AtomicBoolean> indexMappingUpdated = new HashMap<>();
     private static final Map<String, Object> indexSettings = Map.of("index.auto_expand_replicas", "0-1");
     private final NamedXContentRegistry xContentRegistry;
+    private final boolean multiTenancyEnabled;
     // Retries in case of simultaneous updates
     private static final int RETRIES = 5;
 
@@ -96,13 +97,15 @@ public class FlowFrameworkIndicesHandler {
      * @param clusterService ClusterService
      * @param encryptorUtils encryption utility
      * @param xContentRegistry contentRegister to parse any response
+     * @param multiTenancyEnabled whether multitenancy is enabled
      */
     public FlowFrameworkIndicesHandler(
         Client client,
         SdkClient sdkClient,
         ClusterService clusterService,
         EncryptorUtils encryptorUtils,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        boolean multiTenancyEnabled
     ) {
         this.client = client;
         this.sdkClient = sdkClient;
@@ -112,6 +115,7 @@ public class FlowFrameworkIndicesHandler {
             indexMappingUpdated.put(mlIndex.getIndexName(), new AtomicBoolean(false));
         }
         this.xContentRegistry = xContentRegistry;
+        this.multiTenancyEnabled = multiTenancyEnabled;
     }
 
     static {
@@ -177,7 +181,18 @@ public class FlowFrameworkIndicesHandler {
      * @return boolean indicating the existence of an index
      */
     public boolean doesIndexExist(String indexName) {
-        return clusterService.state().metadata().hasIndex(indexName);
+        return doesIndexExistMultitenant(clusterService, indexName, multiTenancyEnabled);
+    }
+
+    /**
+     * Checks if the given index exists, returning true if multitenancy is enabled
+     * @param cs the Cluster Service
+     * @param index the index to test
+     * @param multiTenancy whether multitenancy is enabled
+     * @return boolean indicating the existence of an index. Returns true if multitenancy is enabled.
+     */
+    public static boolean doesIndexExistMultitenant(ClusterService cs, String index, boolean multiTenancy) {
+        return multiTenancy || cs.state().metadata().hasIndex(index);
     }
 
     /**
@@ -191,7 +206,7 @@ public class FlowFrameworkIndicesHandler {
 
         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, threadContext::restore);
-            if (!clusterService.state().metadata().hasIndex(indexName)) {
+            if (!FlowFrameworkIndicesHandler.doesIndexExistMultitenant(clusterService, indexName, multiTenancyEnabled)) {
                 ActionListener<CreateIndexResponse> actionListener = ActionListener.wrap(r -> {
                     if (r.isAcknowledged()) {
                         logger.info("create index: {}", indexName);

--- a/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/flowframework/util/ParseUtils.java
@@ -33,6 +33,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.exception.FlowFrameworkException;
+import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.model.WorkflowState;
 import org.opensearch.flowframework.workflow.WorkflowData;
@@ -418,7 +419,7 @@ public class ParseUtils {
         NamedXContentRegistry xContentRegistry
     ) {
         String index = statePresent ? WORKFLOW_STATE_INDEX : GLOBAL_CONTEXT_INDEX;
-        if (clusterService.state().metadata().hasIndex(index)) {
+        if (FlowFrameworkIndicesHandler.doesIndexExistMultitenant(clusterService, index, isMultitenancyEnabled)) {
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
                 GetDataObjectRequest request = GetDataObjectRequest.builder().index(index).id(workflowId).tenantId(tenantId).build();
                 sdkClient.getDataObjectAsync(request).whenComplete((r, throwable) -> {

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkTenantAwareRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkTenantAwareRestTestCase.java
@@ -19,13 +19,16 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.rest.FakeRestRequest;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -33,7 +36,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.opensearch.common.xcontent.XContentType.JSON;
+import static org.opensearch.flowframework.common.CommonValue.CONFIG_INDEX;
+import static org.opensearch.flowframework.common.CommonValue.GLOBAL_CONTEXT_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.TENANT_ID_HEADER;
+import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_STATE_INDEX;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.FLOW_FRAMEWORK_MULTI_TENANCY_ENABLED;
 
 public abstract class FlowFrameworkTenantAwareRestTestCase extends FlowFrameworkRestTestCase {
@@ -212,5 +218,28 @@ public abstract class FlowFrameworkTenantAwareRestTestCase extends FlowFramework
             SearchResponse searchResponse = searchResponseFromResponse(response);
             assertEquals(hits, searchResponse.getHits().getTotalHits().value());
         }, 20, TimeUnit.SECONDS);
+    }
+
+    protected static void createFlowFrameworkIndices() throws IOException {
+        Map<String, String> indexMappings = Map.ofEntries(
+            Map.entry(CONFIG_INDEX, "/mappings/config.json"),
+            Map.entry(GLOBAL_CONTEXT_INDEX, "/mappings/global-context.json"),
+            Map.entry(WORKFLOW_STATE_INDEX, "/mappings/workflow-state.json")
+        );
+        for (Entry<String, String> entry : indexMappings.entrySet()) {
+            String index = entry.getKey();
+            String mappings = "{\"mappings\":" + ParseUtils.resourceToString(entry.getValue()) + "}";
+
+            try {
+                assertOK(TestHelpers.makeRequest(client(), PUT, "/" + index, Collections.emptyMap(), mappings, null));
+            } catch (ResponseException ex) {
+                assertTrue(ex.getMessage().contains("resource_already_exists_exception"));
+                assertEquals(RestStatus.BAD_REQUEST.getStatus(), ex.getResponse().getStatusLine().getStatusCode());
+                // Index already exists from a previous test, delete to clear contents
+                assertOK(TestHelpers.makeRequest(client(), DELETE, "/" + index, Collections.emptyMap(), "", null));
+                // Then recreate
+                assertOK(TestHelpers.makeRequest(client(), PUT, "/" + index, Collections.emptyMap(), mappings, null));
+            }
+        }
     }
 }

--- a/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
+++ b/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
@@ -123,7 +123,8 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
             sdkClient,
             clusterService,
             encryptorUtils,
-            xContentRegistry()
+            xContentRegistry(),
+            false
         );
         adminClient = mock(AdminClient.class);
         indicesAdminClient = mock(IndicesAdminClient.class);
@@ -167,6 +168,19 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
         verify(mockMetaData, times(1)).hasIndex(indexExistsCaptor.capture());
 
         assertEquals(GLOBAL_CONTEXT_INDEX, indexExistsCaptor.getValue());
+    }
+
+    public void testDoesIndexExistMultitenant() {
+        assertTrue(FlowFrameworkIndicesHandler.doesIndexExistMultitenant(null, null, true));
+        FlowFrameworkIndicesHandler flowFrameworkIndicesHandlerMultitenant = new FlowFrameworkIndicesHandler(
+            client,
+            sdkClient,
+            clusterService,
+            encryptorUtils,
+            xContentRegistry(),
+            true
+        );
+        assertTrue(flowFrameworkIndicesHandlerMultitenant.doesIndexExist(GLOBAL_CONTEXT_INDEX));
     }
 
     public void testFailedUpdateTemplateInGlobalContext() throws IOException {

--- a/src/test/java/org/opensearch/flowframework/rest/RestWorkflowProvisionTenantAwareIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestWorkflowProvisionTenantAwareIT.java
@@ -52,6 +52,10 @@ public class RestWorkflowProvisionTenantAwareIT extends FlowFrameworkTenantAware
 
     public void testWorkflowProvisionThrottle() throws Exception {
         boolean multiTenancyEnabled = isMultiTenancyEnabled();
+        // Code assumes indices exist with multitenancy
+        if (multiTenancyEnabled) {
+            createFlowFrameworkIndices();
+        }
 
         /*
          * Setup

--- a/src/test/java/org/opensearch/flowframework/rest/RestWorkflowStateTenantAwareIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestWorkflowStateTenantAwareIT.java
@@ -41,6 +41,10 @@ public class RestWorkflowStateTenantAwareIT extends FlowFrameworkTenantAwareRest
 
     public void testWorkflowStateCRUD() throws Exception {
         boolean multiTenancyEnabled = isMultiTenancyEnabled();
+        // Code assumes indices exist with multitenancy
+        if (multiTenancyEnabled) {
+            createFlowFrameworkIndices();
+        }
 
         /*
          * Create

--- a/src/test/java/org/opensearch/flowframework/rest/RestWorkflowTenantAwareIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestWorkflowTenantAwareIT.java
@@ -29,6 +29,10 @@ public class RestWorkflowTenantAwareIT extends FlowFrameworkTenantAwareRestTestC
 
     public void testWorkflowCRUD() throws Exception {
         boolean multiTenancyEnabled = isMultiTenancyEnabled();
+        // Code assumes indices exist with multitenancy
+        if (multiTenancyEnabled) {
+            createFlowFrameworkIndices();
+        }
 
         /*
          * Create

--- a/src/test/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/GetWorkflowStateTransportActionTests.java
@@ -86,9 +86,9 @@ public class GetWorkflowStateTransportActionTests extends OpenSearchTestCase {
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList(FlowFrameworkSettings.FILTER_BY_BACKEND_ROLES)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-        this.encryptorUtils = new EncryptorUtils(mock(ClusterService.class), client, sdkClient, xContentRegistry);
+        this.encryptorUtils = new EncryptorUtils(mock(ClusterService.class), client, sdkClient, xContentRegistry, false);
         this.flowFrameworkIndicesHandler = spy(
-            new FlowFrameworkIndicesHandler(client, sdkClient, clusterService, encryptorUtils, xContentRegistry)
+            new FlowFrameworkIndicesHandler(client, sdkClient, clusterService, encryptorUtils, xContentRegistry, false)
         );
 
         this.getWorkflowStateTransportAction = new GetWorkflowStateTransportAction(

--- a/src/test/java/org/opensearch/flowframework/transport/GetWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/GetWorkflowTransportActionTests.java
@@ -75,7 +75,7 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
         this.xContentRegistry = mock(NamedXContentRegistry.class);
         this.flowFrameworkSettings = mock(FlowFrameworkSettings.class);
         this.sdkClient = SdkClientFactory.createSdkClient(client, xContentRegistry, Collections.emptyMap());
-        this.encryptorUtils = new EncryptorUtils(mock(ClusterService.class), client, sdkClient, xContentRegistry);
+        this.encryptorUtils = new EncryptorUtils(mock(ClusterService.class), client, sdkClient, xContentRegistry, false);
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
@@ -83,7 +83,7 @@ public class GetWorkflowTransportActionTests extends OpenSearchTestCase {
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         this.flowFrameworkIndicesHandler = spy(
-            new FlowFrameworkIndicesHandler(client, sdkClient, clusterService, encryptorUtils, xContentRegistry)
+            new FlowFrameworkIndicesHandler(client, sdkClient, clusterService, encryptorUtils, xContentRegistry, false)
         );
 
         this.getTemplateTransportAction = new GetWorkflowTransportAction(

--- a/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportActionTests.java
@@ -103,7 +103,7 @@ public class ProvisionWorkflowTransportActionTests extends OpenSearchTestCase {
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         this.flowFrameworkIndicesHandler = spy(
-            new FlowFrameworkIndicesHandler(client, sdkClient, clusterService, encryptorUtils, xContentRegistry())
+            new FlowFrameworkIndicesHandler(client, sdkClient, clusterService, encryptorUtils, xContentRegistry(), false)
         );
 
         this.provisionWorkflowTransportAction = new ProvisionWorkflowTransportAction(

--- a/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/EncryptorUtilsTests.java
@@ -78,7 +78,7 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
         client = mock(Client.class);
         this.xContentRegistry = mock(NamedXContentRegistry.class);
         this.sdkClient = SdkClientFactory.createSdkClient(client, xContentRegistry, Collections.emptyMap());
-        this.encryptorUtils = new EncryptorUtils(clusterService, client, sdkClient, xContentRegistry);
+        this.encryptorUtils = new EncryptorUtils(clusterService, client, sdkClient, xContentRegistry, false);
         this.testMasterKey = encryptorUtils.generateMasterKey();
         this.testCredentialKey = "credential_key";
         this.testCredentialValue = "12345";
@@ -156,7 +156,7 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
 
         // Index exists case
         // reinitialize with blank master key
-        encryptorUtils = new EncryptorUtils(clusterService, client, sdkClient, xContentRegistry);
+        encryptorUtils = new EncryptorUtils(clusterService, client, sdkClient, xContentRegistry, false);
         assertNull(encryptorUtils.getMasterKey(null));
 
         doAnswer(invocation -> {
@@ -177,7 +177,7 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
 
         // Test ifAbsent version
         // reinitialize with blank master key
-        encryptorUtils = new EncryptorUtils(clusterService, client, sdkClient, xContentRegistry);
+        encryptorUtils = new EncryptorUtils(clusterService, client, sdkClient, xContentRegistry, false);
         assertNull(encryptorUtils.getMasterKey(null));
 
         encryptorUtils.initializeMasterKeyIfAbsent(null);
@@ -209,7 +209,7 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
 
         // reinitialize with blank master key and spied sdkClient
         SdkClient sdkClientSpy = spy(sdkClient);
-        encryptorUtils = new EncryptorUtils(clusterService, client, sdkClientSpy, xContentRegistry);
+        encryptorUtils = new EncryptorUtils(clusterService, client, sdkClientSpy, xContentRegistry, false);
         assertNull(encryptorUtils.getMasterKey(null));
 
         // Have the spied sdkClient return a failed future with CONFLICT
@@ -247,7 +247,7 @@ public class EncryptorUtilsTests extends OpenSearchTestCase {
 
     public void testInitializeMasterKeyFailure() throws IOException {
         // reinitialize with blank master key
-        encryptorUtils = new EncryptorUtils(clusterService, client, sdkClient, xContentRegistry);
+        encryptorUtils = new EncryptorUtils(clusterService, client, sdkClient, xContentRegistry, false);
 
         doAnswer(invocation -> {
             GetResponse getResponse = TestHelpers.createGetResponse(null, MASTER_KEY, CONFIG_INDEX);


### PR DESCRIPTION
### Description

Bypasses the ClusterService test for index existence when multitenancy is enabled.  In this case, indices are assumed to have been created in a remote (or local) store.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
