### PR TITLE
Use ML Commons validation methods in workflow parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add agentic search workflow template with flow agent ([#1349](https://github.com/opensearch-project/flow-framework/pull/1349))
 - Add agentic search workflow template with conversational agent ([#1353](https://github.com/opensearch-project/flow-framework/pull/1353))
 ### Enhancements
+- Use ML Commons validation methods for name/description fields during workflow parsing ([#1368](https://github.com/opensearch-project/flow-framework/pull/1368))
 ### Bug Fixes
 - Add response processor to flow agent agentic search template ([#1367](https://github.com/opensearch-project/flow-framework/pull/1367))
 - Fix hard-coded region in Bedrock template URLs ([#1354](https://github.com/opensearch-project/flow-framework/pull/1354))

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -10,6 +10,7 @@ package org.opensearch.flowframework.workflow;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.flowframework.common.FlowFrameworkSettings;
@@ -21,6 +22,8 @@ import org.opensearch.flowframework.model.Workflow;
 import org.opensearch.flowframework.model.WorkflowEdge;
 import org.opensearch.flowframework.model.WorkflowNode;
 import org.opensearch.flowframework.util.ParseUtils;
+import org.opensearch.ml.common.utils.FieldDescriptor;
+import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.plugins.PluginInfo;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.threadpool.ThreadPool;
@@ -39,6 +42,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.opensearch.flowframework.common.CommonValue.DESCRIPTION_FIELD;
+import static org.opensearch.flowframework.common.CommonValue.NAME_FIELD;
 import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW;
 import static org.opensearch.flowframework.common.CommonValue.PROVISION_WORKFLOW_THREAD_POOL;
 import static org.opensearch.flowframework.common.FlowFrameworkSettings.MAX_WORKFLOW_STEPS;
@@ -62,6 +67,22 @@ public class WorkflowProcessSorter {
         DeleteIndexStep.NAME,
         DeleteIngestPipelineStep.NAME,
         DeleteSearchPipelineStep.NAME
+    );
+
+    /** ML Commons step types that have name/description field validation, mapped to a human-readable label */
+    private static final Map<String, String> ML_COMMONS_VALIDATED_STEPS = Map.of(
+        CreateConnectorStep.NAME,
+        "Model connector",
+        RegisterRemoteModelStep.NAME,
+        "Model",
+        RegisterLocalCustomModelStep.NAME,
+        "Model",
+        RegisterLocalSparseEncodingModelStep.NAME,
+        "Model",
+        RegisterLocalPretrainedModelStep.NAME,
+        "Model",
+        RegisterModelGroupStep.NAME,
+        "Model group"
     );
 
     private WorkflowStepFactory workflowStepFactory;
@@ -437,6 +458,7 @@ public class WorkflowProcessSorter {
             .collect(Collectors.toList());
         validatePluginsInstalled(processNodes, installedPlugins);
         validateGraph(processNodes);
+        validateFieldValues(processNodes);
     }
 
     /**
@@ -506,6 +528,45 @@ public class WorkflowProcessSorter {
                         + expectedInputs.toString(),
                     RestStatus.BAD_REQUEST
                 );
+            }
+        }
+    }
+
+    /**
+     * Validates field values in process nodes using ML Commons validation methods.
+     * Checks that name and description fields in ML Commons steps contain only safe characters.
+     * @param processNodes A list of process nodes
+     * @throws Exception on validation failure
+     */
+    public void validateFieldValues(List<ProcessNode> processNodes) throws Exception {
+        Map<String, FieldDescriptor> fieldsToValidate = new HashMap<>();
+
+        for (ProcessNode processNode : processNodes) {
+            String nodeType = processNode.workflowStep().getName();
+            if (!ML_COMMONS_VALIDATED_STEPS.containsKey(nodeType)) {
+                continue;
+            }
+            Map<String, Object> userInputs = processNode.input().getContent();
+            String stepLabel = ML_COMMONS_VALIDATED_STEPS.get(nodeType);
+
+            Object nameValue = userInputs.get(NAME_FIELD);
+            if (nameValue instanceof String) {
+                fieldsToValidate.put(stepLabel + " name [node " + processNode.id() + "]", new FieldDescriptor((String) nameValue, true));
+            }
+
+            Object descValue = userInputs.get(DESCRIPTION_FIELD);
+            if (descValue instanceof String) {
+                fieldsToValidate.put(
+                    stepLabel + " description [node " + processNode.id() + "]",
+                    new FieldDescriptor((String) descValue, false)
+                );
+            }
+        }
+
+        if (!fieldsToValidate.isEmpty()) {
+            ActionRequestValidationException exception = StringUtils.validateFields(fieldsToValidate);
+            if (exception != null) {
+                throw new FlowFrameworkException(exception.getMessage(), RestStatus.BAD_REQUEST);
             }
         }
     }

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.flowframework.workflow;
 
 import org.opensearch.Version;
+import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -26,6 +27,8 @@ import org.opensearch.flowframework.model.Workflow;
 import org.opensearch.flowframework.model.WorkflowEdge;
 import org.opensearch.flowframework.model.WorkflowNode;
 import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.plugins.PluginsService;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
@@ -830,6 +833,43 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         assertTrue(reprovisionWorkflowStepNames.contains(UpdateSearchPipelineStep.NAME));
         // Assert update index step in the sequence
         assertTrue(reprovisionWorkflowStepNames.contains(UpdateIndexStep.NAME));
+    }
+
+    public void testValidate() throws Exception {
+        WorkflowNode createConnector = new WorkflowNode(
+            "workflow_step_1",
+            CreateConnectorStep.NAME,
+            Collections.emptyMap(),
+            Map.ofEntries(
+                Map.entry("name", "My Valid Connector"),
+                Map.entry("description", "A valid description."),
+                Map.entry("version", "1"),
+                Map.entry("protocol", "http"),
+                Map.entry("parameters", "{}"),
+                Map.entry("credential", "{}"),
+                Map.entry("actions", "[]")
+            )
+        );
+        WorkflowNode registerModel = new WorkflowNode(
+            "workflow_step_2",
+            RegisterRemoteModelStep.NAME,
+            Map.ofEntries(Map.entry("workflow_step_1", CONNECTOR_ID)),
+            Map.ofEntries(Map.entry("name", "Valid Model"), Map.entry("function_name", "remote"), Map.entry("description", "Valid desc"))
+        );
+        WorkflowEdge edge = new WorkflowEdge(createConnector.id(), registerModel.id());
+        Workflow workflow = new Workflow(Collections.emptyMap(), List.of(createConnector, registerModel), List.of(edge));
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), null);
+
+        PluginsService pluginsService = mock(PluginsService.class);
+        PluginsAndModules pluginsAndModules = mock(PluginsAndModules.class);
+        when(pluginsService.info()).thenReturn(pluginsAndModules);
+        when(pluginsAndModules.getPluginInfos()).thenReturn(
+            List.of(
+                new PluginInfo("opensearch-flow-framework", "", "", Version.CURRENT, "", "", List.of(), false),
+                new PluginInfo("opensearch-ml", "", "", Version.CURRENT, "", "", List.of(), false)
+            )
+        );
+        workflowProcessSorter.validate(sortedProcessNodes, pluginsService);
     }
 
     public void testSuccessfulFieldValueValidation() throws Exception {

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -832,4 +832,84 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         assertTrue(reprovisionWorkflowStepNames.contains(UpdateIndexStep.NAME));
     }
 
+    public void testSuccessfulFieldValueValidation() throws Exception {
+        WorkflowNode createConnector = new WorkflowNode(
+            "workflow_step_1",
+            CreateConnectorStep.NAME,
+            Collections.emptyMap(),
+            Map.ofEntries(
+                Map.entry("name", "My Valid Connector"),
+                Map.entry("description", "A valid description."),
+                Map.entry("version", "1"),
+                Map.entry("protocol", "http"),
+                Map.entry("parameters", "{}"),
+                Map.entry("credential", "{}"),
+                Map.entry("actions", "[]")
+            )
+        );
+        Workflow workflow = new Workflow(Collections.emptyMap(), List.of(createConnector), Collections.emptyList());
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), null);
+        workflowProcessSorter.validateFieldValues(sortedProcessNodes);
+    }
+
+    public void testFieldValueValidationInvalidName() throws Exception {
+        WorkflowNode createConnector = new WorkflowNode(
+            "workflow_step_1",
+            CreateConnectorStep.NAME,
+            Collections.emptyMap(),
+            Map.ofEntries(
+                Map.entry("name", "Bad<script>Name"),
+                Map.entry("description", "A valid description."),
+                Map.entry("version", "1"),
+                Map.entry("protocol", "http"),
+                Map.entry("parameters", "{}"),
+                Map.entry("credential", "{}"),
+                Map.entry("actions", "[]")
+            )
+        );
+        Workflow workflow = new Workflow(Collections.emptyMap(), List.of(createConnector), Collections.emptyList());
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), null);
+        FlowFrameworkException ex = expectThrows(
+            FlowFrameworkException.class,
+            () -> workflowProcessSorter.validateFieldValues(sortedProcessNodes)
+        );
+        assertTrue(ex.getMessage().contains("Model connector name"));
+        assertEquals(RestStatus.BAD_REQUEST, ex.getRestStatus());
+    }
+
+    public void testFieldValueValidationInvalidDescription() throws Exception {
+        WorkflowNode registerModel = new WorkflowNode(
+            "workflow_step_1",
+            RegisterRemoteModelStep.NAME,
+            Collections.emptyMap(),
+            Map.ofEntries(
+                Map.entry("name", "Valid Model Name"),
+                Map.entry("function_name", "remote"),
+                Map.entry("description", "Bad<script>Desc"),
+                Map.entry("connector_id", "abc123")
+            )
+        );
+        Workflow workflow = new Workflow(Collections.emptyMap(), List.of(registerModel), Collections.emptyList());
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), null);
+        FlowFrameworkException ex = expectThrows(
+            FlowFrameworkException.class,
+            () -> workflowProcessSorter.validateFieldValues(sortedProcessNodes)
+        );
+        assertTrue(ex.getMessage().contains("Model description"));
+        assertEquals(RestStatus.BAD_REQUEST, ex.getRestStatus());
+    }
+
+    public void testFieldValueValidationSkipsNonMlSteps() throws Exception {
+        WorkflowNode createIndex = new WorkflowNode(
+            "workflow_step_1",
+            CreateIndexStep.NAME,
+            Collections.emptyMap(),
+            Map.ofEntries(Map.entry("index_name", "my-index"), Map.entry("configurations", "{}"))
+        );
+        Workflow workflow = new Workflow(Collections.emptyMap(), List.of(createIndex), Collections.emptyList());
+        List<ProcessNode> sortedProcessNodes = workflowProcessSorter.sortProcessNodes(workflow, "123", Collections.emptyMap(), null);
+        // Should not throw - non-ML steps are skipped
+        workflowProcessSorter.validateFieldValues(sortedProcessNodes);
+    }
+
 }


