### PR TITLE
[2.19] Update maven repo for Central snapshot publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,11 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        maven { url = "https://central.sonatype.com/repository/maven-snapshots/" }
+        maven { url = "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
-        maven { url 'https://jitpack.io' }
+        maven { url = "https://plugins.gradle.org/m2/" }
+        maven { url = 'https://jitpack.io' }
     }
 
     dependencies {
@@ -148,10 +149,10 @@ publishing {
         }
         maven {
             name = "Snapshots"
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            url = "https://central.sonatype.com/repository/maven-snapshots/"
             credentials {
-                username "$System.env.SONATYPE_USERNAME"
-                password "$System.env.SONATYPE_PASSWORD"
+                username = System.getenv("SONATYPE_USERNAME")
+                password = System.getenv("SONATYPE_USERNAME")
             }
         }
     }


### PR DESCRIPTION
### Description

Effectively backports #1170 and #1219.

Cherry-picked from commits that keep getting overwritten, needed for #1222 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
