### PR TITLE
Add response processor to flow agent agentic search template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add agentic search workflow template with conversational agent ([#1353](https://github.com/opensearch-project/flow-framework/pull/1353))
 ### Enhancements
 ### Bug Fixes
+- Add response processor to flow agent agentic search template ([#1367](https://github.com/opensearch-project/flow-framework/pull/1367))
 - Fix hard-coded region in Bedrock template URLs ([#1354](https://github.com/opensearch-project/flow-framework/pull/1354))
 ### Infrastructure
 ### Documentation

--- a/src/main/resources/substitutionTemplates/agentic-search-with-flow-agent-template.json
+++ b/src/main/resources/substitutionTemplates/agentic-search-with-flow-agent-template.json
@@ -99,6 +99,13 @@
                     "agent_id": "${{register_agent.agent_id}}"
                   }
                 }
+              ],
+              "response_processors": [
+                {
+                  "agentic_context": {
+                    "dsl_query": true
+                  }
+                }
               ]
             }
           }


### PR DESCRIPTION
### Description

Adds the `agentic_context` response processor with `dsl_query: true` to the flow agent agentic search workflow template, matching the conversational agent template's behavior of exposing the generated DSL query in the search response.

The conversational agent template already includes this response processor (with both `dsl_query` and `agent_steps_summary`). The flow agent template only needs `dsl_query` since it does not use conversational memory/steps.

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`