### PR TITLE
Add agentic search workflow template with flow agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased 3.x](https://github.com/opensearch-project/flow-framework/compare/3.5...HEAD)
 ### Features
+- Add agentic search workflow template with flow agent ([#1349](https://github.com/opensearch-project/flow-framework/pull/1349))
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
+++ b/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
@@ -163,6 +163,13 @@ public enum DefaultUseCases {
         "defaults/conversational-search-rag-tool-defaults.json",
         "substitutionTemplates/conversational-search-with-bedrock-rag-tool-template.json",
         List.of(CREATE_CONNECTOR_CREDENTIAL_ACCESS_KEY, CREATE_CONNECTOR_CREDENTIAL_SECRET_KEY, CREATE_CONNECTOR_CREDENTIAL_SESSION_TOKEN)
+    ),
+    /** defaults file and substitution ready template for agentic search with flow agent */
+    AGENTIC_SEARCH_WITH_FLOW_AGENT(
+        "agentic_search_with_flow_agent",
+        "defaults/agentic-search-with-flow-agent-defaults.json",
+        "substitutionTemplates/agentic-search-with-flow-agent-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_ACCESS_KEY, CREATE_CONNECTOR_CREDENTIAL_SECRET_KEY, CREATE_CONNECTOR_CREDENTIAL_SESSION_TOKEN)
     );
 
     private final String useCaseName;

--- a/src/main/resources/defaults/agentic-search-with-flow-agent-defaults.json
+++ b/src/main/resources/defaults/agentic-search-with-flow-agent-defaults.json
@@ -1,0 +1,21 @@
+{
+  "template.name": "agentic_search_with_flow_agent",
+  "template.description": "Setting up agentic search with a flow agent and Bedrock Claude",
+  "create_connector.name": "Amazon Bedrock Connector: Claude 4 Sonnet",
+  "create_connector.description": "Connector to Amazon Bedrock Claude model for agentic search",
+  "create_connector.protocol": "aws_sigv4",
+  "create_connector.region": "us-west-2",
+  "create_connector.model": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+  "create_connector.credential.access_key": "",
+  "create_connector.credential.secret_key": "",
+  "create_connector.credential.session_token": "",
+  "create_connector.actions.url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+  "create_connector.actions.request_body": "{ \"system\": [{\"text\": \"${parameters.system_prompt}\"}], \"messages\": [${parameters._chat_history:-}{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}${parameters._interactions:-}]${parameters.tool_configs:-} }",
+  "register_remote_model.name": "Bedrock Claude model for agentic search",
+  "register_remote_model.description": "Model used for query planning in agentic search",
+  "register_agent.name": "Flow Agent for Agentic Search",
+  "register_agent.description": "Flow agent for agentic search",
+  "register_agent.type": "flow",
+  "query_planning_tool.response_filter": "$.output.message.content[0].text",
+  "create_search_pipeline.pipeline_id": "agentic-search-pipeline"
+}

--- a/src/main/resources/substitutionTemplates/agentic-search-with-flow-agent-template.json
+++ b/src/main/resources/substitutionTemplates/agentic-search-with-flow-agent-template.json
@@ -1,0 +1,131 @@
+{
+  "name": "${{template.name}}",
+  "description": "${{template.description}}",
+  "use_case": "AGENTIC_SEARCH_WITH_FLOW_AGENT",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": [
+      "3.2.0",
+      "3.6.0"
+    ]
+  },
+  "workflows": {
+    "provision": {
+      "nodes": [
+        {
+          "id": "create_connector",
+          "type": "create_connector",
+          "user_inputs": {
+            "name": "${{create_connector.name}}",
+            "description": "${{create_connector.description}}",
+            "version": "1",
+            "protocol": "${{create_connector.protocol}}",
+            "parameters": {
+              "region": "${{create_connector.region}}",
+              "service_name": "bedrock",
+              "model": "${{create_connector.model}}"
+            },
+            "credential": {
+              "access_key": "${{create_connector.credential.access_key}}",
+              "secret_key": "${{create_connector.credential.secret_key}}",
+              "session_token": "${{create_connector.credential.session_token}}"
+            },
+            "actions": [
+              {
+                "action_type": "predict",
+                "method": "POST",
+                "url": "${{create_connector.actions.url}}",
+                "headers": {
+                  "content-type": "application/json"
+                },
+                "request_body": "${{create_connector.actions.request_body}}"
+              }
+            ]
+          }
+        },
+        {
+          "id": "register_model",
+          "type": "register_remote_model",
+          "previous_node_inputs": {
+            "create_connector": "parameters"
+          },
+          "user_inputs": {
+            "name": "${{register_remote_model.name}}",
+            "function_name": "remote",
+            "description": "${{register_remote_model.description}}",
+            "deploy": true
+          }
+        },
+        {
+          "id": "query_planning_tool",
+          "type": "create_tool",
+          "previous_node_inputs": {
+            "register_model": "model_id"
+          },
+          "user_inputs": {
+            "type": "QueryPlanningTool",
+            "name": "QueryPlanningTool",
+            "parameters": {
+              "model_id": "${{register_model.model_id}}",
+              "response_filter": "${{query_planning_tool.response_filter}}"
+            }
+          }
+        },
+        {
+          "id": "register_agent",
+          "type": "register_agent",
+          "previous_node_inputs": {
+            "register_model": "model_id",
+            "query_planning_tool": "tools"
+          },
+          "user_inputs": {
+            "name": "${{register_agent.name}}",
+            "type": "${{register_agent.type}}",
+            "description": "${{register_agent.description}}"
+          }
+        },
+        {
+          "id": "create_search_pipeline",
+          "type": "create_search_pipeline",
+          "previous_node_inputs": {
+            "register_agent": "agent_id"
+          },
+          "user_inputs": {
+            "pipeline_id": "${{create_search_pipeline.pipeline_id}}",
+            "configurations": {
+              "request_processors": [
+                {
+                  "agentic_query_translator": {
+                    "agent_id": "${{register_agent.agent_id}}"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "edges": [
+        {
+          "source": "create_connector",
+          "dest": "register_model"
+        },
+        {
+          "source": "register_model",
+          "dest": "query_planning_tool"
+        },
+        {
+          "source": "query_planning_tool",
+          "dest": "register_agent"
+        },
+        {
+          "source": "register_model",
+          "dest": "register_agent"
+        },
+        {
+          "source": "register_agent",
+          "dest": "create_search_pipeline"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/java/org/opensearch/flowframework/common/DefaultUseCasesTests.java
+++ b/src/test/java/org/opensearch/flowframework/common/DefaultUseCasesTests.java
@@ -41,4 +41,22 @@ public class DefaultUseCasesTests extends OpenSearchTestCase {
             () -> DefaultUseCases.getSubstitutionReadyFileByUseCaseName("invalid_use_case")
         );
     }
+
+    public void testAgenticSearchWithFlowAgentDefaults() throws FlowFrameworkException {
+        String defaultsFile = DefaultUseCases.getDefaultsFileByUseCaseName("agentic_search_with_flow_agent");
+        assertEquals("defaults/agentic-search-with-flow-agent-defaults.json", defaultsFile);
+    }
+
+    public void testAgenticSearchWithFlowAgentTemplate() throws FlowFrameworkException {
+        String templateFile = DefaultUseCases.getSubstitutionReadyFileByUseCaseName("agentic_search_with_flow_agent");
+        assertEquals("substitutionTemplates/agentic-search-with-flow-agent-template.json", templateFile);
+    }
+
+    public void testAgenticSearchWithFlowAgentRequiredParams() {
+        var params = DefaultUseCases.getRequiredParamsByUseCaseName("agentic_search_with_flow_agent");
+        assertEquals(3, params.size());
+        assertTrue(params.contains("create_connector.credential.access_key"));
+        assertTrue(params.contains("create_connector.credential.secret_key"));
+        assertTrue(params.contains("create_connector.credential.session_token"));
+    }
 }


### PR DESCRIPTION
### Description

Adds a new default workflow template for **Agentic Search** using a flow agent with QueryPlanningTool and Amazon Bedrock Claude. This addresses item #4 from #1225.

### What it provisions

The template creates the following resources in order:
1. **Bedrock Connector** — `aws_sigv4` connector using the Converse API (defaults to Claude 4 Sonnet)
2. **Remote Model** — registers and deploys the chat model
3. **QueryPlanningTool** — creates the tool with the deployed model and Bedrock response filter
4. **Flow Agent** — registers a flow agent wired to the QueryPlanningTool
5. **Search Pipeline** — creates a search pipeline with `agentic_query_translator` request processor

### Usage

```
POST _plugins/_flow_framework/workflow?use_case=agentic_search_with_flow_agent&provision=true
{
  "create_connector.credential.access_key": "<your-aws-access-key>",
  "create_connector.credential.secret_key": "<your-aws-secret-key>",
  "create_connector.credential.session_token": "<your-aws-session-token>"
}
```

After provisioning, users can query any index with natural language:
```
GET <index>/_search?search_pipeline=agentic-search-pipeline
{
  "query": {
    "agentic": {
      "query_text": "Find all products under 50 dollars"
    }
  }
}
```

### Testing

Tested end-to-end on a local 3.6 cluster with real Bedrock Claude credentials:

1. Provisioned the workflow — all 5 resources created successfully (connector, model, tool, agent, pipeline)
2. Verified the agent was registered with `QueryPlanningTool` attached and correct `response_filter` (`$.output.message.content[0].text`)
3. Created a test index (`test-products`) with 3 documents: Wireless Mouse ($25.99, electronics), Mechanical Keyboard ($89.99, electronics), USB Cable ($9.99, accessories)
4. Ran agentic query: `"Find electronics under 50 dollars"`
5. Result: correctly returned only the Wireless Mouse — the LLM generated a DSL query that filtered by category=electronics and price<50

```json
{
  "hits": {
    "total": { "value": 1, "relation": "eq" },
    "hits": [
      {
        "_id": "1",
        "_source": {
          "name": "Wireless Mouse",
          "price": 25.99,
          "category": "electronics"
        }
      }
    ]
  }
}
```

### Files changed
- `DefaultUseCases.java` — new `AGENTIC_SEARCH_WITH_FLOW_AGENT` enum entry
- `defaults/agentic-search-with-flow-agent-defaults.json` — default parameter values (Bedrock Claude 4 Sonnet)
- `substitutionTemplates/agentic-search-with-flow-agent-template.json` — workflow template
- `DefaultUseCasesTests.java` — tests for the new use case

### Issues Resolved
Partially addresses #1225 (item 4: Agentic search)

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`