### PR TITLE
Bump org.bouncycastle:bcprov-jdk18on from 1.80 to 1.84 and force org.apache.logging.log4j:log4j-core to 2.25.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ dependencies {
     implementation "software.amazon.cryptography:aws-cryptographic-material-providers:1.8.0"
     implementation "org.dafny:DafnyRuntime:4.9.1"
     implementation "software.amazon.smithy.dafny:conversion:0.1.1"
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.80'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.84'
     implementation "jakarta.json.bind:jakarta.json.bind-api:3.0.1"
     implementation "org.glassfish:jakarta.json:2.0.1"
     implementation "org.eclipse:yasson:3.0.4"
@@ -226,6 +226,7 @@ dependencies {
     configurations.all {
         resolutionStrategy {
             force("com.google.guava:guava:33.4.0-jre") // CVE for 31.1, keep to force transitive dependencies
+            force("org.apache.logging.log4j:log4j-core:2.25.4") // CVE-2026-34478, CVE-2026-34477, CVE-2026-34480
         }
     }
 }


### PR DESCRIPTION
### Description
Fix CVE-2026-0636, CVE-2026-34478, CVE-2026-34477, CVE-2026-34480. Bump org.bouncycastle:bcprov-jdk18on from 1.80 to 1.84 to address GHSA-c3fc-8qff-9hwx (versions >=1.74 <1.84 are vulnerable).

Force org.apache.logging.log4j:log4j-core to 2.25.4 to address GHSA-445c-vh5m-36rj, GHSA-6hg6-v5c8-fphq, and GHSA-3pxv-7cmr-fjr4 (versions <2.25.4 are vulnerable).

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/flow-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
