### PR TITLE
Setting bc-fips dependency to complieOnly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,12 +225,8 @@ dependencies {
     implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${awsCryptoMaterialProvidersVersion}")
     implementation("org.dafny:DafnyRuntime:${dafnyRuntimeVersion}")
     implementation("software.amazon.smithy.dafny:conversion:${smithyDafnyVersion}")
-    // When building with -Pcrypto.standard=FIPS-140-3, bcFips jar is provided by OpenSearch
-    if (FipsBuildParams.isInFipsMode()) {
-        compileOnly("org.bouncycastle:bc-fips:${versions.bouncycastle_jce}")
-    } else {
-        implementation("org.bouncycastle:bc-fips:${versions.bouncycastle_jce}")
-    }
+    // bc-fips is bundled in OpenSearch core lib/ (since 3.6), always provided at runtime
+    compileOnly("org.bouncycastle:bc-fips:${versions.bouncycastle_jce}")
     implementation("jakarta.json.bind:jakarta.json.bind-api:${jakartaJsonBindVersion}")
     implementation("org.glassfish:jakarta.json:${jakartaJsonVersion}")
     implementation("org.eclipse:yasson:${yassonVersion}")


### PR DESCRIPTION
### Description
bc-fips is bundled with OpenSearch starting 3.6, causing jarhell. Setting dependency to compile only

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
