### PR TITLE
Add agentic search workflow template with conversational agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 3.x](https://github.com/opensearch-project/flow-framework/compare/3.5...HEAD)
 ### Features
 - Add agentic search workflow template with flow agent ([#1349](https://github.com/opensearch-project/flow-framework/pull/1349))
-- Add agentic search workflow template with conversational agent ([#XXXX](https://github.com/opensearch-project/flow-framework/pull/XXXX))
+- Add agentic search workflow template with conversational agent ([#1353](https://github.com/opensearch-project/flow-framework/pull/1353))
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 3.x](https://github.com/opensearch-project/flow-framework/compare/3.5...HEAD)
 ### Features
 - Add agentic search workflow template with flow agent ([#1349](https://github.com/opensearch-project/flow-framework/pull/1349))
+- Add agentic search workflow template with conversational agent ([#XXXX](https://github.com/opensearch-project/flow-framework/pull/XXXX))
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
+++ b/src/main/java/org/opensearch/flowframework/common/DefaultUseCases.java
@@ -170,6 +170,13 @@ public enum DefaultUseCases {
         "defaults/agentic-search-with-flow-agent-defaults.json",
         "substitutionTemplates/agentic-search-with-flow-agent-template.json",
         List.of(CREATE_CONNECTOR_CREDENTIAL_ACCESS_KEY, CREATE_CONNECTOR_CREDENTIAL_SECRET_KEY, CREATE_CONNECTOR_CREDENTIAL_SESSION_TOKEN)
+    ),
+    /** defaults file and substitution ready template for agentic search with conversational agent */
+    AGENTIC_SEARCH_WITH_CONVERSATIONAL_AGENT(
+        "agentic_search_with_conversational_agent",
+        "defaults/agentic-search-with-conversational-agent-defaults.json",
+        "substitutionTemplates/agentic-search-with-conversational-agent-template.json",
+        List.of(CREATE_CONNECTOR_CREDENTIAL_ACCESS_KEY, CREATE_CONNECTOR_CREDENTIAL_SECRET_KEY, CREATE_CONNECTOR_CREDENTIAL_SESSION_TOKEN)
     );
 
     private final String useCaseName;

--- a/src/main/resources/defaults/agentic-search-with-conversational-agent-defaults.json
+++ b/src/main/resources/defaults/agentic-search-with-conversational-agent-defaults.json
@@ -1,0 +1,23 @@
+{
+  "template.name": "agentic_search_with_conversational_agent",
+  "template.description": "Setting up agentic search with a conversational agent and Bedrock Claude",
+  "create_connector.name": "Amazon Bedrock Connector: Claude 4 Sonnet",
+  "create_connector.description": "Connector to Amazon Bedrock Claude model for conversational agentic search",
+  "create_connector.protocol": "aws_sigv4",
+  "create_connector.region": "us-west-2",
+  "create_connector.model": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+  "create_connector.credential.access_key": "",
+  "create_connector.credential.secret_key": "",
+  "create_connector.credential.session_token": "",
+  "create_connector.actions.url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+  "create_connector.actions.request_body": "{ \"system\": [{\"text\": \"${parameters.system_prompt}\"}], \"messages\": [${parameters._chat_history:-}{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}${parameters._interactions:-}]${parameters.tool_configs:-} }",
+  "register_remote_model.name": "Bedrock Claude model for conversational agentic search",
+  "register_remote_model.description": "Model used for conversational agent in agentic search",
+  "register_agent.name": "Conversational Agent for Agentic Search",
+  "register_agent.description": "Conversational agent for agentic search with memory",
+  "register_agent.type": "conversational",
+  "register_agent.llm_interface": "bedrock/converse",
+  "register_agent.max_iteration": "20",
+  "query_planning_tool.response_filter": "$.output.message.content[0].text",
+  "create_search_pipeline.pipeline_id": "agentic-search-conversational-pipeline"
+}

--- a/src/main/resources/defaults/agentic-search-with-conversational-agent-defaults.json
+++ b/src/main/resources/defaults/agentic-search-with-conversational-agent-defaults.json
@@ -16,7 +16,7 @@
   "register_agent.name": "Conversational Agent for Agentic Search",
   "register_agent.description": "Conversational agent for agentic search with memory",
   "register_agent.type": "conversational",
-  "register_agent.llm_interface": "bedrock/converse",
+  "register_agent.llm_interface": "bedrock/converse/claude",
   "register_agent.max_iteration": "20",
   "query_planning_tool.response_filter": "$.output.message.content[0].text",
   "create_search_pipeline.pipeline_id": "agentic-search-conversational-pipeline"

--- a/src/main/resources/substitutionTemplates/agentic-search-with-conversational-agent-template.json
+++ b/src/main/resources/substitutionTemplates/agentic-search-with-conversational-agent-template.json
@@ -1,0 +1,176 @@
+{
+  "name": "${{template.name}}",
+  "description": "${{template.description}}",
+  "use_case": "AGENTIC_SEARCH_WITH_CONVERSATIONAL_AGENT",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": [
+      "3.2.0",
+      "3.6.0"
+    ]
+  },
+  "workflows": {
+    "provision": {
+      "nodes": [
+        {
+          "id": "create_connector",
+          "type": "create_connector",
+          "user_inputs": {
+            "name": "${{create_connector.name}}",
+            "description": "${{create_connector.description}}",
+            "version": "1",
+            "protocol": "${{create_connector.protocol}}",
+            "parameters": {
+              "region": "${{create_connector.region}}",
+              "service_name": "bedrock",
+              "model": "${{create_connector.model}}"
+            },
+            "credential": {
+              "access_key": "${{create_connector.credential.access_key}}",
+              "secret_key": "${{create_connector.credential.secret_key}}",
+              "session_token": "${{create_connector.credential.session_token}}"
+            },
+            "actions": [
+              {
+                "action_type": "predict",
+                "method": "POST",
+                "url": "${{create_connector.actions.url}}",
+                "headers": {
+                  "content-type": "application/json"
+                },
+                "request_body": "${{create_connector.actions.request_body}}"
+              }
+            ]
+          }
+        },
+        {
+          "id": "register_model",
+          "type": "register_remote_model",
+          "previous_node_inputs": {
+            "create_connector": "parameters"
+          },
+          "user_inputs": {
+            "name": "${{register_remote_model.name}}",
+            "function_name": "remote",
+            "description": "${{register_remote_model.description}}",
+            "deploy": true
+          }
+        },
+        {
+          "id": "query_planning_tool",
+          "type": "create_tool",
+          "previous_node_inputs": {
+            "register_model": "model_id"
+          },
+          "user_inputs": {
+            "type": "QueryPlanningTool",
+            "name": "QueryPlanningTool",
+            "parameters": {
+              "model_id": "${{register_model.model_id}}",
+              "response_filter": "${{query_planning_tool.response_filter}}"
+            }
+          }
+        },
+        {
+          "id": "list_index_tool",
+          "type": "create_tool",
+          "user_inputs": {
+            "type": "ListIndexTool",
+            "name": "ListIndexTool"
+          }
+        },
+        {
+          "id": "index_mapping_tool",
+          "type": "create_tool",
+          "user_inputs": {
+            "type": "IndexMappingTool",
+            "name": "IndexMappingTool"
+          }
+        },
+        {
+          "id": "register_agent",
+          "type": "register_agent",
+          "previous_node_inputs": {
+            "register_model": "model_id",
+            "query_planning_tool": "tools",
+            "list_index_tool": "tools",
+            "index_mapping_tool": "tools"
+          },
+          "user_inputs": {
+            "name": "${{register_agent.name}}",
+            "type": "${{register_agent.type}}",
+            "description": "${{register_agent.description}}",
+            "llm": {
+              "parameters": {
+                "max_iteration": "${{register_agent.max_iteration}}"
+              }
+            },
+            "memory": {
+              "type": "conversation_index"
+            },
+            "parameters": {
+              "_llm_interface": "${{register_agent.llm_interface}}"
+            }
+          }
+        },
+        {
+          "id": "create_search_pipeline",
+          "type": "create_search_pipeline",
+          "previous_node_inputs": {
+            "register_agent": "agent_id"
+          },
+          "user_inputs": {
+            "pipeline_id": "${{create_search_pipeline.pipeline_id}}",
+            "configurations": {
+              "request_processors": [
+                {
+                  "agentic_query_translator": {
+                    "agent_id": "${{register_agent.agent_id}}"
+                  }
+                }
+              ],
+              "response_processors": [
+                {
+                  "agentic_context": {
+                    "agent_steps_summary": true,
+                    "dsl_query": true
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "edges": [
+        {
+          "source": "create_connector",
+          "dest": "register_model"
+        },
+        {
+          "source": "register_model",
+          "dest": "query_planning_tool"
+        },
+        {
+          "source": "query_planning_tool",
+          "dest": "register_agent"
+        },
+        {
+          "source": "list_index_tool",
+          "dest": "register_agent"
+        },
+        {
+          "source": "index_mapping_tool",
+          "dest": "register_agent"
+        },
+        {
+          "source": "register_model",
+          "dest": "register_agent"
+        },
+        {
+          "source": "register_agent",
+          "dest": "create_search_pipeline"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/java/org/opensearch/flowframework/common/DefaultUseCasesTests.java
+++ b/src/test/java/org/opensearch/flowframework/common/DefaultUseCasesTests.java
@@ -59,4 +59,22 @@ public class DefaultUseCasesTests extends OpenSearchTestCase {
         assertTrue(params.contains("create_connector.credential.secret_key"));
         assertTrue(params.contains("create_connector.credential.session_token"));
     }
+
+    public void testAgenticSearchWithConversationalAgentDefaults() throws FlowFrameworkException {
+        String defaultsFile = DefaultUseCases.getDefaultsFileByUseCaseName("agentic_search_with_conversational_agent");
+        assertEquals("defaults/agentic-search-with-conversational-agent-defaults.json", defaultsFile);
+    }
+
+    public void testAgenticSearchWithConversationalAgentTemplate() throws FlowFrameworkException {
+        String templateFile = DefaultUseCases.getSubstitutionReadyFileByUseCaseName("agentic_search_with_conversational_agent");
+        assertEquals("substitutionTemplates/agentic-search-with-conversational-agent-template.json", templateFile);
+    }
+
+    public void testAgenticSearchWithConversationalAgentRequiredParams() {
+        var params = DefaultUseCases.getRequiredParamsByUseCaseName("agentic_search_with_conversational_agent");
+        assertEquals(3, params.size());
+        assertTrue(params.contains("create_connector.credential.access_key"));
+        assertTrue(params.contains("create_connector.credential.secret_key"));
+        assertTrue(params.contains("create_connector.credential.session_token"));
+    }
 }


### PR DESCRIPTION
### Description

Adds a new default workflow template for **Agentic Search** using a conversational agent with QueryPlanningTool and Amazon Bedrock Claude. This complements the flow agent template from #1349 by providing a conversational variant with memory and multi-tool reasoning.

### What it provisions

The template creates the following resources in order:
1. **Bedrock Connector** — `aws_sigv4` connector using the Converse API (defaults to Claude 4 Sonnet)
2. **Remote Model** — registers and deploys the chat model
3. **QueryPlanningTool** — creates the tool with the deployed model and Bedrock response filter
4. **ListIndexTool** — creates tool for index discovery
5. **IndexMappingTool** — creates tool for understanding index structure
6. **Conversational Agent** — registers a conversational agent with all tools, conversation memory, and LLM interface config
7. **Search Pipeline** — creates a search pipeline with `agentic_query_translator` request processor and `agentic_context` response processor

### Key differences from flow agent template (#1349)

| Feature | Flow Agent | Conversational Agent |
|---------|-----------|---------------------|
| Agent type | `flow` | `conversational` |
| Tool selection | Sequential | LLM-driven autonomous |
| Memory | None | `conversation_index` (multi-turn) |
| Tools | QueryPlanningTool only | QueryPlanningTool + ListIndexTool + IndexMappingTool |
| LLM config | Not on agent | `llm` with `model_id` and `max_iteration` |
| LLM interface | N/A | `bedrock/converse/claude` |
| Response processor | None | `agentic_context` (reasoning traces + memory_id) |
| Follow-up queries | Not supported | Supported via `memory_id` |

### Usage

```
POST _plugins/_flow_framework/workflow?use_case=agentic_search_with_conversational_agent&provision=true
{
  "create_connector.credential.access_key": "",
  "create_connector.credential.secret_key": "",
  "create_connector.credential.session_token": ""
}
```

After provisioning, users can query any index with natural language:
```
GET /_search?search_pipeline=agentic-search-conversational-pipeline
{
  "query": {
    "agentic": {
      "query_text": "Find all products under 50 dollars"
    }
  }
}
```

Follow-up queries with conversation memory:
```
GET /_search?search_pipeline=agentic-search-conversational-pipeline
{
  "query": {
    "agentic": {
      "query_text": "Actually, show black ones instead",
      "memory_id": "<memory_id from previous response>"
    }
  }
}
```

### Testing

Tested end-to-end on a local 3.6 cluster with real Bedrock Claude credentials:

1. Provisioned the workflow — all 5 resources created successfully (connector, model, agent, tools, pipeline)
2. Verified the agent was registered as `conversational` type with `_llm_interface: bedrock/converse/claude`, `memory: conversation_index`, and `max_iteration: 20`
3. Verified the agent has all 3 tools wired in: `QueryPlanningTool`, `ListIndexTool`, `IndexMappingTool`
4. Verified the search pipeline has both `agentic_query_translator` request processor and `agentic_context` response processor
5. Created a test index (`test-products`) with 3 documents: Wireless Mouse ($25.99, electronics, white), Mechanical Keyboard ($89.99, electronics, black), USB Cable ($9.99, accessories, white)
6. Ran agentic query: `"Find electronics under 50 dollars"`
7. Result: correctly returned only the Wireless Mouse — the agent autonomously used `ListIndexTool` to discover `test-products`, `IndexMappingTool` to understand the schema, then `QueryPlanningTool` to generate a DSL query filtering by `category=electronics AND price<50`

```json
{
  "hits": {
    "total": { "value": 1, "relation": "eq" },
    "hits": [
      {
        "_id": "1",
        "_source": {
          "name": "Wireless Mouse",
          "price": 25.99,
          "category": "electronics",
          "color": "white"
        }
      }
    ]
  },
  "ext": {
    "agent_steps_summary": "I need to find electronics under 50 dollars. Since no index name was provided, I'll first discover available indices...",
    "memory_id": "<memory_id>",
    "dsl_query": "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"category\":\"electronics\"}},{\"range\":{\"price\":{\"lt\":50}}}]}}}"
  }
}
```

8. Tested conversation memory with follow-up query: `"Actually, show me white ones instead"` using `memory_id` from previous response
9. Result: the agent correctly remembered the previous context (electronics under $50) and interpreted "white ones instead" as white electronics under $50, generating DSL with `category=electronics AND color=white AND price<50`

```json
{
  "hits": {
    "total": { "value": 1, "relation": "eq" },
    "hits": [
      {
        "_id": "1",
        "_source": {
          "name": "Wireless Mouse",
          "price": 25.99,
          "category": "electronics",
          "color": "white"
        }
      }
    ]
  },
  "ext": {
    "agent_steps_summary": "...Based on your request for \"white ones instead\" and the context from the previous electronics search, I understand you want white electronics...",
    "memory_id": "<memory_id>",
    "dsl_query": "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"category\":\"electronics\"}},{\"term\":{\"color\":\"white\"}},{\"range\":{\"price\":{\"lt\":50}}}]}}}"
  }
}
```

### Files changed
- `CHANGELOG.md` — new entry
- `DefaultUseCases.java` — new `AGENTIC_SEARCH_WITH_CONVERSATIONAL_AGENT` enum entry
- `defaults/agentic-search-with-conversational-agent-defaults.json` — default parameter values
- `substitutionTemplates/agentic-search-with-conversational-agent-template.json` — workflow template
- `DefaultUseCasesTests.java` — tests for the new use case

### Issues Resolved
Partially addresses #1225

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`