### PR TITLE
Update opensearch-build workflow references from commit SHA to main

### DIFF
--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@b2d99a40d4cec48d1545cd41ed8e18f1817b165f # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
     with:
       product: opensearch
 

--- a/build.gradle
+++ b/build.gradle
@@ -278,6 +278,10 @@ dependencies {
             force("com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}")
             force("org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}")
             force("org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}")
+            // The Jackson 3.x BOM (tools.jackson:jackson-bom) transitively constrains jackson-annotations
+            // to an older version than the one declared via the version catalog, causing a version conflict.
+            // Pin to the catalog version to resolve it.
+            force("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
 
             if (System.getenv('REMOTE_METADATA_SDK_IMPL') == 'ddb-client') {
                 // OpenSearch Java client brings in different versions of the below dependencies.


### PR DESCRIPTION
### Description
This PR replaces SHA-pinned references to `opensearch-project/opensearch-build` reusable workflows with `@main` branch references.

Reusable workflows from `opensearch-build` should track the `main` branch rather than being pinned to specific commit SHAs, as these are internal org workflows that are maintained upstream.

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).