### PR TITLE
Fix templates for OpenSearch 3.x by removing _doc mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Fix substitution templates for OpenSearch 3.x compatibility by removing `_doc` mapping ([#1301](https://github.com/opensearch-project/flow-framework/pull/1301))
+
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/resources/substitutionTemplates/hybrid-search-template.json
+++ b/src/main/resources/substitutionTemplates/hybrid-search-template.json
@@ -48,21 +48,19 @@
                 "index.search.default_pipeline": "${{create_search_pipeline.pipeline_id}}"
               },
               "mappings": {
-                "_doc": {
-                  "properties": {
-                    "${{text_embedding.field_map.output}}": {
-                      "type": "knn_vector",
-                      "dimension": "${{text_embedding.field_map.output.dimension}}",
-                      "method": {
-                        "engine": "${{create_index.mappings.method.engine}}",
-                        "space_type": "${{create_index.mappings.method.space_type}}",
-                        "name": "${{create_index.mappings.method.name}}",
-                        "parameters": {}
-                      }
-                    },
-                    "${{text_embedding.field_map.input}}": {
-                      "type": "text"
+                "properties": {
+                  "${{text_embedding.field_map.output}}": {
+                    "type": "knn_vector",
+                    "dimension": "${{text_embedding.field_map.output.dimension}}",
+                    "method": {
+                      "engine": "${{create_index.mappings.method.engine}}",
+                      "space_type": "${{create_index.mappings.method.space_type}}",
+                      "name": "${{create_index.mappings.method.name}}",
+                      "parameters": {}
                     }
+                  },
+                  "${{text_embedding.field_map.input}}": {
+                    "type": "text"
                   }
                 }
               }

--- a/src/main/resources/substitutionTemplates/multi-modal-search-template.json
+++ b/src/main/resources/substitutionTemplates/multi-modal-search-template.json
@@ -49,23 +49,21 @@
                 "number_of_shards": "${{create_index.settings.number_of_shards}}"
               },
               "mappings": {
-                "_doc": {
-                  "properties": {
-                    "${{text_image_embedding.embedding}}": {
-                      "type": "knn_vector",
-                      "dimension": "${{text_image_embedding.field_map.output.dimension}}",
-                      "method": {
-                        "engine": "${{create_index.mappings.method.engine}}",
-                        "name": "${{create_index.mappings.method.name}}",
-                        "parameters": {}
-                      }
-                    },
-                    "${{text_image_embedding.field_map.text}}": {
-                      "type": "${{text_image_embedding.field_map.text.type}}"
-                    },
-                    "${{text_image_embedding.field_map.image}}": {
-                      "type": "${{text_image_embedding.field_map.image.type}}"
+                "properties": {
+                  "${{text_image_embedding.embedding}}": {
+                    "type": "knn_vector",
+                    "dimension": "${{text_image_embedding.field_map.output.dimension}}",
+                    "method": {
+                      "engine": "${{create_index.mappings.method.engine}}",
+                      "name": "${{create_index.mappings.method.name}}",
+                      "parameters": {}
                     }
+                  },
+                  "${{text_image_embedding.field_map.text}}": {
+                    "type": "${{text_image_embedding.field_map.text.type}}"
+                  },
+                  "${{text_image_embedding.field_map.image}}": {
+                    "type": "${{text_image_embedding.field_map.image.type}}"
                   }
                 }
               }

--- a/src/main/resources/substitutionTemplates/multi-modal-search-with-bedrock-titan-template.json
+++ b/src/main/resources/substitutionTemplates/multi-modal-search-with-bedrock-titan-template.json
@@ -56,7 +56,7 @@
             "name": "${{register_remote_model.name}}",
             "function_name": "remote",
             "description": "${{register_remote_model.description}}",
-            "deploy" : true
+            "deploy": true
           }
         },
         {
@@ -99,23 +99,21 @@
                 "number_of_shards": "${{create_index.settings.number_of_shards}}"
               },
               "mappings": {
-                "_doc": {
-                  "properties": {
-                    "${{text_image_embedding.embedding}}": {
-                      "type": "knn_vector",
-                      "dimension": "${{text_image_embedding.field_map.output.dimension}}",
-                      "method": {
-                        "engine": "${{create_index.mappings.method.engine}}",
-                        "name": "${{create_index.mappings.method.name}}",
-                        "parameters": {}
-                      }
-                    },
-                    "${{text_image_embedding.field_map.text}}": {
-                      "type": "${{text_image_embedding.field_map.text.type}}"
-                    },
-                    "${{text_image_embedding.field_map.image}}": {
-                      "type": "${{text_image_embedding.field_map.image.type}}"
+                "properties": {
+                  "${{text_image_embedding.embedding}}": {
+                    "type": "knn_vector",
+                    "dimension": "${{text_image_embedding.field_map.output.dimension}}",
+                    "method": {
+                      "engine": "${{create_index.mappings.method.engine}}",
+                      "name": "${{create_index.mappings.method.name}}",
+                      "parameters": {}
                     }
+                  },
+                  "${{text_image_embedding.field_map.text}}": {
+                    "type": "${{text_image_embedding.field_map.text.type}}"
+                  },
+                  "${{text_image_embedding.field_map.image}}": {
+                    "type": "${{text_image_embedding.field_map.image.type}}"
                   }
                 }
               }

--- a/src/main/resources/substitutionTemplates/neural-sparse-local-biencoder-template.json
+++ b/src/main/resources/substitutionTemplates/neural-sparse-local-biencoder-template.json
@@ -59,14 +59,12 @@
                 "default_pipeline": "${{create_ingest_pipeline.pipeline_id}}"
               },
               "mappings": {
-                "_doc": {
-                  "properties": {
-                    "${{create_ingest_pipeline.text_embedding.field_map.output}}": {
-                      "type": "rank_features"
-                    },
-                    "${{create_ingest_pipeline.text_embedding.field_map.input}}": {
-                      "type": "text"
-                    }
+                "properties": {
+                  "${{create_ingest_pipeline.text_embedding.field_map.output}}": {
+                    "type": "rank_features"
+                  },
+                  "${{create_ingest_pipeline.text_embedding.field_map.input}}": {
+                    "type": "text"
                   }
                 }
               }

--- a/src/main/resources/substitutionTemplates/semantic-search-template.json
+++ b/src/main/resources/substitutionTemplates/semantic-search-template.json
@@ -47,21 +47,19 @@
                 "number_of_shards": "${{create_index.settings.number_of_shards}}"
               },
               "mappings": {
-                "_doc": {
-                  "properties": {
-                    "${{text_embedding.field_map.output}}": {
-                      "type": "knn_vector",
-                      "dimension": "${{text_embedding.field_map.output.dimension}}",
-                      "method": {
-                        "engine": "${{create_index.mappings.method.engine}}",
-                        "space_type": "${{create_index.mappings.method.space_type}}",
-                        "name": "${{create_index.mappings.method.name}}",
-                        "parameters": {}
-                      }
-                    },
-                    "${{text_embedding.field_map.input}}": {
-                      "type": "text"
+                "properties": {
+                  "${{text_embedding.field_map.output}}": {
+                    "type": "knn_vector",
+                    "dimension": "${{text_embedding.field_map.output.dimension}}",
+                    "method": {
+                      "engine": "${{create_index.mappings.method.engine}}",
+                      "space_type": "${{create_index.mappings.method.space_type}}",
+                      "name": "${{create_index.mappings.method.name}}",
+                      "parameters": {}
                     }
+                  },
+                  "${{text_embedding.field_map.input}}": {
+                    "type": "text"
                   }
                 }
               }

--- a/src/main/resources/substitutionTemplates/semantic-search-with-model-and-query-enricher-template.json
+++ b/src/main/resources/substitutionTemplates/semantic-search-with-model-and-query-enricher-template.json
@@ -97,21 +97,19 @@
                 "index.search.default_pipeline": "${{create_search_pipeline.pipeline_id}}"
               },
               "mappings": {
-                "_doc": {
-                  "properties": {
-                    "${{text_embedding.field_map.output}}": {
-                      "type": "knn_vector",
-                      "dimension": "${{text_embedding.field_map.output.dimension}}",
-                      "method": {
-                        "engine": "${{create_index.mappings.method.engine}}",
-                        "space_type": "${{create_index.mappings.method.space_type}}",
-                        "name": "${{create_index.mappings.method.name}}",
-                        "parameters": {}
-                      }
-                    },
-                    "${{text_embedding.field_map.input}}": {
-                      "type": "text"
+                "properties": {
+                  "${{text_embedding.field_map.output}}": {
+                    "type": "knn_vector",
+                    "dimension": "${{text_embedding.field_map.output.dimension}}",
+                    "method": {
+                      "engine": "${{create_index.mappings.method.engine}}",
+                      "space_type": "${{create_index.mappings.method.space_type}}",
+                      "name": "${{create_index.mappings.method.name}}",
+                      "parameters": {}
                     }
+                  },
+                  "${{text_embedding.field_map.input}}": {
+                    "type": "text"
                   }
                 }
               }
@@ -129,7 +127,7 @@
             "configurations": {
               "request_processors": [
                 {
-                  "neural_query_enricher" : {
+                  "neural_query_enricher": {
                     "description": "Sets the default model ID at index and field levels",
                     "default_model_id": "${{register_model.model_id}}"
                   }

--- a/src/main/resources/substitutionTemplates/semantic-search-with-model-template.json
+++ b/src/main/resources/substitutionTemplates/semantic-search-with-model-template.json
@@ -96,21 +96,19 @@
                 "number_of_shards": "${{create_index.settings.number_of_shards}}"
               },
               "mappings": {
-                "_doc": {
-                  "properties": {
-                    "${{text_embedding.field_map.output}}": {
-                      "type": "knn_vector",
-                      "dimension": "${{text_embedding.field_map.output.dimension}}",
-                      "method": {
-                        "engine": "${{create_index.mappings.method.engine}}",
-                        "space_type": "${{create_index.mappings.method.space_type}}",
-                        "name": "${{create_index.mappings.method.name}}",
-                        "parameters": {}
-                      }
-                    },
-                    "${{text_embedding.field_map.input}}": {
-                      "type": "text"
+                "properties": {
+                  "${{text_embedding.field_map.output}}": {
+                    "type": "knn_vector",
+                    "dimension": "${{text_embedding.field_map.output.dimension}}",
+                    "method": {
+                      "engine": "${{create_index.mappings.method.engine}}",
+                      "space_type": "${{create_index.mappings.method.space_type}}",
+                      "name": "${{create_index.mappings.method.name}}",
+                      "parameters": {}
                     }
+                  },
+                  "${{text_embedding.field_map.input}}": {
+                    "type": "text"
                   }
                 }
               }

--- a/src/main/resources/substitutionTemplates/semantic-search-with-query-enricher-template.json
+++ b/src/main/resources/substitutionTemplates/semantic-search-with-query-enricher-template.json
@@ -40,7 +40,7 @@
             "configurations": {
               "request_processors": [
                 {
-                  "neural_query_enricher" : {
+                  "neural_query_enricher": {
                     "description": "Sets the default model ID at index and field levels",
                     "default_model_id": "${{create_ingest_pipeline.model_id}}"
                   }
@@ -65,21 +65,19 @@
                 "index.search.default_pipeline": "${{create_search_pipeline.pipeline_id}}"
               },
               "mappings": {
-                "_doc": {
-                  "properties": {
-                    "${{text_embedding.field_map.output}}": {
-                      "type": "knn_vector",
-                      "dimension": "${{text_embedding.field_map.output.dimension}}",
-                      "method": {
-                        "engine": "${{create_index.mappings.method.engine}}",
-                        "space_type": "${{create_index.mappings.method.space_type}}",
-                        "name": "${{create_index.mappings.method.name}}",
-                        "parameters": {}
-                      }
-                    },
-                    "${{text_embedding.field_map.input}}": {
-                      "type": "text"
+                "properties": {
+                  "${{text_embedding.field_map.output}}": {
+                    "type": "knn_vector",
+                    "dimension": "${{text_embedding.field_map.output.dimension}}",
+                    "method": {
+                      "engine": "${{create_index.mappings.method.engine}}",
+                      "space_type": "${{create_index.mappings.method.space_type}}",
+                      "name": "${{create_index.mappings.method.name}}",
+                      "parameters": {}
                     }
+                  },
+                  "${{text_embedding.field_map.input}}": {
+                    "type": "text"
                   }
                 }
               }


### PR DESCRIPTION
### Description
This PR fixes a compatibility issue with OpenSearch 3.x where workflows created from the `hybrid_search` template fail during the `create_index` step.

The root cause was the use of the deprecated `_doc` mapping type in the index definition, which is no longer permitted starting in OpenSearch 3.x. This change updates the `hybrid_search` template to remove the `_doc` mapping and align it with OpenSearch 3.x requirements, while preserving existing behavior on OpenSearch 2.x.

As a result, workflows using the `hybrid_search` template now complete successfully on OpenSearch 3.x.

---

### Related Issues
https://github.com/opensearch-project/flow-framework/issues/1300

---

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request created (not applicable).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created (not applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check
[here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

