### PR TITLE
[Backport 2.19] Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (flow-framework)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,12 @@ buildscript {
 
     dependencies {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:7.0.2"
+        // Spotless 8.10.x/7.x requires a Java 17+ runtime to resolve its plugin. Only put it on
+        // the buildscript classpath on Java 17+ so the Java 11 CI matrix doesn't fail resolving
+        // it. formatter/formatting.gradle applies it (also gated to Java 17+) only when available.
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+            classpath "com.diffplug.spotless:spotless-plugin-gradle:8.10.1"
+        }
     }
 }
 
@@ -66,7 +71,6 @@ apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.yaml-rest-test'
 apply plugin: 'opensearch.pluginzip'
 // for formatting and license headers
-apply plugin: 'com.diffplug.spotless'
 apply from: 'formatter/formatting.gradle'
 // for javadocs and checks spotless doesn't do
 apply plugin: 'checkstyle'

--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -1,4 +1,15 @@
 allprojects {
+    // Spotless 8.10.x (the pinned Eclipse-JDT toolchain) requires a Java 17+ runtime to even
+    // resolve/apply its Gradle plugin. Skip it on older JDKs (e.g. the Java 11 CI matrix) so
+    // non-spotless builds don't fail at configuration time. Formatting still runs on Java 17+.
+    if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+        return
+    }
+    project.apply plugin: 'com.diffplug.spotless'
+
+    // Only wire the Eclipse JDT step when a spotless task is actually being run.
+    def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
+
     spotless {
         java {
             // Normally this isn't necessary, but we have Java sources in
@@ -21,7 +32,13 @@ allprojects {
                     '',
                     '\\#java|\\#org.opensearch|\\#org.hamcrest|\\#'
             )
-            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            // Pin 4.34 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
+            // formatter resolves from Maven Central through the mirror below instead of querying a
+            // P2 update site at configuration time. 4.34 keeps the formatting identical to the
+            // eclipse() default of the previous spotless 7.0.2 this branch used.
+            if (runningSpotlessTask) {
+                eclipse('4.34').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            }
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
Backport f5ba22ae0a9512afd750c2a0fe9eb03ed32a35d1 from #1471.