### PR TITLE
Set provisioned_by field on ML resources for adoption metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add agentic search workflow template with flow agent ([#1349](https://github.com/opensearch-project/flow-framework/pull/1349))
 - Add agentic search workflow template with conversational agent ([#1353](https://github.com/opensearch-project/flow-framework/pull/1353))
 ### Enhancements
+- Set provisioned_by field on connectors, models, and agents for adoption metrics attribution ([#1388](https://github.com/opensearch-project/flow-framework/pull/1388))
 - Use ML Commons validation methods for name/description fields during workflow parsing ([#1368](https://github.com/opensearch-project/flow-framework/pull/1368))
 - Support Jackson 3.x release line ([#1376](https://github.com/opensearch-project/flow-framework/pull/1376))
 ### Bug Fixes

--- a/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/AbstractRegisterLocalModelStep.java
@@ -143,7 +143,8 @@ public abstract class AbstractRegisterLocalModelStep extends AbstractRetryableWo
             MLRegisterModelInputBuilder mlInputBuilder = MLRegisterModelInput.builder()
                 .modelName(modelName)
                 .version(modelVersion)
-                .modelFormat(MLModelFormat.from(modelFormat));
+                .modelFormat(MLModelFormat.from(modelFormat))
+                .provisionedBy("flow-framework");
 
             if (functionName != null) {
                 mlInputBuilder.functionName(FunctionName.from(functionName));

--- a/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/CreateConnectorStep.java
@@ -179,7 +179,8 @@ public class CreateConnectorStep implements WorkflowStep {
                 .parameters(parameters)
                 .credential(credentials)
                 .actions(actions)
-                .tenantId(tenantId);
+                .tenantId(tenantId)
+                .provisionedBy("flow-framework");
 
             if (backendRoles != null) {
                 mlInputBuilder.backendRoles(backendRoles);

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterAgentStep.java
@@ -218,7 +218,8 @@ public class RegisterAgentStep implements WorkflowStep {
                 .createdTime(createdTime)
                 .lastUpdateTime(lastUpdateTime)
                 .appType(appType)
-                .tenantId(tenantId);
+                .tenantId(tenantId)
+                .provisionedBy("flow-framework");
 
             if (contextManagementName != null) {
                 builder.contextManagementName(contextManagementName);

--- a/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStep.java
@@ -141,7 +141,8 @@ public class RegisterRemoteModelStep implements WorkflowStep {
                 .functionName(FunctionName.REMOTE)
                 .modelName(modelName)
                 .connectorId(connectorId)
-                .tenantId(tenantId);
+                .tenantId(tenantId)
+                .provisionedBy("flow-framework");
 
             if (modelGroupId != null) {
                 builder.modelGroupId(modelGroupId);

--- a/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/CreateConnectorStepTests.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -172,7 +173,9 @@ public class CreateConnectorStepTests extends OpenSearchTestCase {
             null
         );
 
-        verify(machineLearningNodeClient).createConnector(any(MLCreateConnectorInput.class), any());
+        ArgumentCaptor<MLCreateConnectorInput> captor = ArgumentCaptor.forClass(MLCreateConnectorInput.class);
+        verify(machineLearningNodeClient).createConnector(captor.capture(), any());
+        assertEquals("flow-framework", captor.getValue().getProvisionedBy());
         assertTrue(future.isDone());
         assertEquals(connectorId, future.get().getContent().get(CONNECTOR_ID));
 

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterAgentTests.java
@@ -132,6 +132,7 @@ public class RegisterAgentTests extends OpenSearchTestCase {
 
         verify(machineLearningNodeClient).registerAgent(mlAgentArgumentCaptor.capture(), actionListenerCaptor.capture());
         assertEquals(llmParams, mlAgentArgumentCaptor.getValue().getLlm().getParameters());
+        assertEquals("flow-framework", mlAgentArgumentCaptor.getValue().getProvisionedBy());
 
         assertTrue(future.isDone());
         assertEquals(agentId, future.get().getContent().get(AGENT_ID));

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterLocalCustomModelStepTests.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -182,7 +183,9 @@ public class RegisterLocalCustomModelStepTests extends OpenSearchTestCase {
 
         future.actionGet();
 
-        verify(machineLearningNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
+        ArgumentCaptor<MLRegisterModelInput> captor = ArgumentCaptor.forClass(MLRegisterModelInput.class);
+        verify(machineLearningNodeClient, times(1)).register(captor.capture(), any());
+        assertEquals("flow-framework", captor.getValue().getProvisionedBy());
         verify(machineLearningNodeClient, times(1)).getTask(any(), nullable(String.class), any());
 
         assertEquals(modelId, future.get().getContent().get(MODEL_ID));

--- a/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/RegisterRemoteModelStepTests.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -129,7 +130,9 @@ public class RegisterRemoteModelStepTests extends OpenSearchTestCase {
             null
         );
 
-        verify(mlNodeClient, times(1)).register(any(MLRegisterModelInput.class), any());
+        ArgumentCaptor<MLRegisterModelInput> captor = ArgumentCaptor.forClass(MLRegisterModelInput.class);
+        verify(mlNodeClient, times(1)).register(captor.capture(), any());
+        assertEquals("flow-framework", captor.getValue().getProvisionedBy());
         assertTrue(future.isDone());
         assertEquals(modelId, future.get().getContent().get(MODEL_ID));
         assertEquals(status, future.get().getContent().get(REGISTER_MODEL_STATUS));


### PR DESCRIPTION
### Description

Sets the `provisioned_by` field to `"flow-framework"` when creating connectors, registering models, and registering agents. This enables ML Commons adoption metrics to attribute resource creation to Flow Framework as the provisioning client.

#### Changes
- `CreateConnectorStep`: adds `.provisionedBy("flow-framework")` to `MLCreateConnectorInput` builder
- `RegisterRemoteModelStep`: adds `.provisionedBy("flow-framework")` to `MLRegisterModelInput` builder
- `AbstractRegisterLocalModelStep`: adds `.provisionedBy("flow-framework")` to `MLRegisterModelInput` builder
- `RegisterAgentStep`: adds `.provisionedBy("flow-framework")` to `MLAgent` builder

#### Testing
- Added `ArgumentCaptor`-based assertions in `CreateConnectorStepTests`, `RegisterRemoteModelStepTests`, `RegisterLocalCustomModelStepTests`, and `RegisterAgentTests` to verify the field is set correctly.

### Related Issues
Depends on https://github.com/opensearch-project/ml-commons/pull/4754

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).