### PR TITLE
Fix tests for updated User XContent requirements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,6 @@ dependencies {
             // Some other plugin dependencies that don't use version catalog conflict here
             force("com.google.guava:guava:${versions.guava}")
             force("org.slf4j:slf4j-api:${versions.slf4j}")
-            force("com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}")
 
             if (System.getenv('REMOTE_METADATA_SDK_IMPL') == 'ddb-client') {
                 // OpenSearch Java client brings in different versions of the below dependencies.

--- a/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/flowframework/util/ParseUtilsTests.java
@@ -122,7 +122,12 @@ public class ParseUtilsTests extends OpenSearchTestCase {
     public void testAddUserRoleFilterWithNullUserBackendRole() {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         ParseUtils.addUserBackendRolesFilter(
-            new User(randomAlphaOfLength(5), null, ImmutableList.of(randomAlphaOfLength(5)), ImmutableList.of(randomAlphaOfLength(5))),
+            new User(
+                randomAlphaOfLength(5),
+                null,
+                ImmutableList.of(randomAlphaOfLength(5)),
+                ImmutableList.of(String.join("=", randomAlphaOfLength(5), randomAlphaOfLength(5)))
+            ),
             searchSourceBuilder
         );
         assertEquals(
@@ -140,7 +145,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
                 randomAlphaOfLength(5),
                 ImmutableList.of(),
                 ImmutableList.of(randomAlphaOfLength(5)),
-                ImmutableList.of(randomAlphaOfLength(5))
+                ImmutableList.of(String.join("=", randomAlphaOfLength(5), randomAlphaOfLength(5)))
             ),
             searchSourceBuilder
         );
@@ -161,7 +166,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
                 randomAlphaOfLength(5),
                 ImmutableList.of(backendRole1, backendRole2),
                 ImmutableList.of(randomAlphaOfLength(5)),
-                ImmutableList.of(randomAlphaOfLength(5))
+                ImmutableList.of(String.join("=", randomAlphaOfLength(5), randomAlphaOfLength(5)))
             ),
             searchSourceBuilder
         );
@@ -420,7 +425,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
             randomAlphaOfLength(5),
             ImmutableList.of(),
             ImmutableList.of("all_access"),
-            ImmutableList.of(randomAlphaOfLength(5))
+            ImmutableList.of(String.join("=", randomAlphaOfLength(5), randomAlphaOfLength(5)))
         );
         assertTrue(isAdmin(user1));
     }
@@ -431,7 +436,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
             randomAlphaOfLength(5),
             ImmutableList.of(backendRole1),
             ImmutableList.of(randomAlphaOfLength(5)),
-            ImmutableList.of(randomAlphaOfLength(5))
+            ImmutableList.of(String.join("=", randomAlphaOfLength(5), randomAlphaOfLength(5)))
         );
         assertFalse(isAdmin(user1));
     }


### PR DESCRIPTION
### Description

A recent bugfix in the `User` constructor (https://github.com/opensearch-project/common-utils/pull/878) changes the expectation to require a key-value pair.

### Related Issues
Resolves #1235 

Reference PR: https://github.com/opensearch-project/security-analytics/pull/1583

### Check List
- [x] New functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
