### PR TITLE
Declare workflow_state as child resource of workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Declare `workflow_state` as a child resource of `workflow` so state documents inherit the workflow's access shares ([#1455](https://github.com/opensearch-project/flow-framework/pull/1455))
 - Add jackson-databind dependency required by swagger-parser ([#1406](https://github.com/opensearch-project/flow-framework/pull/1406))
 - Set number_of_shards to 1 for plugin system indices ([#1407](https://github.com/opensearch-project/flow-framework/pull/1407))
 ### Infrastructure

--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkResourceSharingExtension.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkResourceSharingExtension.java
@@ -49,6 +49,21 @@ public class FlowFrameworkResourceSharingExtension implements ResourceSharingExt
             public String resourceIndexName() {
                 return WORKFLOW_STATE_INDEX;
             }
+
+            // Workflow state documents are companion resources of the workflow
+            // (template) they track: access is inherited from the parent
+            // workflow's sharing record. This also covers state documents
+            // written without an authenticated user in the thread context
+            // (e.g. during provisioning steps executed under system context).
+            @Override
+            public String parentType() {
+                return CommonValue.WORKFLOW_RESOURCE_TYPE;
+            }
+
+            @Override
+            public String parentIdField() {
+                return CommonValue.WORKFLOW_ID_FIELD;
+            }
         });
     }
 


### PR DESCRIPTION
### Description
`workflow_state` documents track the provisioning/execution state of a workflow template and have no independent access semantics, yet they are registered with the resource-sharing framework as a standalone type. Consequences:
- access to state documents does not follow the parent workflow's shares
- state documents written without an authenticated user in the thread context receive no sharing records at all (the security plugin's `ResourceIndexListener` cannot attribute them)

This declares `parentType`/`parentIdField` on the `workflow_state` provider so state documents inherit access from their workflow, via the `workflow_id` field already present in the state index mapping. Access evaluation in the security plugin delegates child→parent natively.

### Related PRs
- opensearch-project/security#6373 — needed for state documents written under system context to receive parent-linked sharing entries (integration-tested there via the sample plugin hierarchy)
- Same pattern as opensearch-project/reporting#1213 (report-instance → report-definition)

### Category
Bug fix

### Testing
- `compileJava` + spotless pass; parent id field verified against `mappings/workflow-state.json`
- Child→parent inheritance semantics covered by security#6373 integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.