### PR TITLE
Handle ResourceAlreadyExistsException in FlowFrameworkIndicesHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 - Support Jackson 3.x release line ([#1376](https://github.com/opensearch-project/flow-framework/pull/1376))
 ### Bug Fixes
+- Handle ResourceAlreadyExistsException race condition in FlowFrameworkIndicesHandler ([#1378](https://github.com/opensearch-project/flow-framework/pull/1378))
 - Add response processor to flow agent agentic search template ([#1367](https://github.com/opensearch-project/flow-framework/pull/1367))
 - Fix hard-coded region in Bedrock template URLs ([#1354](https://github.com/opensearch-project/flow-framework/pull/1354))
 - Add missing fields to workflow steps matching ml-commons builders ([#1360](https://github.com/opensearch-project/flow-framework/pull/1360))

--- a/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
+++ b/src/main/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandler.java
@@ -13,6 +13,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessageFactory;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.OpenSearchWrapperException;
+import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.DocWriteRequest.OpType;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
@@ -215,10 +217,16 @@ public class FlowFrameworkIndicesHandler {
                         internalListener.onResponse(false);
                     }
                 }, e -> {
-                    String errorMessage = ParameterizedMessageFactory.INSTANCE.newMessage("Failed to create index {}", indexName)
-                        .getFormattedMessage();
-                    logger.error(errorMessage, e);
-                    internalListener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                    if (e instanceof ResourceAlreadyExistsException
+                        || (e instanceof OpenSearchWrapperException && e.getCause() instanceof ResourceAlreadyExistsException)) {
+                        logger.info("Index {} already created by another request", indexName);
+                        internalListener.onResponse(true);
+                    } else {
+                        String errorMessage = ParameterizedMessageFactory.INSTANCE.newMessage("Failed to create index {}", indexName)
+                            .getFormattedMessage();
+                        logger.error(errorMessage, e);
+                        internalListener.onFailure(new FlowFrameworkException(errorMessage, ExceptionsHelper.status(e)));
+                    }
                 });
                 CreateIndexRequest request = new CreateIndexRequest(indexName).mapping("{\"_doc\":" + mapping + "}")
                     .settings(indexSettings);

--- a/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
+++ b/src/test/java/org/opensearch/flowframework/indices/FlowFrameworkIndicesHandlerTests.java
@@ -8,9 +8,12 @@
  */
 package org.opensearch.flowframework.indices;
 
+import org.opensearch.OpenSearchWrapperException;
+import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.Version;
 import org.opensearch.action.DocWriteResponse.Result;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
@@ -292,6 +295,45 @@ public class FlowFrameworkIndicesHandlerTests extends OpenSearchTestCase {
         flowFrameworkIndicesHandler.initFlowFrameworkIndexIfAbsent(FlowFrameworkIndex.GLOBAL_CONTEXT, listener);
 
         verify(indicesAdminClient, times(1)).create(any(CreateIndexRequest.class), any());
+    }
+
+    public void testInitIndexIfAbsent_ResourceAlreadyExistsException() {
+        @SuppressWarnings("unchecked")
+        ActionListener<Boolean> listener = mock(ActionListener.class);
+        doAnswer(invocation -> {
+            ActionListener<CreateIndexResponse> actionListener = invocation.getArgument(1);
+            actionListener.onFailure(new ResourceAlreadyExistsException("index [.plugins-flow-framework-state] already exists"));
+            return null;
+        }).when(indicesAdminClient).create(any(CreateIndexRequest.class), any());
+
+        flowFrameworkIndicesHandler.initFlowFrameworkIndexIfAbsent(FlowFrameworkIndex.WORKFLOW_STATE, listener);
+
+        ArgumentCaptor<Boolean> captor = ArgumentCaptor.forClass(Boolean.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue());
+    }
+
+    public void testInitIndexIfAbsent_WrappedResourceAlreadyExistsException() {
+        @SuppressWarnings("unchecked")
+        ActionListener<Boolean> listener = mock(ActionListener.class);
+        doAnswer(invocation -> {
+            ActionListener<CreateIndexResponse> actionListener = invocation.getArgument(1);
+            actionListener.onFailure(new TestWrappedException(new ResourceAlreadyExistsException("index already exists")));
+            return null;
+        }).when(indicesAdminClient).create(any(CreateIndexRequest.class), any());
+
+        flowFrameworkIndicesHandler.initFlowFrameworkIndexIfAbsent(FlowFrameworkIndex.WORKFLOW_STATE, listener);
+
+        ArgumentCaptor<Boolean> captor = ArgumentCaptor.forClass(Boolean.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue());
+    }
+
+    // Helper class that implements OpenSearchWrapperException for testing
+    private static class TestWrappedException extends Exception implements OpenSearchWrapperException {
+        TestWrappedException(Throwable cause) {
+            super(cause);
+        }
     }
 
     public void testIsWorkflowProvisionedFailedParsing() {


### PR DESCRIPTION
### Description

Fixes a race condition in `FlowFrameworkIndicesHandler.initFlowFrameworkIndexIfAbsent()` where concurrent index creation requests on a multi-node cluster can fail with a 400 BAD_REQUEST error.

When two nodes simultaneously check `doesIndexExistMultitenant()` and both get `false`, the second `CreateIndexRequest` throws `ResourceAlreadyExistsException`. Previously this was treated as a failure. Now it is treated as success, since the index exists (which is the desired state).

This matches the pattern used by ML Commons' `MLIndicesHandler`.

Resolves #1377

### Issues Resolved

- [#1377](https://github.com/opensearch-project/flow-framework/issues/1377)

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`
- [x] Changelog entry added