### PR TITLE
refactor: Add constants to CreateConnectorStep and update enum usage #535

### DIFF
--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -57,20 +57,20 @@ public class CreateConnectorStep implements WorkflowStep {
 
     /** The name of this step, used as a key in the template and the {@link WorkflowStepFactory} */
     public static final String NAME = "create_connector";
-
-    public static final Set<String> REQUIRED_INPUTS =Set.of(
-            NAME_FIELD,
-            DESCRIPTION_FIELD,
-            VERSION_FIELD,
-            PROTOCOL_FIELD,
-            PARAMETERS_FIELD,
-            CREDENTIAL_FIELD,
-            ACTIONS_FIELD
+    /** Required input keys */
+    public static final Set<String> REQUIRED_INPUTS = Set.of(
+        NAME_FIELD,
+        DESCRIPTION_FIELD,
+        VERSION_FIELD,
+        PROTOCOL_FIELD,
+        PARAMETERS_FIELD,
+        CREDENTIAL_FIELD,
+        ACTIONS_FIELD
     );
-
+    /** Optional input keys */
     public static final Set<String> OPTIONAL_INPUTS = Collections.emptySet();
-
-    public static final Set<String> PROVIDED_OUTPUTS =Set.of(CONNECTOR_ID);
+    /** Provided output keys */
+    public static final Set<String> PROVIDED_OUTPUTS = Set.of(CONNECTOR_ID);
 
     /**
      * Instantiate this class
@@ -117,8 +117,6 @@ public class CreateConnectorStep implements WorkflowStep {
                 createConnectorFuture.onFailure(new WorkflowStepException(errorMessage, ExceptionsHelper.status(e)));
             }
         };
-
-
 
         try {
             Map<String, Object> inputs = ParseUtils.getInputsFromPreviousSteps(

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -23,15 +23,18 @@ import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.opensearch.flowframework.common.CommonValue.ACTIONS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.CONFIGURATIONS;
-import static org.opensearch.flowframework.common.CommonValue.CREDENTIAL_FIELD;
-import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESTINATION_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.EMBEDDING_DIMENSION;
 import static org.opensearch.flowframework.common.CommonValue.FRAMEWORK_TYPE;
@@ -42,9 +45,7 @@ import static org.opensearch.flowframework.common.CommonValue.MODEL_GROUP_STATUS
 import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.OPENSEARCH_ML;
-import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PIPELINE_ID;
-import static org.opensearch.flowframework.common.CommonValue.PROTOCOL_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.CommonValue.SOURCE_INDEX;
 import static org.opensearch.flowframework.common.CommonValue.SUCCESS;

--- a/src/test/java/org/opensearch/flowframework/model/WorkflowStepValidatorTests.java
+++ b/src/test/java/org/opensearch/flowframework/model/WorkflowStepValidatorTests.java
@@ -13,8 +13,6 @@ import org.opensearch.flowframework.workflow.WorkflowStepFactory;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 public class WorkflowStepValidatorTests extends OpenSearchTestCase {
 
@@ -25,13 +23,13 @@ public class WorkflowStepValidatorTests extends OpenSearchTestCase {
 
     public void testParseWorkflowStepValidator() throws IOException {
 
-       var step = WorkflowStepFactory.WorkflowSteps.CREATE_CONNECTOR;
+        var step = WorkflowStepFactory.WorkflowSteps.CREATE_CONNECTOR;
 
-        assertEquals(CreateConnectorStep.NAME,step.getWorkflowStepName());
+        assertEquals(CreateConnectorStep.NAME, step.getWorkflowStepName());
 
-        assertEquals(CreateConnectorStep.REQUIRED_INPUTS.size(),step.inputs().size());
+        assertEquals(CreateConnectorStep.REQUIRED_INPUTS.size(), step.inputs().size());
         assertTrue(step.inputs().containsAll(CreateConnectorStep.REQUIRED_INPUTS));
-        assertEquals(CreateConnectorStep.PROVIDED_OUTPUTS.size(),step.outputs().size());
+        assertEquals(CreateConnectorStep.PROVIDED_OUTPUTS.size(), step.outputs().size());
         assertTrue(step.outputs().containsAll(CreateConnectorStep.PROVIDED_OUTPUTS));
     }
 


### PR DESCRIPTION
### Description
Add constants to CreateConnectorStep and update enum usage

### Related Issues
Part of #535 

### Check List
-.- Add REQUIRED_INPUTS, OPTIONAL_INPUTS, and PROVIDED_OUTPUTS constants to CreateConnectorStep
- Update WorkflowSteps.CREATE_CONNECTOR enum to use constants from CreateConnectorStep class
- Refactor WorkflowStepValidatorTests to use constants instead of magic strings
- Remove code duplication between CreateConnectorStep and WorkflowSteps enum


