### PR TITLE
Add missing fields to workflow steps matching ml-commons builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 - Add response processor to flow agent agentic search template ([#1367](https://github.com/opensearch-project/flow-framework/pull/1367))
 - Fix hard-coded region in Bedrock template URLs ([#1354](https://github.com/opensearch-project/flow-framework/pull/1354))
+- Add missing fields to workflow steps matching ml-commons builders ([#1360](https://github.com/opensearch-project/flow-framework/pull/1360))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/flowframework/common/CommonValue.java
+++ b/src/main/java/org/opensearch/flowframework/common/CommonValue.java
@@ -197,10 +197,36 @@ public class CommonValue {
     public static final String LLM = "llm";
     /** Guardrails field */
     public static final String GUARDRAILS_FIELD = "guardrails";
+    /** Is Enabled field */
+    public static final String IS_ENABLED_FIELD = "is_enabled";
+    /** Rate Limiter field */
+    public static final String RATE_LIMITER_FIELD = "rate_limiter";
+    /** Deploy Setting field */
+    public static final String DEPLOY_SETTING_FIELD = "deploy_setting";
+    /** Model Node IDs field */
+    public static final String MODEL_NODE_IDS_FIELD = "model_node_ids";
     /** Delay field */
     public static final String DELAY_FIELD = "delay";
     /** Model Interface Field */
     public static final String INTERFACE_FIELD = "interface";
+    /** Client Config field */
+    public static final String CLIENT_CONFIG_FIELD = "client_config";
+    /** Connector URL field */
+    public static final String CONNECTOR_URL_FIELD = "url";
+    /** Connector Headers field */
+    public static final String HEADERS_FIELD = "headers";
+    /** Model field for agent */
+    public static final String MODEL_FIELD = "model";
+    /** Context Management Name field for agent */
+    public static final String CONTEXT_MANAGEMENT_NAME_FIELD = "context_management_name";
+    /** Context Management field for agent */
+    public static final String CONTEXT_MANAGEMENT_FIELD = "context_management";
+    /** Memory Container ID field */
+    public static final String MEMORY_CONTAINER_ID_FIELD = "memory_container_id";
+    /** Runtime Resources field for tool */
+    public static final String RUNTIME_RESOURCES_FIELD = "runtime_resources";
+    /** Connector Action Name field */
+    public static final String CONNECTOR_ACTION_NAME_FIELD = "name";
     /** The source index field for reindex */
     public static final String SOURCE_INDEX = "source_index";
     /** The destination index field for reindex */

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
@@ -25,28 +25,41 @@ import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.controller.MLRateLimiter;
 import org.opensearch.ml.common.model.BaseModelConfig;
+import org.opensearch.ml.common.model.Guardrails;
+import org.opensearch.ml.common.model.MLDeploySetting;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.opensearch.flowframework.common.CommonValue.ADDITIONAL_CONFIG;
+import static org.opensearch.flowframework.common.CommonValue.ADD_ALL_BACKEND_ROLES;
 import static org.opensearch.flowframework.common.CommonValue.ALL_CONFIG;
+import static org.opensearch.flowframework.common.CommonValue.BACKEND_ROLES_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_SETTING_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
+import static org.opensearch.flowframework.common.CommonValue.GUARDRAILS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.IS_ENABLED_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_ACCESS_MODE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONFIG;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_NODE_IDS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_TYPE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.RATE_LIMITER_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.URL;
 import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
@@ -116,6 +129,15 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
             String modelGroupId = (String) inputs.get(MODEL_GROUP_ID);
             String modelInterface = (String) inputs.get(INTERFACE_FIELD);
             final Boolean deploy = ParseUtils.parseIfExists(inputs, DEPLOY_FIELD, Boolean.class);
+            final Boolean isEnabled = ParseUtils.parseIfExists(inputs, IS_ENABLED_FIELD, Boolean.class);
+            MLRateLimiter rateLimiter = (MLRateLimiter) inputs.get(RATE_LIMITER_FIELD);
+            MLDeploySetting deploySetting = (MLDeploySetting) inputs.get(DEPLOY_SETTING_FIELD);
+            Guardrails guardrails = (Guardrails) inputs.get(GUARDRAILS_FIELD);
+            @SuppressWarnings("unchecked")
+            List<String> backendRoles = (List<String>) inputs.get(BACKEND_ROLES_FIELD);
+            Boolean addAllBackendRoles = ParseUtils.parseIfExists(inputs, ADD_ALL_BACKEND_ROLES, Boolean.class);
+            String accessMode = (String) inputs.get(MODEL_ACCESS_MODE);
+            String[] modelNodeIds = (String[]) inputs.get(MODEL_NODE_IDS_FIELD);
 
             // Build register model input
             MLRegisterModelInputBuilder mlInputBuilder = MLRegisterModelInput.builder()
@@ -179,6 +201,30 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
             }
             if (deploy != null) {
                 mlInputBuilder.deployModel(deploy);
+            }
+            if (isEnabled != null) {
+                mlInputBuilder.isEnabled(isEnabled);
+            }
+            if (rateLimiter != null) {
+                mlInputBuilder.rateLimiter(rateLimiter);
+            }
+            if (deploySetting != null) {
+                mlInputBuilder.deploySetting(deploySetting);
+            }
+            if (guardrails != null) {
+                mlInputBuilder.guardrails(guardrails);
+            }
+            if (backendRoles != null) {
+                mlInputBuilder.backendRoles(backendRoles);
+            }
+            if (addAllBackendRoles != null) {
+                mlInputBuilder.addAllBackendRoles(addAllBackendRoles);
+            }
+            if (accessMode != null) {
+                mlInputBuilder.accessMode(AccessMode.from(accessMode));
+            }
+            if (modelNodeIds != null) {
+                mlInputBuilder.modelNodeIds(modelNodeIds);
             }
 
             MLRegisterModelInput mlInput = mlInputBuilder.build();

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -26,7 +26,6 @@ import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
 import org.opensearch.secure_sm.AccessController;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -35,8 +34,14 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import static org.opensearch.flowframework.common.CommonValue.ACTIONS_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.ADD_ALL_BACKEND_ROLES;
+import static org.opensearch.flowframework.common.CommonValue.BACKEND_ROLES_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.CLIENT_CONFIG_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.CONNECTOR_URL_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.CREDENTIAL_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.HEADERS_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_ACCESS_MODE;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PROTOCOL_FIELD;
@@ -68,7 +73,14 @@ public class CreateConnectorStep implements WorkflowStep {
         ACTIONS_FIELD
     );
     /** Optional input keys */
-    public static final Set<String> OPTIONAL_INPUTS = Collections.emptySet();
+    public static final Set<String> OPTIONAL_INPUTS = Set.of(
+        BACKEND_ROLES_FIELD,
+        ADD_ALL_BACKEND_ROLES,
+        MODEL_ACCESS_MODE,
+        CLIENT_CONFIG_FIELD,
+        CONNECTOR_URL_FIELD,
+        HEADERS_FIELD
+    );
     /** Provided output keys */
     public static final Set<String> PROVIDED_OUTPUTS = Set.of(CONNECTOR_ID);
 
@@ -149,7 +161,17 @@ public class CreateConnectorStep implements WorkflowStep {
                 throw new FlowFrameworkException("Exception in connector configuration", RestStatus.UNAUTHORIZED);
             }
 
-            MLCreateConnectorInput mlInput = MLCreateConnectorInput.builder()
+            @SuppressWarnings("unchecked")
+            List<String> backendRoles = (List<String>) inputs.get(BACKEND_ROLES_FIELD);
+            Boolean addAllBackendRoles = ParseUtils.parseIfExists(inputs, ADD_ALL_BACKEND_ROLES, Boolean.class);
+            String accessMode = (String) inputs.get(MODEL_ACCESS_MODE);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> clientConfigMap = (Map<String, Object>) inputs.get(CLIENT_CONFIG_FIELD);
+            String connectorUrl = (String) inputs.get(CONNECTOR_URL_FIELD);
+            @SuppressWarnings("unchecked")
+            Map<String, String> headers = (Map<String, String>) inputs.get(HEADERS_FIELD);
+
+            MLCreateConnectorInput.MLCreateConnectorInputBuilder mlInputBuilder = MLCreateConnectorInput.builder()
                 .name(name)
                 .description(description)
                 .version(version)
@@ -157,8 +179,34 @@ public class CreateConnectorStep implements WorkflowStep {
                 .parameters(parameters)
                 .credential(credentials)
                 .actions(actions)
-                .tenantId(tenantId)
-                .build();
+                .tenantId(tenantId);
+
+            if (backendRoles != null) {
+                mlInputBuilder.backendRoles(backendRoles);
+            }
+            if (addAllBackendRoles != null) {
+                mlInputBuilder.addAllBackendRoles(addAllBackendRoles);
+            }
+            if (accessMode != null) {
+                mlInputBuilder.access(org.opensearch.ml.common.AccessMode.from(accessMode));
+            }
+            if (clientConfigMap != null) {
+                mlInputBuilder.connectorClientConfig(
+                    org.opensearch.ml.common.connector.ConnectorClientConfig.builder()
+                        .maxConnections((Integer) clientConfigMap.get("max_connection"))
+                        .connectionTimeout((Integer) clientConfigMap.get("connection_timeout"))
+                        .readTimeout((Integer) clientConfigMap.get("read_timeout"))
+                        .build()
+                );
+            }
+            if (connectorUrl != null) {
+                mlInputBuilder.url(connectorUrl);
+            }
+            if (headers != null) {
+                mlInputBuilder.headers(headers);
+            }
+
+            MLCreateConnectorInput mlInput = mlInputBuilder.build();
 
             mlClient.createConnector(mlInput, actionListener);
         } catch (FlowFrameworkException e) {
@@ -196,6 +244,7 @@ public class CreateConnectorStep implements WorkflowStep {
             @SuppressWarnings("unchecked")
             ConnectorAction action = ConnectorAction.builder()
                 .actionType(ActionType.valueOf(actionType.toUpperCase(Locale.ROOT)))
+                .name((String) map.get(ConnectorAction.NAME_FIELD))
                 .method((String) map.get(ConnectorAction.METHOD_FIELD))
                 .url((String) map.get(ConnectorAction.URL_FIELD))
                 .headers((Map<String, String>) map.get(ConnectorAction.HEADERS_FIELD))

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -28,8 +28,10 @@ import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.agent.LLMSpec;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLAgent.MLAgentBuilder;
+import org.opensearch.ml.common.agent.MLAgentModelSpec;
 import org.opensearch.ml.common.agent.MLMemorySpec;
 import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.contextmanager.ContextManagementTemplate;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentResponse;
 
 import java.nio.charset.StandardCharsets;
@@ -45,11 +47,14 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.opensearch.flowframework.common.CommonValue.APP_TYPE_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.CONTEXT_MANAGEMENT_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.CONTEXT_MANAGEMENT_NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.CREATED_TIME;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.LAST_UPDATED_TIME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.LLM;
 import static org.opensearch.flowframework.common.CommonValue.MEMORY_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.TOOLS_FIELD;
@@ -125,13 +130,16 @@ public class RegisterAgentStep implements WorkflowStep {
         Set<String> optionalKeys = Set.of(
             DESCRIPTION_FIELD,
             LLM,
+            MODEL_FIELD,
             TOOLS_FIELD,
             TOOLS_ORDER_FIELD,
             PARAMETERS_FIELD,
             MEMORY_FIELD,
             CREATED_TIME,
             LAST_UPDATED_TIME_FIELD,
-            APP_TYPE_FIELD
+            APP_TYPE_FIELD,
+            CONTEXT_MANAGEMENT_NAME_FIELD,
+            CONTEXT_MANAGEMENT_FIELD
         );
 
         try {
@@ -158,6 +166,9 @@ public class RegisterAgentStep implements WorkflowStep {
             Instant createdTime = Instant.now();
             Instant lastUpdateTime = createdTime;
             String appType = (String) inputs.get(APP_TYPE_FIELD);
+            String contextManagementName = (String) inputs.get(CONTEXT_MANAGEMENT_NAME_FIELD);
+            String contextManagementField = (String) inputs.get(CONTEXT_MANAGEMENT_FIELD);
+            String modelField = (String) inputs.get(MODEL_FIELD);
 
             String llmModelId = null;
             Map<String, String> llmParameters = new HashMap<>();
@@ -208,6 +219,45 @@ public class RegisterAgentStep implements WorkflowStep {
                 .lastUpdateTime(lastUpdateTime)
                 .appType(appType)
                 .tenantId(tenantId);
+
+            if (contextManagementName != null) {
+                builder.contextManagementName(contextManagementName);
+            }
+            if (contextManagementField != null) {
+                try {
+                    BytesReference cmBytes = new BytesArray(contextManagementField.getBytes(StandardCharsets.UTF_8));
+                    var cmParser = XContentHelper.createParser(
+                        org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                        org.opensearch.core.xcontent.DeprecationHandler.IGNORE_DEPRECATIONS,
+                        cmBytes,
+                        MediaTypeRegistry.JSON
+                    );
+                    cmParser.nextToken();
+                    builder.contextManagement(ContextManagementTemplate.parse(cmParser));
+                } catch (Exception ex) {
+                    String errorMessage = "Failed to parse context_management field: " + ex.getMessage();
+                    logger.error(errorMessage, ex);
+                    registerAgentModelFuture.onFailure(new WorkflowStepException(errorMessage, RestStatus.BAD_REQUEST));
+                    return registerAgentModelFuture;
+                }
+            }
+            if (modelField != null) {
+                Map<String, Object> modelMap = getParseFieldMap(modelField);
+                MLAgentModelSpec.MLAgentModelSpecBuilder modelSpecBuilder = MLAgentModelSpec.builder();
+                modelSpecBuilder.modelId((String) modelMap.get(MLAgentModelSpec.MODEL_ID_FIELD));
+                modelSpecBuilder.modelProvider((String) modelMap.get(MLAgentModelSpec.MODEL_PROVIDER_FIELD));
+                @SuppressWarnings("unchecked")
+                Map<String, String> modelCred = (Map<String, String>) modelMap.get(MLAgentModelSpec.CREDENTIAL_FIELD);
+                if (modelCred != null) {
+                    modelSpecBuilder.credential(modelCred);
+                }
+                @SuppressWarnings("unchecked")
+                Map<String, String> modelParams = (Map<String, String>) modelMap.get(MLAgentModelSpec.MODEL_PARAMETERS_FIELD);
+                if (modelParams != null) {
+                    modelSpecBuilder.modelParameters(modelParams);
+                }
+                builder.model(modelSpecBuilder.build());
+            }
 
             MLAgent mlAgent = builder.build();
 
@@ -295,6 +345,7 @@ public class RegisterAgentStep implements WorkflowStep {
         }
         sessionId = (String) map.get(MLMemorySpec.SESSION_ID_FIELD);
         windowSize = (Integer) map.get(MLMemorySpec.WINDOW_SIZE_FIELD);
+        String memoryContainerId = (String) map.get(MLMemorySpec.MEMORY_CONTAINER_ID_FIELD);
 
         MLMemorySpec.MLMemorySpecBuilder builder = MLMemorySpec.builder();
 
@@ -304,6 +355,9 @@ public class RegisterAgentStep implements WorkflowStep {
         }
         if (windowSize != null) {
             builder.windowSize(windowSize);
+        }
+        if (memoryContainerId != null) {
+            builder.memoryContainerId(memoryContainerId);
         }
 
         return builder.build();

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStep.java
@@ -16,15 +16,23 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.util.Set;
 
+import static org.opensearch.flowframework.common.CommonValue.ADD_ALL_BACKEND_ROLES;
 import static org.opensearch.flowframework.common.CommonValue.ALL_CONFIG;
+import static org.opensearch.flowframework.common.CommonValue.BACKEND_ROLES_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_SETTING_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
+import static org.opensearch.flowframework.common.CommonValue.GUARDRAILS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.IS_ENABLED_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_ACCESS_MODE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONFIG;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_NODE_IDS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.RATE_LIMITER_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.URL;
 import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
@@ -60,7 +68,21 @@ public class RegisterLocalCustomModelStep extends AbstractRegisterLocalModelStep
 
     @Override
     protected Set<String> getOptionalKeys() {
-        return Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, ALL_CONFIG, DEPLOY_FIELD, INTERFACE_FIELD);
+        return Set.of(
+            DESCRIPTION_FIELD,
+            MODEL_GROUP_ID,
+            ALL_CONFIG,
+            DEPLOY_FIELD,
+            INTERFACE_FIELD,
+            IS_ENABLED_FIELD,
+            RATE_LIMITER_FIELD,
+            DEPLOY_SETTING_FIELD,
+            GUARDRAILS_FIELD,
+            BACKEND_ROLES_FIELD,
+            ADD_ALL_BACKEND_ROLES,
+            MODEL_ACCESS_MODE,
+            MODEL_NODE_IDS_FIELD
+        );
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStep.java
@@ -16,10 +16,19 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.util.Set;
 
+import static org.opensearch.flowframework.common.CommonValue.ADD_ALL_BACKEND_ROLES;
+import static org.opensearch.flowframework.common.CommonValue.BACKEND_ROLES_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_SETTING_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.GUARDRAILS_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.IS_ENABLED_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_ACCESS_MODE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_NODE_IDS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.RATE_LIMITER_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
 
@@ -54,7 +63,20 @@ public class RegisterLocalPretrainedModelStep extends AbstractRegisterLocalModel
 
     @Override
     protected Set<String> getOptionalKeys() {
-        return Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, DEPLOY_FIELD);
+        return Set.of(
+            DESCRIPTION_FIELD,
+            MODEL_GROUP_ID,
+            DEPLOY_FIELD,
+            INTERFACE_FIELD,
+            IS_ENABLED_FIELD,
+            RATE_LIMITER_FIELD,
+            DEPLOY_SETTING_FIELD,
+            GUARDRAILS_FIELD,
+            BACKEND_ROLES_FIELD,
+            ADD_ALL_BACKEND_ROLES,
+            MODEL_ACCESS_MODE,
+            MODEL_NODE_IDS_FIELD
+        );
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterLocalSparseEncodingModelStep.java
@@ -16,12 +16,20 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.util.Set;
 
+import static org.opensearch.flowframework.common.CommonValue.ADD_ALL_BACKEND_ROLES;
+import static org.opensearch.flowframework.common.CommonValue.BACKEND_ROLES_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_SETTING_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.FUNCTION_NAME;
+import static org.opensearch.flowframework.common.CommonValue.GUARDRAILS_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.IS_ENABLED_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_ACCESS_MODE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_CONTENT_HASH_VALUE;
 import static org.opensearch.flowframework.common.CommonValue.MODEL_FORMAT;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_NODE_IDS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.RATE_LIMITER_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.URL;
 import static org.opensearch.flowframework.common.CommonValue.VERSION_FIELD;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
@@ -57,7 +65,22 @@ public class RegisterLocalSparseEncodingModelStep extends AbstractRegisterLocalM
 
     @Override
     protected Set<String> getOptionalKeys() {
-        return Set.of(DESCRIPTION_FIELD, MODEL_GROUP_ID, DEPLOY_FIELD, MODEL_CONTENT_HASH_VALUE, URL, FUNCTION_NAME);
+        return Set.of(
+            DESCRIPTION_FIELD,
+            MODEL_GROUP_ID,
+            DEPLOY_FIELD,
+            MODEL_CONTENT_HASH_VALUE,
+            URL,
+            FUNCTION_NAME,
+            IS_ENABLED_FIELD,
+            RATE_LIMITER_FIELD,
+            DEPLOY_SETTING_FIELD,
+            GUARDRAILS_FIELD,
+            BACKEND_ROLES_FIELD,
+            ADD_ALL_BACKEND_ROLES,
+            MODEL_ACCESS_MODE,
+            MODEL_NODE_IDS_FIELD
+        );
     }
 
     @Override

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -23,21 +23,32 @@ import org.opensearch.flowframework.exception.WorkflowStepException;
 import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.controller.MLRateLimiter;
 import org.opensearch.ml.common.model.Guardrails;
+import org.opensearch.ml.common.model.MLDeploySetting;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput.MLRegisterModelInputBuilder;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.opensearch.flowframework.common.CommonValue.ADD_ALL_BACKEND_ROLES;
+import static org.opensearch.flowframework.common.CommonValue.BACKEND_ROLES_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.DEPLOY_SETTING_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.GUARDRAILS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.IS_ENABLED_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_ACCESS_MODE;
+import static org.opensearch.flowframework.common.CommonValue.MODEL_NODE_IDS_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.RATE_LIMITER_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
 import static org.opensearch.flowframework.common.WorkflowResources.MODEL_GROUP_ID;
@@ -66,7 +77,14 @@ public class RegisterRemoteModelStep implements WorkflowStep {
         DESCRIPTION_FIELD,
         DEPLOY_FIELD,
         GUARDRAILS_FIELD,
-        INTERFACE_FIELD
+        INTERFACE_FIELD,
+        IS_ENABLED_FIELD,
+        RATE_LIMITER_FIELD,
+        DEPLOY_SETTING_FIELD,
+        BACKEND_ROLES_FIELD,
+        ADD_ALL_BACKEND_ROLES,
+        MODEL_ACCESS_MODE,
+        MODEL_NODE_IDS_FIELD
     );
     /** Provided output keys */
     public static final Set<String> PROVIDED_OUTPUTS = Set.of(MODEL_ID, REGISTER_MODEL_STATUS);
@@ -110,6 +128,14 @@ public class RegisterRemoteModelStep implements WorkflowStep {
             Guardrails guardRails = (Guardrails) inputs.get(GUARDRAILS_FIELD);
             String modelInterface = (String) inputs.get(INTERFACE_FIELD);
             final Boolean deploy = ParseUtils.parseIfExists(inputs, DEPLOY_FIELD, Boolean.class);
+            final Boolean isEnabled = ParseUtils.parseIfExists(inputs, IS_ENABLED_FIELD, Boolean.class);
+            MLRateLimiter rateLimiter = (MLRateLimiter) inputs.get(RATE_LIMITER_FIELD);
+            MLDeploySetting deploySetting = (MLDeploySetting) inputs.get(DEPLOY_SETTING_FIELD);
+            @SuppressWarnings("unchecked")
+            List<String> backendRoles = (List<String>) inputs.get(BACKEND_ROLES_FIELD);
+            Boolean addAllBackendRoles = ParseUtils.parseIfExists(inputs, ADD_ALL_BACKEND_ROLES, Boolean.class);
+            String accessMode = (String) inputs.get(MODEL_ACCESS_MODE);
+            String[] modelNodeIds = (String[]) inputs.get(MODEL_NODE_IDS_FIELD);
 
             MLRegisterModelInputBuilder builder = MLRegisterModelInput.builder()
                 .functionName(FunctionName.REMOTE)
@@ -128,6 +154,27 @@ public class RegisterRemoteModelStep implements WorkflowStep {
             }
             if (guardRails != null) {
                 builder.guardrails(guardRails);
+            }
+            if (isEnabled != null) {
+                builder.isEnabled(isEnabled);
+            }
+            if (rateLimiter != null) {
+                builder.rateLimiter(rateLimiter);
+            }
+            if (deploySetting != null) {
+                builder.deploySetting(deploySetting);
+            }
+            if (backendRoles != null) {
+                builder.backendRoles(backendRoles);
+            }
+            if (addAllBackendRoles != null) {
+                builder.addAllBackendRoles(addAllBackendRoles);
+            }
+            if (accessMode != null) {
+                builder.accessMode(AccessMode.from(accessMode));
+            }
+            if (modelNodeIds != null) {
+                builder.modelNodeIds(modelNodeIds);
             }
             if (modelInterface != null) {
                 try {

--- a/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ToolStep.java
@@ -32,6 +32,7 @@ import static org.opensearch.ml.common.agent.MLToolSpec.CONFIG_FIELD;
 import static org.opensearch.ml.common.agent.MLToolSpec.DESCRIPTION_FIELD;
 import static org.opensearch.ml.common.agent.MLToolSpec.INCLUDE_OUTPUT_IN_AGENT_RESPONSE;
 import static org.opensearch.ml.common.agent.MLToolSpec.PARAMETERS_FIELD;
+import static org.opensearch.ml.common.agent.MLToolSpec.RUN_TIME_RESOURCES_FIELD;
 import static org.opensearch.ml.common.agent.MLToolSpec.TOOL_NAME_FIELD;
 import static org.opensearch.ml.common.agent.MLToolSpec.TOOL_TYPE_FIELD;
 
@@ -54,7 +55,8 @@ public class ToolStep implements WorkflowStep {
         PARAMETERS_FIELD,
         ATTRIBUTES_FIELD,
         CONFIG_FIELD,
-        INCLUDE_OUTPUT_IN_AGENT_RESPONSE
+        INCLUDE_OUTPUT_IN_AGENT_RESPONSE,
+        RUN_TIME_RESOURCES_FIELD
     );
     /** Provided output keys */
     public static final Set<String> PROVIDED_OUTPUTS = Set.of(TOOLS_FIELD);
@@ -98,6 +100,8 @@ public class ToolStep implements WorkflowStep {
             Map<String, String> attributes = (Map<String, String>) inputs.get(ATTRIBUTES_FIELD);
             @SuppressWarnings("unchecked")
             Map<String, String> config = (Map<String, String>) inputs.getOrDefault(CONFIG_FIELD, Collections.emptyMap());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> runtimeResources = (Map<String, Object>) inputs.get(RUN_TIME_RESOURCES_FIELD);
 
             MLToolSpec.MLToolSpecBuilder builder = MLToolSpec.builder();
 
@@ -118,6 +122,10 @@ public class ToolStep implements WorkflowStep {
                 builder.includeOutputInAgentResponse(includeOutputInAgentResponse);
             }
             builder.configMap(config);
+
+            if (runtimeResources != null) {
+                builder.runtimeResources(runtimeResources);
+            }
 
             MLToolSpec mlToolSpec = builder.build();
 

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
@@ -81,6 +81,69 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
         );
     }
 
+    public void testCreateConnectorWithOptionalFields() throws IOException, ExecutionException, InterruptedException {
+        Map<String, String> params = Map.ofEntries(Map.entry("endpoint", "endpoint"), Map.entry("temp", "7"));
+        Map<String, String> credentials = Map.ofEntries(Map.entry("key1", "value1"), Map.entry("key2", "value2"));
+        Map<?, ?>[] actions = new Map<?, ?>[] {
+            Map.ofEntries(
+                Map.entry(ConnectorAction.ACTION_TYPE_FIELD, ConnectorAction.ActionType.PREDICT.name()),
+                Map.entry(ConnectorAction.NAME_FIELD, "predict-action"),
+                Map.entry(ConnectorAction.METHOD_FIELD, "post"),
+                Map.entry(ConnectorAction.URL_FIELD, "foo.test"),
+                Map.entry(ConnectorAction.REQUEST_BODY_FIELD, "{ \"model\": \"${parameters.model}\" }")
+            ) };
+
+        WorkflowData optionalInputData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry(CommonValue.NAME_FIELD, "test"),
+                Map.entry(CommonValue.DESCRIPTION_FIELD, "description"),
+                Map.entry(CommonValue.VERSION_FIELD, "1"),
+                Map.entry(CommonValue.PROTOCOL_FIELD, "http"),
+                Map.entry(CommonValue.PARAMETERS_FIELD, params),
+                Map.entry(CommonValue.CREDENTIAL_FIELD, credentials),
+                Map.entry(CommonValue.ACTIONS_FIELD, actions),
+                Map.entry(CommonValue.BACKEND_ROLES_FIELD, List.of("role1", "role2")),
+                Map.entry(CommonValue.ADD_ALL_BACKEND_ROLES, true),
+                Map.entry(CommonValue.MODEL_ACCESS_MODE, "public"),
+                Map.entry(CommonValue.CLIENT_CONFIG_FIELD, Map.of("max_connection", 30, "connection_timeout", 30, "read_timeout", 30)),
+                Map.entry(CommonValue.CONNECTOR_URL_FIELD, "http://mcp.example.com"),
+                Map.entry(CommonValue.HEADERS_FIELD, Map.of("Content-Type", "application/json"))
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        String connectorId = "connect";
+        CreateConnectorStep createConnectorStep = new CreateConnectorStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+
+        doAnswer(invocation -> {
+            ActionListener<MLCreateConnectorResponse> actionListener = invocation.getArgument(1);
+            MLCreateConnectorResponse output = new MLCreateConnectorResponse(connectorId);
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<WorkflowData> updateResponseListener = invocation.getArgument(5);
+            updateResponseListener.onResponse(new WorkflowData(Map.of(CONNECTOR_ID, connectorId), "test-id", "test-node-id"));
+            return null;
+        }).when(flowFrameworkIndicesHandler)
+            .addResourceToStateIndex(any(WorkflowData.class), anyString(), anyString(), anyString(), any(), any());
+
+        PlainActionFuture<WorkflowData> future = createConnectorStep.execute(
+            optionalInputData.getNodeId(),
+            optionalInputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+
+        verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());
+        assertTrue(future.isDone());
+        assertEquals(connectorId, future.get().getContent().get(CONNECTOR_ID));
+    }
+
     public void testCreateConnector() throws IOException, ExecutionException, InterruptedException {
 
         String connectorId = "connect";

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -17,16 +17,16 @@ import org.opensearch.flowframework.util.ApiSpecFetcher;
 import org.opensearch.flowframework.util.ParseUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLAgentType;
-import org.opensearch.ml.common.agent.LLMSpec;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLMemorySpec;
 import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.contextmanager.ContextManagementTemplate;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -52,7 +52,6 @@ public class RegisterAgentTests extends OpenSearchTestCase {
 
     private FlowFrameworkIndicesHandler flowFrameworkIndicesHandler;
     private MLToolSpec tools;
-    private LLMSpec llmSpec;
     private Map<String, String> llmParams;
     private Map<?, ?> mlMemorySpec;
 
@@ -69,8 +68,6 @@ public class RegisterAgentTests extends OpenSearchTestCase {
             .parameters(Collections.emptyMap())
             .includeOutputInAgentResponse(false)
             .build();
-
-        this.llmSpec = new LLMSpec("xyz", Collections.emptyMap());
 
         this.mlMemorySpec = Map.ofEntries(
             Map.entry(MLMemorySpec.MEMORY_TYPE_FIELD, "type"),
@@ -101,14 +98,13 @@ public class RegisterAgentTests extends OpenSearchTestCase {
         );
     }
 
-    public void testRegisterAgent() throws IOException, ExecutionException, InterruptedException {
+    public void testRegisterAgent() throws ExecutionException, InterruptedException {
         String agentId = AGENT_ID;
         RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ActionListener<MLRegisterAgentResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
 
-        @SuppressWarnings("unchecked")
         ArgumentCaptor<MLAgent> mlAgentArgumentCaptor = ArgumentCaptor.forClass(MLAgent.class);
 
         doAnswer(invocation -> {
@@ -141,7 +137,7 @@ public class RegisterAgentTests extends OpenSearchTestCase {
         assertEquals(agentId, future.get().getContent().get(AGENT_ID));
     }
 
-    public void testRegisterAgentFailure() throws IOException {
+    public void testRegisterAgentFailure() {
         String agentId = AGENT_ID;
         RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
@@ -191,8 +187,242 @@ public class RegisterAgentTests extends OpenSearchTestCase {
         assertTrue(isMatch);
     }
 
-    public void testLLMParametersFieldParseFailure() throws Exception {
+    public void testRegisterAgentWithModelField() throws Exception {
         String agentId = AGENT_ID;
+        RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+
+        Map<String, Object> modelFieldMap = new HashMap<>();
+        modelFieldMap.put("model_id", "test-model-id");
+        modelFieldMap.put("model_provider", "openai");
+        modelFieldMap.put("credential", Map.of("api_key", "test-key"));
+        modelFieldMap.put("model_parameters", Map.of("temperature", "0.7"));
+
+        WorkflowData modelInputData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "test"),
+                Map.entry("type", MLAgentType.CONVERSATIONAL.name()),
+                Map.entry("model", ParseUtils.parseArbitraryStringToObjectMapToString(modelFieldMap))
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ActionListener<MLRegisterAgentResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        ArgumentCaptor<MLAgent> mlAgentArgumentCaptor = ArgumentCaptor.forClass(MLAgent.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterAgentResponse> actionListener = invocation.getArgument(1);
+            MLRegisterAgentResponse output = new MLRegisterAgentResponse(agentId);
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());
+
+        doAnswer(invocation -> {
+            ActionListener<WorkflowData> updateResponseListener = invocation.getArgument(5);
+            updateResponseListener.onResponse(new WorkflowData(Map.of(AGENT_ID, agentId), "test-id", "test-node-id"));
+            return null;
+        }).when(flowFrameworkIndicesHandler)
+            .addResourceToStateIndex(any(WorkflowData.class), anyString(), anyString(), anyString(), nullable(String.class), any());
+
+        PlainActionFuture<WorkflowData> future = registerAgentStep.execute(
+            modelInputData.getNodeId(),
+            modelInputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+
+        verify(machineLearningNodeClient).registerAgent(mlAgentArgumentCaptor.capture(), actionListenerCaptor.capture());
+        assertNotNull(mlAgentArgumentCaptor.getValue().getModel());
+        assertEquals("test-model-id", mlAgentArgumentCaptor.getValue().getModel().getModelId());
+        assertEquals("openai", mlAgentArgumentCaptor.getValue().getModel().getModelProvider());
+
+        assertTrue(future.isDone());
+        assertEquals(agentId, future.get().getContent().get(AGENT_ID));
+    }
+
+    public void testRegisterAgentWithContextManagementName() throws Exception {
+        String agentId = AGENT_ID;
+        RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+
+        WorkflowData cmInputData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "test"),
+                Map.entry("type", MLAgentType.FLOW.name()),
+                Map.entry("context_management_name", "my-context-template")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ActionListener<MLRegisterAgentResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        ArgumentCaptor<MLAgent> mlAgentArgumentCaptor = ArgumentCaptor.forClass(MLAgent.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterAgentResponse> actionListener = invocation.getArgument(1);
+            MLRegisterAgentResponse output = new MLRegisterAgentResponse(agentId);
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());
+
+        doAnswer(invocation -> {
+            ActionListener<WorkflowData> updateResponseListener = invocation.getArgument(5);
+            updateResponseListener.onResponse(new WorkflowData(Map.of(AGENT_ID, agentId), "test-id", "test-node-id"));
+            return null;
+        }).when(flowFrameworkIndicesHandler)
+            .addResourceToStateIndex(any(WorkflowData.class), anyString(), anyString(), anyString(), nullable(String.class), any());
+
+        PlainActionFuture<WorkflowData> future = registerAgentStep.execute(
+            cmInputData.getNodeId(),
+            cmInputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+
+        verify(machineLearningNodeClient).registerAgent(mlAgentArgumentCaptor.capture(), actionListenerCaptor.capture());
+        assertEquals("my-context-template", mlAgentArgumentCaptor.getValue().getContextManagementName());
+
+        assertTrue(future.isDone());
+        assertEquals(agentId, future.get().getContent().get(AGENT_ID));
+    }
+
+    public void testRegisterAgentWithMemoryContainerId() throws Exception {
+        String agentId = AGENT_ID;
+        RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+
+        Map<?, ?> memorySpecWithContainerId = Map.ofEntries(
+            Map.entry(MLMemorySpec.MEMORY_TYPE_FIELD, "type"),
+            Map.entry(MLMemorySpec.SESSION_ID_FIELD, "abc"),
+            Map.entry(MLMemorySpec.WINDOW_SIZE_FIELD, 2),
+            Map.entry(MLMemorySpec.MEMORY_CONTAINER_ID_FIELD, "container-123")
+        );
+
+        WorkflowData memoryInputData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "test"),
+                Map.entry("type", MLAgentType.FLOW.name()),
+                Map.entry("memory", memorySpecWithContainerId)
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ActionListener<MLRegisterAgentResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        ArgumentCaptor<MLAgent> mlAgentArgumentCaptor = ArgumentCaptor.forClass(MLAgent.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterAgentResponse> actionListener = invocation.getArgument(1);
+            MLRegisterAgentResponse output = new MLRegisterAgentResponse(agentId);
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());
+
+        doAnswer(invocation -> {
+            ActionListener<WorkflowData> updateResponseListener = invocation.getArgument(5);
+            updateResponseListener.onResponse(new WorkflowData(Map.of(AGENT_ID, agentId), "test-id", "test-node-id"));
+            return null;
+        }).when(flowFrameworkIndicesHandler)
+            .addResourceToStateIndex(any(WorkflowData.class), anyString(), anyString(), anyString(), nullable(String.class), any());
+
+        PlainActionFuture<WorkflowData> future = registerAgentStep.execute(
+            memoryInputData.getNodeId(),
+            memoryInputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+
+        verify(machineLearningNodeClient).registerAgent(mlAgentArgumentCaptor.capture(), actionListenerCaptor.capture());
+        assertNotNull(mlAgentArgumentCaptor.getValue().getMemory());
+        assertEquals("container-123", mlAgentArgumentCaptor.getValue().getMemory().getMemoryContainerId());
+
+        assertTrue(future.isDone());
+        assertEquals(agentId, future.get().getContent().get(AGENT_ID));
+    }
+
+    public void testRegisterAgentWithContextManagementFieldParseFailure() throws Exception {
+        RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+
+        WorkflowData cmInputData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "test"),
+                Map.entry("type", MLAgentType.FLOW.name()),
+                Map.entry("context_management", "{invalid json")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        PlainActionFuture<WorkflowData> future = registerAgentStep.execute(
+            cmInputData.getNodeId(),
+            cmInputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+
+        assertTrue(future.isDone());
+        ExecutionException ex = assertThrows(ExecutionException.class, () -> future.get().getContent());
+        assertTrue(ex.getCause() instanceof FlowFrameworkException);
+        assertTrue(ex.getCause().getMessage().startsWith("Failed to parse context_management field:"));
+    }
+
+    public void testRegisterAgentWithContextManagementField() throws Exception {
+        String agentId = AGENT_ID;
+        RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
+
+        String cmJson = "{\"name\":\"my-cm\",\"description\":\"test context management\"}";
+
+        WorkflowData cmInputData = new WorkflowData(
+            Map.ofEntries(Map.entry("name", "test"), Map.entry("type", MLAgentType.FLOW.name()), Map.entry("context_management", cmJson)),
+            "test-id",
+            "test-node-id"
+        );
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ActionListener<MLRegisterAgentResponse>> actionListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        ArgumentCaptor<MLAgent> mlAgentArgumentCaptor = ArgumentCaptor.forClass(MLAgent.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterAgentResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(new MLRegisterAgentResponse(agentId));
+            return null;
+        }).when(machineLearningNodeClient).registerAgent(any(MLAgent.class), actionListenerCaptor.capture());
+
+        doAnswer(invocation -> {
+            ActionListener<WorkflowData> updateResponseListener = invocation.getArgument(5);
+            updateResponseListener.onResponse(new WorkflowData(Map.of(AGENT_ID, agentId), "test-id", "test-node-id"));
+            return null;
+        }).when(flowFrameworkIndicesHandler)
+            .addResourceToStateIndex(any(WorkflowData.class), anyString(), anyString(), anyString(), nullable(String.class), any());
+
+        PlainActionFuture<WorkflowData> future = registerAgentStep.execute(
+            cmInputData.getNodeId(),
+            cmInputData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+
+        verify(machineLearningNodeClient).registerAgent(mlAgentArgumentCaptor.capture(), actionListenerCaptor.capture());
+        ContextManagementTemplate cm = mlAgentArgumentCaptor.getValue().getContextManagement();
+        assertNotNull(cm);
+        assertEquals("my-cm", cm.getName());
+
+        assertTrue(future.isDone());
+        assertEquals(agentId, future.get().getContent().get(AGENT_ID));
+    }
+
+    public void testLLMParametersFieldParseFailure() throws Exception {
         RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
         // Create llm parameters with wrong format
@@ -231,7 +461,6 @@ public class RegisterAgentTests extends OpenSearchTestCase {
     }
 
     public void testLLMParametersValidationFailure() throws Exception {
-        String agentId = AGENT_ID;
         RegisterAgentStep registerAgentStep = new RegisterAgentStep(machineLearningNodeClient, flowFrameworkIndicesHandler);
 
         // Create llm parameters with non-string value

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalPretrainedModelStepTests.java
@@ -24,6 +24,9 @@ import org.opensearch.flowframework.util.ApiSpecFetcher;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.controller.MLRateLimiter;
+import org.opensearch.ml.common.model.Guardrails;
+import org.opensearch.ml.common.model.MLDeploySetting;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 import org.opensearch.rest.RestRequest;
@@ -123,6 +126,120 @@ public class RegisterLocalPretrainedModelStepTests extends OpenSearchTestCase {
     @AfterClass
     public static void cleanup() {
         ThreadPool.terminate(testThreadPool, 500, TimeUnit.MILLISECONDS);
+    }
+
+    public void testRegisterLocalPretrainedModelWithOptionalFields() throws Exception {
+
+        String taskId = "abcd";
+        String modelId = "model-id";
+        String status = MLTaskState.COMPLETED.name();
+
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterModelResponse> actionListener = invocation.getArgument(1);
+            MLRegisterModelResponse output = new MLRegisterModelResponse(taskId, status, null);
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<MLTask> actionListener = invocation.getArgument(2);
+            MLTask output = MLTask.builder().taskId(taskId).modelId(modelId).state(MLTaskState.COMPLETED).async(false).build();
+            actionListener.onResponse(output);
+            return null;
+        }).when(machineLearningNodeClient).getTask(any(), nullable(String.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<WorkflowData> updateResponseListener = invocation.getArgument(5);
+            updateResponseListener.onResponse(new WorkflowData(Map.of(MODEL_ID, modelId), "test-id", "test-node-id"));
+            return null;
+        }).when(flowFrameworkIndicesHandler)
+            .addResourceToStateIndex(any(WorkflowData.class), anyString(), anyString(), anyString(), any(), any());
+
+        WorkflowData optionalFieldsData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "xyz"),
+                Map.entry("version", "1.0.0"),
+                Map.entry("model_format", "TORCH_SCRIPT"),
+                Map.entry(MODEL_GROUP_ID, "abcdefg"),
+                Map.entry("description", "desc"),
+                Map.entry("is_enabled", true),
+                Map.entry("backend_roles", List.of("role1")),
+                Map.entry("add_all_backend_roles", false),
+                Map.entry("access_mode", "public")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        PlainActionFuture<WorkflowData> future = registerLocalPretrainedModelStep.execute(
+            optionalFieldsData.getNodeId(),
+            optionalFieldsData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+
+        future.actionGet();
+
+        verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
+        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
+        assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
+    }
+
+    public void testRegisterLocalPretrainedModelWithRateLimiterDeploySettingGuardrailsNodeIds() throws Exception {
+
+        String taskId = "abcd";
+        String modelId = "model-id";
+        String status = MLTaskState.COMPLETED.name();
+
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterModelResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(new MLRegisterModelResponse(taskId, status, null));
+            return null;
+        }).when(machineLearningNodeClient).register(any(MLRegisterModelInput.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<MLTask> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTask.builder().taskId(taskId).modelId(modelId).state(MLTaskState.COMPLETED).async(false).build());
+            return null;
+        }).when(machineLearningNodeClient).getTask(any(), nullable(String.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<WorkflowData> updateResponseListener = invocation.getArgument(5);
+            updateResponseListener.onResponse(new WorkflowData(Map.of(MODEL_ID, modelId), "test-id", "test-node-id"));
+            return null;
+        }).when(flowFrameworkIndicesHandler)
+            .addResourceToStateIndex(any(WorkflowData.class), anyString(), anyString(), anyString(), any(), any());
+
+        WorkflowData data = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "xyz"),
+                Map.entry("version", "1.0.0"),
+                Map.entry("model_format", "TORCH_SCRIPT"),
+                Map.entry(MODEL_GROUP_ID, "abcdefg"),
+                Map.entry("rate_limiter", new MLRateLimiter("10", TimeUnit.SECONDS)),
+                Map.entry("deploy_setting", new MLDeploySetting(true, 60L)),
+                Map.entry("guardrails", Guardrails.builder().type("model").build()),
+                Map.entry("model_node_ids", new String[] { "node1", "node2" })
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        PlainActionFuture<WorkflowData> future = registerLocalPretrainedModelStep.execute(
+            data.getNodeId(),
+            data,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+
+        future.actionGet();
+
+        verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
+        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
     }
 
     public void testRegisterLocalPretrainedModelSuccess() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -20,6 +20,9 @@ import org.opensearch.flowframework.indices.FlowFrameworkIndicesHandler;
 import org.opensearch.flowframework.util.ApiSpecFetcher;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.controller.MLRateLimiter;
+import org.opensearch.ml.common.model.Guardrails;
+import org.opensearch.ml.common.model.MLDeploySetting;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
 import org.opensearch.rest.RestRequest;
@@ -31,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mockito.Mock;
@@ -38,6 +42,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.flowframework.common.CommonValue.DEPLOY_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.INTERFACE_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.IS_ENABLED_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.ML_COMMONS_API_SPEC_YAML_URI;
 import static org.opensearch.flowframework.common.CommonValue.REGISTER_MODEL_STATUS;
 import static org.opensearch.flowframework.common.WorkflowResources.CONNECTOR_ID;
@@ -80,6 +85,100 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             "test-id",
             "test-node-id"
         );
+    }
+
+    public void testRegisterRemoteModelWithOptionalFields() throws Exception {
+
+        String taskId = "abcd";
+        String modelId = "efgh";
+        String status = MLTaskState.CREATED.name();
+
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterModelResponse> actionListener = invocation.getArgument(1);
+            MLRegisterModelResponse output = new MLRegisterModelResponse(taskId, status, modelId);
+            actionListener.onResponse(output);
+            return null;
+        }).when(mlNodeClient).register(any(MLRegisterModelInput.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<WorkflowData> updateResponseListener = invocation.getArgument(5);
+            updateResponseListener.onResponse(new WorkflowData(Map.of(MODEL_ID, modelId), "test-id", "test-node-id"));
+            return null;
+        }).when(flowFrameworkIndicesHandler)
+            .addResourceToStateIndex(any(WorkflowData.class), anyString(), anyString(), anyString(), any(), any());
+
+        WorkflowData optionalFieldsData = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "xyz"),
+                Map.entry(CONNECTOR_ID, "abcdefg"),
+                Map.entry(IS_ENABLED_FIELD, true),
+                Map.entry("backend_roles", List.of("role1")),
+                Map.entry("add_all_backend_roles", false),
+                Map.entry("access_mode", "public")
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        PlainActionFuture<WorkflowData> future = this.registerRemoteModelStep.execute(
+            optionalFieldsData.getNodeId(),
+            optionalFieldsData,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+
+        verify(mlNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
+        assertTrue(future.isDone());
+        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
+        assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));
+    }
+
+    public void testRegisterRemoteModelWithGuardrailsRateLimiterDeploySetting() throws Exception {
+
+        String taskId = "abcd";
+        String modelId = "efgh";
+        String status = MLTaskState.CREATED.name();
+
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterModelResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(new MLRegisterModelResponse(taskId, status, modelId));
+            return null;
+        }).when(mlNodeClient).register(any(MLRegisterModelInput.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<WorkflowData> updateResponseListener = invocation.getArgument(5);
+            updateResponseListener.onResponse(new WorkflowData(Map.of(MODEL_ID, modelId), "test-id", "test-node-id"));
+            return null;
+        }).when(flowFrameworkIndicesHandler)
+            .addResourceToStateIndex(any(WorkflowData.class), anyString(), anyString(), anyString(), any(), any());
+
+        WorkflowData data = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("name", "xyz"),
+                Map.entry(CONNECTOR_ID, "abcdefg"),
+                Map.entry("guardrails", Guardrails.builder().type("model").build()),
+                Map.entry("rate_limiter", new MLRateLimiter("10", TimeUnit.SECONDS)),
+                Map.entry("deploy_setting", new MLDeploySetting(true, 60L)),
+                Map.entry("model_node_ids", new String[] { "node1", "node2" })
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        PlainActionFuture<WorkflowData> future = this.registerRemoteModelStep.execute(
+            data.getNodeId(),
+            data,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+
+        verify(mlNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
+        assertTrue(future.isDone());
+        assertEquals(modelId, future.get().getContent().get(MODEL_ID));
     }
 
     public void testRegisterRemoteModelSuccess() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ToolStepTests.java
@@ -212,4 +212,36 @@ public class ToolStepTests extends OpenSearchTestCase {
         MLToolSpec mlToolSpec = (MLToolSpec) tools;
         assertEquals(mlToolSpec.getParameters(), Map.of(AGENT_ID, mockedAgentId));
     }
+
+    public void testToolWithRuntimeResources() throws ExecutionException, InterruptedException {
+        ToolStep toolStep = new ToolStep();
+
+        WorkflowData inputDataWithRuntimeResources = new WorkflowData(
+            Map.ofEntries(
+                Map.entry("type", "type"),
+                Map.entry("name", "name"),
+                Map.entry("description", "description"),
+                Map.entry("parameters", Collections.emptyMap()),
+                Map.entry("include_output_in_agent_response", false),
+                Map.entry("runtime_resources", Map.of("resource_key", "resource_value"))
+            ),
+            "test-id",
+            "test-node-id"
+        );
+
+        PlainActionFuture<WorkflowData> future = toolStep.execute(
+            inputDataWithRuntimeResources.getNodeId(),
+            inputDataWithRuntimeResources,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null
+        );
+        assertTrue(future.isDone());
+        Object tools = future.get().getContent().get("tools");
+        assertEquals(MLToolSpec.class, tools.getClass());
+        MLToolSpec mlToolSpec = (MLToolSpec) tools;
+        assertNotNull(mlToolSpec.getRuntimeResources());
+        assertEquals("resource_value", mlToolSpec.getRuntimeResources().get("resource_key"));
+    }
 }


### PR DESCRIPTION
### Description

CommonValue.java — Added 13 new constants:
- IS_ENABLED_FIELD, RATE_LIMITER_FIELD, DEPLOY_SETTING_FIELD, MODEL_NODE_IDS_FIELD (model registration fields)
- CLIENT_CONFIG_FIELD, CONNECTOR_URL_FIELD, HEADERS_FIELD (connector fields)
- MODEL_FIELD, CONTEXT_MANAGEMENT_NAME_FIELD, CONTEXT_MANAGEMENT_FIELD (agent fields)
- MEMORY_CONTAINER_ID_FIELD (memory spec field)
- RUNTIME_RESOURCES_FIELD (tool field)
- CONNECTOR_ACTION_NAME_FIELD (connector action field)

CreateConnectorStep.java — High priority:
- Added url, headers to optional inputs (unblocks MCP connector creation)
- Added backend_roles, add_all_backend_roles, access_mode, client_config to optional inputs
- Added name field to ConnectorAction parsing
- Wired all new fields into MLCreateConnectorInput.builder()

RegisterAgentStep.java — High priority:
- Added model field to optional keys (unblocks unified agent interface via MLAgentModelSpec)
- Added context_management_name and context_management to optional keys
- Wired model spec parsing (model_id, model_provider, credential, model_parameters)
- Wired context management parsing via ContextManagementTemplate.parse()
- Added memory_container_id to MLMemorySpec parsing

RegisterRemoteModelStep.java — Medium + Lower priority:
- Added is_enabled, rate_limiter, deploy_setting to optional inputs
- Added backend_roles, add_all_backend_roles, access_mode, model_node_ids to optional inputs
- Wired all into MLRegisterModelInput.builder()

AbstractRegisterLocalModelStep.java + all 3 subclasses — Medium + Lower priority:
- Added is_enabled, rate_limiter, deploy_setting, guardrails, backend_roles, add_all_backend_roles, access_mode, model_node_ids to optional keys in all local model steps
- Added interface to RegisterLocalPretrainedModelStep (was missing)
- Wired all new fields into the builder in the abstract class

ToolStep.java — Medium priority:
- Added runtime_resources to optional inputs
- Wired it into MLToolSpec.builder()

Add unit tests for new optional fields in workflow steps

CreateConnectorStepTests:
- testCreateConnectorWithOptionalFields: exercises url, headers, backend_roles,
  add_all_backend_roles, access_mode, client_config, and ConnectorAction name field

RegisterAgentTests:
- testRegisterAgentWithModelField: exercises model field (MLAgentModelSpec) with
  model_id, model_provider, credential, and model_parameters
- testRegisterAgentWithContextManagementName: exercises context_management_name field
- testRegisterAgentWithMemoryContainerId: exercises memory_container_id in MLMemorySpec

RegisterRemoteModelStepTests:
- testRegisterRemoteModelWithOptionalFields: exercises is_enabled, backend_roles,
  add_all_backend_roles, and access_mode fields

RegisterLocalPretrainedModelStepTests:
- testRegisterLocalPretrainedModelWithOptionalFields: exercises is_enabled,
  backend_roles, add_all_backend_roles, and access_mode fields

ToolStepTests:
- testToolWithRuntimeResources: exercises runtime_resources field

### Related Issues

Fixes #1359 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
