### PR TITLE
Pre-create ML Commons indices for Tenant Aware tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,11 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased 3.2](https://github.com/opensearch-project/flow-framework/compare/3.1...HEAD)
+## [Unreleased 3.3](https://github.com/opensearch-project/flow-framework/compare/3.2...HEAD)
 ### Features
-- Add JsonToJson Recommender as a utility function ([#1167](https://github.com/opensearch-project/flow-framework/issues/1167))([#1168](https://github.com/opensearch-project/flow-framework/pull/1168))
-- Add JsonToJson Transformer as a utility function ([#1167](https://github.com/opensearch-project/flow-framework/issues/1167)) ([#1176](https://github.com/opensearch-project/flow-framework/pull/1176))
-
 ### Enhancements
 ### Bug Fixes
-- Fix ApiSpecFetcher Memory Issues and Exception Handling ([#1185](https://github.com/opensearch-project/flow-framework/pull/1185))
-- Better handling of Workflow Steps with Bad Request status ([#1190](https://github.com/opensearch-project/flow-framework/pull/1190))
-- update RegisterLocalCustomModelStep ([#1194](https://github.com/opensearch-project/flow-framework/pull/1194))
-- Avoid race condition setting encryption key ([#1200](https://github.com/opensearch-project/flow-framework/pull/1200))
-- Fixing connector name in default use case ([#1205](https://github.com/opensearch-project/flow-framework/pull/1205))
+- Pre-create ML Commons indices for Tenant Aware tests ([#1217](https://github.com/opensearch-project/flow-framework/pull/1217))
 
 ### Infrastructure
 ### Documentation

--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,13 @@ dependencies {
         exclude group: 'org.slf4j', module: 'slf4j-api'
         exclude group: 'net.minidev', module: 'json-smart'
     }
+    // needed to use MLIndex class mappings at (test) runtime but must be provided by calling plugins
+    compileOnly('com.networknt:json-schema-validator:1.4.0') {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+        exclude group: 'com.fasterxml.jackson.dataformat', module: 'jackson-dataformat-yaml'
+        exclude group: 'org.yml', module: 'snakeyaml'
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     implementation("org.apache.commons:commons-text:${commonsTextVersion}")
     api("org.opensearch.client:opensearch-rest-client:${opensearch_version}") {
         exclude group: "org.apache.httpcomponents.client5", module: "httpclient5"

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkTenantAwareRestTestCase.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkTenantAwareRestTestCase.java
@@ -20,6 +20,7 @@ import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.flowframework.util.ParseUtils;
+import org.opensearch.ml.common.MLIndex;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.rest.FakeRestRequest;
 
@@ -239,6 +240,23 @@ public abstract class FlowFrameworkTenantAwareRestTestCase extends FlowFramework
                 assertOK(TestHelpers.makeRequest(client(), DELETE, "/" + index, Collections.emptyMap(), "", null));
                 // Then recreate
                 assertOK(TestHelpers.makeRequest(client(), PUT, "/" + index, Collections.emptyMap(), mappings, null));
+            }
+        }
+    }
+
+    protected static void createMLCommonsIndices() throws Exception {
+        // Create each ML index. For tests we can just use default settings.
+        for (MLIndex mlIndex : MLIndex.values()) {
+            String requestPath = "/" + mlIndex.getIndexName();
+            String requestBody = "{\"mappings\":" + mlIndex.getMapping() + "}";
+            try {
+                TestHelpers.makeRequest(client(), "PUT", requestPath, null, requestBody, null);
+            } catch (ResponseException e) {
+                if (e.getMessage().contains("resource_already_exists_exception")) {
+                    // Index already exists, continue to the next one
+                    continue;
+                }
+                throw e;
             }
         }
     }

--- a/src/test/java/org/opensearch/flowframework/rest/RestWorkflowProvisionTenantAwareIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestWorkflowProvisionTenantAwareIT.java
@@ -54,6 +54,7 @@ public class RestWorkflowProvisionTenantAwareIT extends FlowFrameworkTenantAware
         boolean multiTenancyEnabled = isMultiTenancyEnabled();
         // Code assumes indices exist with multitenancy
         if (multiTenancyEnabled) {
+            createMLCommonsIndices();
             createFlowFrameworkIndices();
         }
 

--- a/src/test/java/org/opensearch/flowframework/rest/RestWorkflowStateTenantAwareIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestWorkflowStateTenantAwareIT.java
@@ -43,6 +43,7 @@ public class RestWorkflowStateTenantAwareIT extends FlowFrameworkTenantAwareRest
         boolean multiTenancyEnabled = isMultiTenancyEnabled();
         // Code assumes indices exist with multitenancy
         if (multiTenancyEnabled) {
+            createMLCommonsIndices();
             createFlowFrameworkIndices();
         }
 

--- a/src/test/java/org/opensearch/flowframework/rest/RestWorkflowTenantAwareIT.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestWorkflowTenantAwareIT.java
@@ -31,6 +31,7 @@ public class RestWorkflowTenantAwareIT extends FlowFrameworkTenantAwareRestTestC
         boolean multiTenancyEnabled = isMultiTenancyEnabled();
         // Code assumes indices exist with multitenancy
         if (multiTenancyEnabled) {
+            createMLCommonsIndices();
             createFlowFrameworkIndices();
         }
 


### PR DESCRIPTION
### Description

ML Commons indices are no longer created when tenant awareness is enabled, as it is assumed that external setup scripts are used to create these indices.

This iterates through the `MLIndex` enum and creates indices prior to running the Tenant Aware integ tests.

### Related Issues
 - Fixes https://github.com/opensearch-project/flow-framework/issues/1216 (currently failing CI tests)
 - Relates to https://github.com/opensearch-project/ml-commons/issues/3860

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
