### PR TITLE
Bump aws-cryptographic-material-providers from 1.11.0 to 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Infrastructure
 ### Documentation
 ### Maintenance
+- Bump `software.amazon.cryptography:aws-cryptographic-material-providers` from 1.11.0 to 1.11.1 ([#1405](https://github.com/opensearch-project/flow-framework/pull/1405))
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
 
         // Version constants for dependencies
         awsEncryptionSdkVersion = "3.0.2"
-        awsCryptoMaterialProvidersVersion = "1.11.0"
+        awsCryptoMaterialProvidersVersion = "1.11.1"
         dafnyRuntimeVersion = "4.11.0"
         smithyDafnyVersion = "0.1.2"
         gsonVersion = "2.14.0"
@@ -308,6 +308,7 @@ dependencies {
                 force("software.amazon.awssdk:dynamodb:${versions.aws}")
                 force("org.dafny:DafnyRuntime:${dafnyRuntimeVersion}")
                 force("software.amazon.smithy.dafny:conversion:${smithyDafnyVersion}")
+                force("software.amazon.cryptography:aws-cryptographic-material-providers:${awsCryptoMaterialProvidersVersion}")
             }
         }
     }


### PR DESCRIPTION
### Description

Bumps `software.amazon.cryptography:aws-cryptographic-material-providers` from 1.11.0 to 1.11.1 and adds a `force()` resolution for the ddb-client configuration.

The `opensearch-remote-metadata-sdk` [bumped this dependency to 1.11.1](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/commit/b7aac2d3), but `aws-database-encryption-sdk-dynamodb:3.9.0` (a transitive dependency) still pulls in 1.11.0. This version conflict causes `bundlePlugin` to fail with `failOnVersionConflict` when `REMOTE_METADATA_SDK_IMPL=ddb-client`.

### Issues Resolved

Resolves CI build failure on main: https://github.com/opensearch-project/flow-framework/actions/runs/26833156012

### Check List
- [x] New functionality includes testing
  - N/A - dependency version bump only
- [x] New functionality has been documented
  - N/A - dependency version bump only
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and Signing Commits, please see the [contributing guide](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md).