### PR TITLE
Revert error_prone_annotations version force

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,6 @@ dependencies {
             // Some other plugin dependencies that don't use version catalog conflict here
             force("com.google.guava:guava:${versions.guava}")
             force("org.slf4j:slf4j-api:${versions.slf4j}")
-            force("com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}")
 
             if (System.getenv('REMOTE_METADATA_SDK_IMPL') == 'ddb-client') {
                 // OpenSearch Java client brings in different versions of the below dependencies.


### PR DESCRIPTION
### Description

An OpenSearch log4j version bump caused jar hell with the `error_prone_annotations` which we fixed as part of #1232.

OpenSearch has reverted the change (https://github.com/opensearch-project/OpenSearch/pull/19430) so it's no longer in the version catalog.

This PR may fail tests until the version bump change filters its way down through various upstream dependency fixes and snapshot publications (neural search, knn), so keep an eye out for those and merge when it passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
