### PR TITLE
Add Gradle cache to setup-java steps in CI workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           java-version: 25
           distribution: temurin
+          cache: gradle
       - name: Spotless Check
         run: ./gradlew spotlessCheck
   javadoc:
@@ -31,6 +32,7 @@ jobs:
         with:
           java-version: 25
           distribution: temurin
+          cache: gradle
       - name: Javadoc CheckStyle
         run: ./gradlew checkstyleMain
       - name: Javadoc Check
@@ -50,6 +52,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
+          cache: gradle
       - name: Build and Run Tests
         shell: bash
         run: |
@@ -77,6 +80,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
+          cache: gradle
       - name: Build and Run Tests
         shell: bash
         run: |
@@ -97,6 +101,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
+          cache: gradle
       - name: Build and Run Tests
         shell: bash
         run: |
@@ -120,6 +125,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
+          cache: gradle
       - name: Build and Run Tests
         shell: bash
         run: |

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -20,11 +20,12 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 25
-      - uses: actions/checkout@v6
+          cache: gradle
 
       - name: Load secret
         uses: 1password/load-secrets-action@v4

--- a/.github/workflows/test-api-consistency.yml
+++ b/.github/workflows/test-api-consistency.yml
@@ -18,10 +18,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: gradle
 
       - name: Run API Consistency Tests
         run: ./gradlew test --tests "org.opensearch.flowframework.workflow.*"

--- a/.github/workflows/test_bwc.yml
+++ b/.github/workflows/test_bwc.yml
@@ -20,14 +20,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Flow Framework
+        uses: actions/checkout@v6
+
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-
-      - name: Checkout Flow Framework
-        uses: actions/checkout@v6
+          cache: gradle
 
       - name: Assemble Flow Framework
         run: |

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: gradle
       - name: Run tests
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Fix hard-coded region in Bedrock template URLs ([#1354](https://github.com/opensearch-project/flow-framework/pull/1354))
 - Add missing fields to workflow steps matching ml-commons builders ([#1360](https://github.com/opensearch-project/flow-framework/pull/1360))
 ### Infrastructure
+- Add Gradle cache to setup-java steps in GitHub Actions workflows ([#1372](https://github.com/opensearch-project/flow-framework/pull/1372))
 ### Documentation
 ### Maintenance
 ### Refactoring


### PR DESCRIPTION
### Description

Adds `cache: gradle` to all `actions/setup-java` steps across GitHub Actions workflow files. This enables the [built-in dependency caching](https://github.com/actions/setup-java#caching-packages-dependencies) provided by the setup-java action, which caches Gradle dependencies between workflow runs to reduce build times.

### Changes

- Added `cache: gradle` to all 9 `setup-java` steps across 5 workflow files:
  - `CI.yml` (6 steps: spotless, javadoc, build, integTest, integMultiNodeTest, integTenantAwareTest)
  - `publish-snapshots.yml` (1 step)
  - `test-api-consistency.yml` (1 step)
  - `test_bwc.yml` (1 step)
  - `test_security.yml` (1 step)
- Bumped `setup-java` from v3 to v4 in `test-api-consistency.yml` for consistency with other workflows

### Reference

- [actions/setup-java caching documentation](https://github.com/actions/setup-java#caching-packages-dependencies)

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing
  - N/A (infrastructure-only change, CI runs will validate)
- [x] New functionality has been documented
  - N/A
- [x] Commits are signed per the DCO using `--signoff`