### PR TITLE
[2.19] Checkstyle requires JDK17+

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       # Spotless requires JDK 17+
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: Spotless Check
         run: ./gradlew spotlessCheck
@@ -28,6 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+	  # Checkstyle requires JDK 17+
+	  - uses: actions/setup-java@v4
+	    with:
+	      java-version: 21
+	      distribution: temurin
       - name: Javadoc CheckStyle
         run: ./gradlew checkstyleMain
       - name: Javadoc Check


### PR DESCRIPTION
### Description

Update spotless and checkstyle to run on JDK21.  They require JDK17+ but this will future-proof just a bit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
