### PR TITLE
Add jackson-databind dependency required by swagger-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Add jackson-databind dependency required by swagger-parser ([#1406](https://github.com/opensearch-project/flow-framework/pull/1406))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/build.gradle
+++ b/build.gradle
@@ -255,6 +255,8 @@ dependencies {
     // Jackson dependencies
     implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
     implementation("tools.jackson.core:jackson-databind:${versions.jackson3_databind}")
+    // Required by swagger-parser at runtime (no longer provided transitively by upstream)
+    implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
 
     testImplementation("org.junit.jupiter:junit-jupiter:${junitJupiterVersion}")
     testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}")


### PR DESCRIPTION
### Description

Adds `com.fasterxml.jackson.core:jackson-databind` as a direct dependency. The swagger-parser library requires it at runtime (`OpenAPIV3Parser` static initializer loads `com.fasterxml.jackson.databind.Module`).

This was previously provided transitively via `opensearch-remote-metadata-sdk`, which included it through the `opensearch-java` client's Jackson 2 dependencies. Snapshot publication on the SDK was broken (opensearch-project/opensearch-remote-metadata-sdk@d9b7779), so flow-framework consumed a stale snapshot. During that time the SDK migrated to Jackson 3 (opensearch-project/opensearch-remote-metadata-sdk@780ae4c). When publication resumed (opensearch-project/opensearch-remote-metadata-sdk@4ff1572), the new snapshot no longer provided Jackson 2 `jackson-databind`, causing `NoClassDefFoundError: com/fasterxml/jackson/databind/Module` in `ApiSpecFetcherTests`.

### Issues Resolved

Fixes CI unit test failure (`ApiSpecFetcherTests`) on main.

### Check List
- [x] New functionality includes testing
  - N/A - existing tests now pass (were failing with NoClassDefFoundError)
- [x] New functionality has been documented
  - N/A
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and Signing Commits, please see the [contributing guide](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md).