### PR TITLE
Exclude conflicting netty versions from ddb client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -239,6 +239,7 @@ dependencies {
         api("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}")
         implementation("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}") {
             exclude group: "jakarta.json", module: "jakarta.json-api"
+            exclude group: "io.netty"
         }
     } else {
         implementation("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}")


### PR DESCRIPTION
### Description

Excludes the transitive (old) netty versions from ddb client import

### Related Issues

Fixes build failures blocking #3693

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