### PR DESCRIPTION
### Description

Resolves #1152.

Adds field value validation during workflow template validation (`validation=all`) using ML Commons `StringUtils.validateFields()`. This catches invalid characters in `name` and `description` fields at parse time rather than waiting for runtime provisioning failures.

### Validated steps

The following ML Commons steps now have name/description validated during workflow parsing, matching the validation added in [ml-commons#3805](https://github.com/opensearch-project/ml-commons/pull/3805):

| Step | `name` (required) | `description` (optional) |
|------|---------------------|---------------------------|
| `create_connector` | ✅ | ✅ |
| `register_remote_model` | ✅ | ✅ |
| `register_local_custom_model` | ✅ | ✅ |
| `register_local_sparse_encoding_model` | ✅ | ✅ |
| `register_local_pretrained_model` | ✅ | ✅ |
| `register_model_group` | ✅ | ✅ |

### Changes

- **`WorkflowProcessSorter.java`**: Added `validateFieldValues()` method called from `validate()`. Uses `StringUtils.validateFields()` and `FieldDescriptor` from ML Commons directly — no duplicated validation logic.
- **`WorkflowProcessSorterTests.java`**: Added 4 tests covering valid inputs, invalid name, invalid description, and non-ML step passthrough.

### Design decisions

- Only validates literal string values in user inputs. Fields provided via `previous_node_inputs` (runtime references) are not validated at parse time.
- Substitution template fields (e.g., `${{name}}`) are also not validated, as these are resolved at provisioning time with user-supplied values.
- Uses the same `FieldDescriptor` required/optional semantics as ML Commons: `name` is required, `description` is optional.
- Error messages include the step label and node ID for easy debugging.
- Agent and tool steps are not included because ML Commons does not yet validate those (see [jngz-es comment on #3805](https://github.com/opensearch-project/ml-commons/pull/3805#issuecomment-2867823107)).

### How to test

```bash
# Create a workflow with an invalid connector name
POST _plugins/_flow_framework/workflow?validation=all
{
  "name": "test",
  "workflows": {
    "provision": {
      "nodes": [{
        "id": "create_connector",
        "type": "create_connector",
        "user_inputs": {
          "name": "Bad<script>Name",
          "description": "test",
          "version": "1",
          "protocol": "http",
          "parameters": {},
          "credential": {},
          "actions": []
        }
      }]
    }
  }
}
# Should return 400 with validation error about connector name
```

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).